### PR TITLE
Fix undeclared 'typeof' when compiling with -std=c++11

### DIFF
--- a/mp/src/public/tier0/threadtools.h
+++ b/mp/src/public/tier0/threadtools.h
@@ -833,8 +833,17 @@ template<typename T> T strip_cv_quals_for_mutex(const T&);
 template<typename T> T strip_cv_quals_for_mutex(volatile T&);
 template<typename T> T strip_cv_quals_for_mutex(const volatile T&);
 
+#if (__cplusplus == 201103L) || defined(__GXX_EXPERIMENTAL_CXX0X__) || defined(__GXX_EXPERIMENTAL_CXX11__)
+
+#define AUTO_LOCK( mutex ) \
+    AUTO_LOCK_( decltype(::strip_cv_quals_for_mutex(mutex)), mutex )
+    
+#else
+
 #define AUTO_LOCK( mutex ) \
     AUTO_LOCK_( typeof(::strip_cv_quals_for_mutex(mutex)), mutex )
+    
+#endif
 
 #else // GNUC
 

--- a/sp/src/public/tier0/threadtools.h
+++ b/sp/src/public/tier0/threadtools.h
@@ -833,8 +833,17 @@ template<typename T> T strip_cv_quals_for_mutex(const T&);
 template<typename T> T strip_cv_quals_for_mutex(volatile T&);
 template<typename T> T strip_cv_quals_for_mutex(const volatile T&);
 
+#if (__cplusplus == 201103L) || defined(__GXX_EXPERIMENTAL_CXX0X__) || defined(__GXX_EXPERIMENTAL_CXX11__)
+
+#define AUTO_LOCK( mutex ) \
+    AUTO_LOCK_( decltype(::strip_cv_quals_for_mutex(mutex)), mutex )
+    
+#else
+
 #define AUTO_LOCK( mutex ) \
     AUTO_LOCK_( typeof(::strip_cv_quals_for_mutex(mutex)), mutex )
+    
+#endif
 
 #else // GNUC
 


### PR DESCRIPTION
I am compiling my plugins with -std=c++11 because I use some stuff only available in C++11. It looks like "typeof" is undeclared when compiling with -std=c++11, which cause errors in threadtools.h.
typeof equivalent in C++11 is decltype. I have attached a patch which detect if C++11 is enabled and use decltype instead of typeof.
