### PR TITLE
Fast GCC assembly word swap in tier0/platform.h on Linux

### DIFF
--- a/mp/src/public/tier0/platform.h
+++ b/mp/src/public/tier0/platform.h
@@ -935,7 +935,7 @@ inline T QWordSwapC( T dw )
 
 	#pragma warning(pop)
 
-#elif defined( _LINUX ) || defined( __APPLE__)
+#elif defined( _LINUX ) || defined( __APPLE__ )
 
 	#define WordSwap  WordSwapAsm
 	#define DWordSwap DWordSwapAsm

--- a/sp/src/public/tier0/platform.h
+++ b/sp/src/public/tier0/platform.h
@@ -935,7 +935,7 @@ inline T QWordSwapC( T dw )
 
 	#pragma warning(pop)
 
-#elif defined( _LINUX ) || defined( __APPLE__)
+#elif defined( _LINUX ) || defined( __APPLE__ )
 
 	#define WordSwap  WordSwapAsm
 	#define DWordSwap DWordSwapAsm


### PR DESCRIPTION
Added fast x86 assembly tier0/platform.h inline byte swap for Linux (ported from Windows).
