### PR TITLE
Fix typo and value which should be non float

### DIFF
--- a/mp/src/game/shared/playernet_vars.h
+++ b/mp/src/game/shared/playernet_vars.h
@@ -77,10 +77,10 @@ struct fogplayerparams_t
 	{
 		m_hCtrl.Set( NULL );
 		m_flTransitionTime = -1.0f;
-		m_OldColor.r = m_OldColor.g = m_OldColor.g = m_OldColor.a = 0.0f;
+		m_OldColor.r = m_OldColor.g = m_OldColor.b = m_OldColor.a = 0;
 		m_flOldStart = 0.0f;
 		m_flOldEnd = 0.0f;
-		m_NewColor.r = m_NewColor.g = m_NewColor.g = m_NewColor.a = 0.0f;
+		m_NewColor.r = m_NewColor.g = m_NewColor.b = m_NewColor.a = 0;
 		m_flNewStart = 0.0f;
 		m_flNewEnd = 0.0f;
 	}

--- a/sp/src/game/shared/playernet_vars.h
+++ b/sp/src/game/shared/playernet_vars.h
@@ -77,10 +77,10 @@ struct fogplayerparams_t
 	{
 		m_hCtrl.Set( NULL );
 		m_flTransitionTime = -1.0f;
-		m_OldColor.r = m_OldColor.g = m_OldColor.g = m_OldColor.a = 0.0f;
+		m_OldColor.r = m_OldColor.g = m_OldColor.b = m_OldColor.a = 0;
 		m_flOldStart = 0.0f;
 		m_flOldEnd = 0.0f;
-		m_NewColor.r = m_NewColor.g = m_NewColor.g = m_NewColor.a = 0.0f;
+		m_NewColor.r = m_NewColor.g = m_NewColor.b = m_NewColor.a = 0;
 		m_flNewStart = 0.0f;
 		m_flNewEnd = 0.0f;
 	}


### PR DESCRIPTION
Two issues:
m_OldColor.g is being set to 0 twice. One should be m_OldColor.b.
Compilation error because the value should be non float: "operation on '((fogplayerparams_t*)this)->fogplayerparams_t::m_OldColor.color32_s::g' may be undefined"
