### PR TITLE
Fixed creategameprojects and createallprojects for multiplayer

### DIFF
--- a/mp/src/createallprojects
+++ b/mp/src/createallprojects
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-devtools/bin/vpc /hl2 /episodic +everything /mksln everything
+devtools/bin/vpc /hl2mp +everything /mksln everything
 

--- a/mp/src/creategameprojects
+++ b/mp/src/creategameprojects
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-devtools/bin/vpc /hl2 /episodic +game /mksln games
+devtools/bin/vpc /hl2mp +game /mksln games
 


### PR DESCRIPTION
Looks like this was copied from sp without being changed for the different multiplayer projects.
