### PR TITLE
Make create*projects scripts work independently of current directory - Windows

### DIFF
--- a/mp/src/createallprojects.bat
+++ b/mp/src/createallprojects.bat
@@ -1,1 +1,3 @@
+pushd %~dp0
 devtools\bin\vpc.exe /hl2mp +everything /mksln everything.sln
+popd

--- a/mp/src/creategameprojects.bat
+++ b/mp/src/creategameprojects.bat
@@ -1,1 +1,3 @@
+pushd %~dp0
 devtools\bin\vpc.exe /hl2mp +game /mksln games.sln
+popd

--- a/sp/src/createallprojects.bat
+++ b/sp/src/createallprojects.bat
@@ -1,1 +1,3 @@
+pushd %~dp0
 devtools\bin\vpc.exe /hl2 /episodic +everything /mksln everything.sln
+popd

--- a/sp/src/creategameprojects.bat
+++ b/sp/src/creategameprojects.bat
@@ -1,1 +1,3 @@
+pushd %~dp0
 devtools\bin\vpc.exe /hl2 /episodic +game /mksln games.sln
+popd


### PR DESCRIPTION
As requested from @JoeLudwig at https://github.com/ValveSoftware/source-sdk-2013/pull/196, here's the pull request that fixes the bat scripts to work independently of the working directory as well.
