### PR TITLE
Custom URL handlers for the vgui::HTML panel now pass the URL and protocol.

### DIFF
--- a/mp/src/vgui2/vgui_controls/HTML.cpp
+++ b/mp/src/vgui2/vgui_controls/HTML.cpp
@@ -1732,7 +1732,7 @@ bool HTML::OnStartRequest( const char *url, const char *target, const char *pchP
 			Panel *targetPanel = m_CustomURLHandlers[i].hPanel;
 			if (targetPanel)
 			{
-				PostMessage(targetPanel, new KeyValues("CustomURL", "url", url + strlen(m_CustomURLHandlers[i].url) + 3 ) );
+				PostMessage(targetPanel, new KeyValues("CustomURL", "url", url + strlen(m_CustomURLHandlers[i].url) + 3, "protocol", m_CustomURLHandlers[i].url));
 			}
 
 			bURLHandled = true;

--- a/sp/src/vgui2/vgui_controls/HTML.cpp
+++ b/sp/src/vgui2/vgui_controls/HTML.cpp
@@ -1732,7 +1732,7 @@ bool HTML::OnStartRequest( const char *url, const char *target, const char *pchP
 			Panel *targetPanel = m_CustomURLHandlers[i].hPanel;
 			if (targetPanel)
 			{
-				PostMessage(targetPanel, new KeyValues("CustomURL", "url", url + strlen(m_CustomURLHandlers[i].url) + 3 ) );
+				PostMessage(targetPanel, new KeyValues("CustomURL", "url", url + strlen(m_CustomURLHandlers[i].url) + 3, "protocol", m_CustomURLHandlers[i].url));
 			}
 
 			bURLHandled = true;


### PR DESCRIPTION
In Source 2007, the vgui::HTML panel passed a KeyValues object containing `url` and `protocol`.

For custom URLs such as `test://foobar`, `url` would be `foobar` and `protocol` would be `test`.

In Source 2013, `protocol` was missing, and `url` was set to the protocol.
