### PR TITLE
Changed delay parameter for ent_fire

### DIFF
--- a/sp/src/game/server/baseentity.cpp
+++ b/sp/src/game/server/baseentity.cpp
@@ -5341,7 +5341,7 @@ public:
 		{
 			const char *target = "", *action = "Use";
 			variant_t value;
-			int delay = 0;
+			float delay = 0;
 
 			target = STRING( AllocPooledString(command.Arg( 1 ) ) );
 


### PR DESCRIPTION
Originally, the delay param was an integer, and supplying any decimal value as a delay (e.g. 2.5 seconds) would simply round down (e.g., to **2** seconds). This was basically due to the fact that it was set as an integer. 
