### PR TITLE
Make create*projects scripts work independently of current directory

### DIFF
--- a/mp/src/createallprojects
+++ b/mp/src/createallprojects
@@ -1,4 +1,5 @@
 #!/bin/bash
 
+pushd `dirname $0`
 devtools/bin/vpc /hl2mp +everything /mksln everything
-
+popd

--- a/mp/src/creategameprojects
+++ b/mp/src/creategameprojects
@@ -1,4 +1,5 @@
 #!/bin/bash
 
+pushd `dirname $0`
 devtools/bin/vpc /hl2mp +game /mksln games
-
+popd

--- a/sp/src/createallprojects
+++ b/sp/src/createallprojects
@@ -1,4 +1,5 @@
 #!/bin/bash
 
+pushd `dirname $0`
 devtools/bin/vpc /hl2 /episodic +everything /mksln everything
-
+popd

--- a/sp/src/creategameprojects
+++ b/sp/src/creategameprojects
@@ -1,4 +1,5 @@
 #!/bin/bash
 
+pushd `dirname $0`
 devtools/bin/vpc /hl2 /episodic +game /mksln games
-
+popd


### PR DESCRIPTION
This patch allows one to execute `call*projects` scripts without need to be in the `sp/src/` or `mp/src/` directory at the time of calling them. The implementation is not ideal but it works (I had to create separate file for calling vpc to avoid code duplication, otherwise I'd put that `cd somewhere; call vpc; cd oldpwd` part directly in the scripts).

After applying this patch the behaviour is consistent with what's described at https://developer.valvesoftware.com/wiki/SDK2013_GettingStarted
