### PR TITLE
Switched to font xhair for weapons: SLAM, stunstick and cubemap

### DIFF
--- a/mp/game/mod_hl2mp/scripts/weapon_cubemap.txt
+++ b/mp/game/mod_hl2mp/scripts/weapon_cubemap.txt
@@ -51,11 +51,8 @@ WeaponData
 		}
 		"crosshair"
 		{
-				"file"		"sprites/crosshairs"
-				"x"			"0"
-				"y"			"48"
-				"width"		"24"
-				"height"	"24"
+				"font"		"Crosshairs"
+				"character"	"Q"
 		}
 		"autoaim"
 		{

--- a/mp/game/mod_hl2mp/scripts/weapon_slam.txt
+++ b/mp/game/mod_hl2mp/scripts/weapon_slam.txt
@@ -38,11 +38,8 @@ WeaponData
 		}
 		"crosshair"
 		{
-				"file"		"sprites/crosshairs"
-				"x"			"0"
-				"y"			"48"
-				"width"		"24"
-				"height"	"24"
+				"font"		"Crosshairs"
+				"character"	"Q"
 		}
 		"autoaim"
 		{

--- a/mp/game/mod_hl2mp/scripts/weapon_stunstick.txt
+++ b/mp/game/mod_hl2mp/scripts/weapon_stunstick.txt
@@ -55,11 +55,8 @@ WeaponData
 		}
 		"crosshair"
 		{
-				"file"		"sprites/crosshairs"
-				"x"			"0"
-				"y"			"48"
-				"width"		"24"
-				"height"	"24"
+				"font"		"Crosshairs"
+				"character"	"Q"
 		}
 		"autoaim"
 		{


### PR DESCRIPTION
These 3 weapons (SLAM, stunstick and cubemap) used crosshair from sprite, while other weapons normally use Q-glyph from halflife2.ttf.
Here i fixed this issue.
