### PR TITLE
Print chat messages to console in color

### DIFF
--- a/mp/src/game/client/hud_basechat.cpp
+++ b/mp/src/game/client/hud_basechat.cpp
@@ -47,41 +47,6 @@ Color g_ColorYellow( 255, 178, 0, 255 );
 Color g_ColorGrey( 204, 204, 204, 255 );
 
 
-// removes all color markup characters, so Msg can deal with the string properly
-// returns a pointer to str
-char* RemoveColorMarkup( char *str )
-{
-	char *out = str;
-	for ( char *in = str; *in != 0; ++in )
-	{
-		if ( *in > 0 && *in < COLOR_MAX )
-		{
-			if ( *in == COLOR_HEXCODE || *in == COLOR_HEXCODE_ALPHA )
-			{
-				// skip the next six or eight characters
-				const int nSkip = ( *in == COLOR_HEXCODE ? 6 : 8 );
-				for ( int i = 0; i < nSkip && *in != 0; i++ )
-				{
-					++in;
-				}
-
-				// if we reached the end of the string first, then back up
-				if ( *in == 0 )
-				{
-					--in;
-				}
-			}
-
-			continue;
-		}
-		*out = *in;
-		++out;
-	}
-	*out = 0;
-
-	return str;
-}
-
 // converts all '\r' characters to '\n', so that the engine can deal with the properly
 // returns a pointer to str
 char* ConvertCRtoNL( char *str )
@@ -366,12 +331,6 @@ float CBaseHudChatLine::GetStartTime( void )
 void CBaseHudChatLine::Expire( void )
 {
 	SetVisible( false );
-
-	// Spit out label text now
-//	char text[ 256 ];
-//	GetText( text, 256 );
-
-//	Msg( "%s\n", text );
 }
 #endif // _XBOX
 
@@ -780,8 +739,6 @@ void CBaseHudChat::MsgFunc_SayText( bf_read &msg )
 
 	CLocalPlayerFilter filter;
 	C_BaseEntity::EmitSound( filter, SOUND_FROM_LOCAL_PLAYER, "HudChat.Message" );
-
-	Msg( "%s", szString );
 }
 
 int CBaseHudChat::GetFilterForString( const char *pString )
@@ -833,8 +790,6 @@ void CBaseHudChat::MsgFunc_SayText2( bf_read &msg )
 
 		// print raw chat text
 		ChatPrintf( client, iFilter, "%s", ansiString );
-
-		Msg( "%s\n", RemoveColorMarkup(ansiString) );
 
 		CLocalPlayerFilter filter;
 		C_BaseEntity::EmitSound( filter, SOUND_FROM_LOCAL_PLAYER, "HudChat.Message" );
@@ -921,7 +876,6 @@ void CBaseHudChat::MsgFunc_TextMsg( bf_read &msg )
 			Q_strncat( szString, "\n", sizeof(szString), 1 );
 		}
 		Printf( CHAT_FILTER_NONE, "%s", ConvertCRtoNL( szString ) );
-		Msg( "%s", ConvertCRtoNL( szString ) );
 		break;
 
 	case HUD_PRINTCONSOLE:
@@ -1394,7 +1348,7 @@ void CBaseHudChatLine::InsertAndColorizeText( wchar_t *buf, int clientIndex )
 	wchar_t *txt = m_text;
 	int lineLen = wcslen( m_text );
 	Color colCustom;
-	if ( m_text[0] == COLOR_PLAYERNAME || m_text[0] == COLOR_LOCATION || m_text[0] == COLOR_NORMAL || m_text[0] == COLOR_ACHIEVEMENT || m_text[0] == COLOR_CUSTOM || m_text[0] == COLOR_HEXCODE || m_text[0] == COLOR_HEXCODE_ALPHA )
+	if ( m_text[0] <= COLOR_MAX && m_text[0] != COLOR_USEOLDCOLORS )
 	{
 		while ( txt && *txt )
 		{
@@ -1550,6 +1504,8 @@ void CBaseHudChatLine::Colorize( int alpha )
 			InsertColorChange( color );
 			InsertString( wText );
 
+			ConColorMsg( color, "%ls", wText );
+
 			CBaseHudChat *pChat = dynamic_cast<CBaseHudChat*>(GetParent() );
 
 			if ( pChat && pChat->GetChatHistory() )
@@ -1566,6 +1522,8 @@ void CBaseHudChatLine::Colorize( int alpha )
 
 		}
 	}
+
+	Msg("\n");
 
 	InvalidateLayout( true );
 }

--- a/mp/src/game/client/hud_basechat.h
+++ b/mp/src/game/client/hud_basechat.h
@@ -99,7 +99,6 @@ char* ConvertCRtoNL( char *str );
 wchar_t* ConvertCRtoNL( wchar_t *str );
 wchar_t* ReadLocalizedString( bf_read &msg, OUT_Z_BYTECAP(outSizeInBytes) wchar_t *pOut, int outSizeInBytes, bool bStripNewline, OUT_Z_CAP(originalSize) char *originalString = NULL, int originalSize = 0 );
 wchar_t* ReadChatTextString( bf_read &msg, OUT_Z_BYTECAP(outSizeInBytes) wchar_t *pOut, int outSizeInBytes );
-char* RemoveColorMarkup( char *str );
 
 //--------------------------------------------------------------------------------------------------------
 /**


### PR DESCRIPTION
- Chat messages are now printed to console in `CBaseHudChatLine::Colorize`
- Removed `RemoveColorMarkup` function (no longer used)

**Note**: as the chat message are printed to console in chunks of color, this feature depends on #57 being fixed, otherwise the message is printed out of order.
