### PR TITLE
Fixed vbsp not loading game shader libraries

### DIFF
--- a/sp/src/utils/common/utilmatlib.cpp
+++ b/sp/src/utils/common/utilmatlib.cpp
@@ -52,6 +52,11 @@ void LoadMaterialSystemInterface( CreateInterfaceFn fileSystemFactory )
 	{
 		Error( "Could not start the empty shader (shaderapiempty.dll)!" );
 	}
+	
+	// loads game shader dlls from game directory
+	// i.e. allows you to use custom lightmapped shaders in hammer
+	// the respective call to ModShutdown() has been left out on purpose because it makes vbsp crash
+	g_pMaterialSystem->ModInit(); 
 }
 
 void InitMaterialSystem( const char *materialBaseDirPath, CreateInterfaceFn fileSystemFactory )


### PR DESCRIPTION
VBsp is not loading game shader libraries by default which results in custom lightmapped shaders to be unlit in-game. It can be fixed by calling IMaterialSystem::ModInit right after VBsp initialized the material system.
