### PR TITLE
Improve vector-friendliness of material proxies.

### DIFF
--- a/mp/src/game/client/functionproxy.cpp
+++ b/mp/src/game/client/functionproxy.cpp
@@ -14,6 +14,51 @@
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"
 
+// Get the named material variable and the vector component, if applicable.
+static bool GetMaterialVariable(IMaterial* pMaterial, const char* pVarName,
+		IMaterialVar*& pMaterialVar, int& vecComp)
+{
+	// Look for array specification...
+	char pTemp[256];
+	if (strchr(pVarName, '['))
+	{
+		// strip off the array...
+		Q_strncpy( pTemp, pVarName, 256 );
+		char *pArray = strchr( pTemp, '[' );
+		*pArray++ = 0;
+
+		char* pIEnd;
+		vecComp = strtol( pArray, &pIEnd, 10 );
+
+		// Use the version without the array...
+		pVarName = pTemp;
+	}
+	else
+	{
+		vecComp = -1;
+	}
+
+	bool foundVar;
+	pMaterialVar = pMaterial->FindVar( pVarName, &foundVar, true );
+	return foundVar;
+}
+
+// Return the material's float value if vecComp is < 0, otherwise
+// return the given component of the material's vector.
+static float GetMaterialFloat(const IMaterialVar& material, int vecComp)
+{
+	if( vecComp < 0 )
+		return material.GetFloatValue();
+
+	int iVecSize = material.VectorSize();
+	if ( vecComp >= iVecSize )
+		return 0;
+
+	float v[4];
+	material.GetVecValue( v, iVecSize );
+	return v[vecComp];
+}
+
 //-----------------------------------------------------------------------------
 // Helper class to deal with floating point inputs
 //-----------------------------------------------------------------------------
@@ -36,30 +81,7 @@ bool CFloatInput::Init( IMaterial *pMaterial, KeyValues *pKeyValues, const char 
 				return true;
 			}
 
-			// Look for array specification...
-			char pTemp[256];
-			if (strchr(pVarName, '['))
-			{		 
-				// strip off the array...
-				Q_strncpy( pTemp, pVarName, 256 );
-				char *pArray = strchr( pTemp, '[' );
-				*pArray++ = 0;
-
-				char* pIEnd;
-				m_FloatVecComp = strtol( pArray, &pIEnd, 10 );
-
-				// Use the version without the array...
-				pVarName = pTemp;
-			}
-			else
-			{
-				m_FloatVecComp = -1;
-			}
-
-			bool bFoundVar;
-			m_pFloatVar = pMaterial->FindVar( pVarName, &bFoundVar, true );
-			if (!bFoundVar)
-				return false;
+			return GetMaterialVariable(pMaterial, pVarName, m_pFloatVar, m_FloatVecComp);
 		}
 		else
 		{
@@ -109,36 +131,11 @@ CResultProxy::~CResultProxy()
 
 bool CResultProxy::Init( IMaterial *pMaterial, KeyValues *pKeyValues )
 {
-	char const* pResult = pKeyValues->GetString( "resultVar" );
-	if( !pResult )
+	char const* pVarName = pKeyValues->GetString( "resultVar" );
+	if( !pVarName )
 		return false;
 
-	// Look for array specification...
-	char pTemp[256];
-	if (strchr(pResult, '['))
-	{		 
-		// strip off the array...
-		Q_strncpy( pTemp, pResult, 256 );
-		char *pArray = strchr( pTemp, '[' );
-		*pArray++ = 0;
-
-		char* pIEnd;
-		m_ResultVecComp = strtol( pArray, &pIEnd, 10 );
-
-		// Use the version without the array...
-		pResult = pTemp;
-	}
-	else
-	{
-		m_ResultVecComp = -1;
-	}
-
-	bool foundVar;
-	m_pResult = pMaterial->FindVar( pResult, &foundVar, true );
-	if( !foundVar )
-		return false;
-
-	return true;
+	return GetMaterialVariable(pMaterial, pVarName, m_pResult, m_ResultVecComp);
 }
 
 
@@ -206,8 +203,7 @@ bool CFunctionProxy::Init( IMaterial *pMaterial, KeyValues *pKeyValues )
 	if( !pSrcVar1 )
 		return false;
 
-	bool foundVar;
-	m_pSrc1 = pMaterial->FindVar( pSrcVar1, &foundVar, true );
+	bool foundVar = GetMaterialVariable(pMaterial, pSrcVar1, m_pSrc1, m_Src1VecComp);
 	if( !foundVar )
 		return false;
 
@@ -215,7 +211,7 @@ bool CFunctionProxy::Init( IMaterial *pMaterial, KeyValues *pKeyValues )
 	char const* pSrcVar2 = pKeyValues->GetString( "srcVar2" );
 	if( pSrcVar2 && (*pSrcVar2) )
 	{
-		m_pSrc2 = pMaterial->FindVar( pSrcVar2, &foundVar, true );
+		foundVar = GetMaterialVariable(pMaterial, pSrcVar2, m_pSrc2, m_Src2VecComp);
 		if( !foundVar )
 			return false;
 	}
@@ -257,3 +253,12 @@ void CFunctionProxy::ComputeResultType( MaterialVarType_t& resultType, int& vecS
 	}
 }
 
+float CFunctionProxy::GetSrc1Float() const
+{
+	return GetMaterialFloat(*m_pSrc1, m_Src1VecComp);
+}
+
+float CFunctionProxy::GetSrc2Float() const
+{
+	return GetMaterialFloat(*m_pSrc2, m_Src2VecComp);
+}

--- a/mp/src/game/client/functionproxy.h
+++ b/mp/src/game/client/functionproxy.h
@@ -65,9 +65,13 @@ public:
 
 protected:
 	void ComputeResultType( MaterialVarType_t& resultType, int& vecSize );
+	float GetSrc1Float() const;
+	float GetSrc2Float() const;
 
 	IMaterialVar* m_pSrc1;
 	IMaterialVar* m_pSrc2;
+	int m_Src1VecComp;
+	int m_Src2VecComp;
 };
 
 #endif // FUNCTIONPROXY_H

--- a/mp/src/game/client/mathproxy.cpp
+++ b/mp/src/game/client/mathproxy.cpp
@@ -60,7 +60,7 @@ void CAddProxy::OnBind( void *pC_BaseEntity )
 		break;
 
 	case MATERIAL_VAR_TYPE_FLOAT:
-		SetFloatResult( m_pSrc1->GetFloatValue() + m_pSrc2->GetFloatValue() );
+		SetFloatResult( GetSrc1Float() + GetSrc2Float() );
 		break;
 
 	case MATERIAL_VAR_TYPE_INT:
@@ -117,7 +117,7 @@ void CSubtractProxy::OnBind( void *pC_BaseEntity )
 		break;
 
 	case MATERIAL_VAR_TYPE_FLOAT:
-		SetFloatResult( m_pSrc1->GetFloatValue() - m_pSrc2->GetFloatValue() );
+		SetFloatResult( GetSrc1Float() - GetSrc2Float() );
 		break;
 
 	case MATERIAL_VAR_TYPE_INT:
@@ -174,7 +174,7 @@ void CMultiplyProxy::OnBind( void *pC_BaseEntity )
 		break;
 
 	case MATERIAL_VAR_TYPE_FLOAT:
-		SetFloatResult( m_pSrc1->GetFloatValue() * m_pSrc2->GetFloatValue() );
+		SetFloatResult( GetSrc1Float() * GetSrc2Float() );
 		break;
 
 	case MATERIAL_VAR_TYPE_INT:
@@ -232,13 +232,13 @@ void CDivideProxy::OnBind( void *pC_BaseEntity )
 		break;
 
 	case MATERIAL_VAR_TYPE_FLOAT:
-		if (m_pSrc2->GetFloatValue() != 0)
+		if (GetSrc2Float() != 0)
 		{
-			SetFloatResult( m_pSrc1->GetFloatValue() / m_pSrc2->GetFloatValue() );
+			SetFloatResult( GetSrc1Float() / GetSrc2Float() );
 		}
 		else
 		{
-			SetFloatResult( m_pSrc1->GetFloatValue() );
+			SetFloatResult( GetSrc1Float() );
 		}
 		break;
 
@@ -328,7 +328,7 @@ void CClampProxy::OnBind( void *pC_BaseEntity )
 
 	case MATERIAL_VAR_TYPE_FLOAT:
 		{
-			float src = m_pSrc1->GetFloatValue();
+			float src = GetSrc1Float();
 			if (src < flMin)
 				src = flMin;
 			else if (src > flMax)
@@ -413,7 +413,7 @@ void CSineProxy::OnBind( void *pC_BaseEntity )
 	// get a value in [min,max]	
 	flValue = ( flSineMax - flSineMin ) * flValue + flSineMin;
 	
-	SetFloatResult( flValue );
+	SetFloatResult( 1 );
 
 	if ( ToolsEnabled() )
 	{
@@ -453,7 +453,7 @@ void CEqualsProxy::OnBind( void *pC_BaseEntity )
 		break;
 
 	case MATERIAL_VAR_TYPE_FLOAT:
-		SetFloatResult( m_pSrc1->GetFloatValue() );
+		SetFloatResult( GetSrc1Float() );
 		break;
 
 	case MATERIAL_VAR_TYPE_INT:
@@ -505,7 +505,7 @@ void CFracProxy::OnBind( void *pC_BaseEntity )
 
 	case MATERIAL_VAR_TYPE_FLOAT:
 		{
-			float a = m_pSrc1->GetFloatValue();
+			float a = GetSrc1Float();
 			a -= ( int )a;
 			SetFloatResult( a );
 		}
@@ -559,7 +559,7 @@ void CIntProxy::OnBind( void *pC_BaseEntity )
 
 	case MATERIAL_VAR_TYPE_FLOAT:
 		{
-			float a = m_pSrc1->GetFloatValue();
+			float a = GetSrc1Float();
 			a = ( float )( int )a;
 			SetFloatResult( a );
 		}
@@ -898,7 +898,7 @@ void CLessOrEqualProxy::OnBind( void *pC_BaseEntity )
 	Assert( m_pSrc1 && m_pSrc2 && m_pLessVar && m_pGreaterVar && m_pResult );
 
 	IMaterialVar *pSourceVar;
-	if (m_pSrc1->GetFloatValue() <= m_pSrc2->GetFloatValue())
+	if (GetSrc1Float() <= GetSrc2Float())
 	{
 		pSourceVar = m_pLessVar;
 	}
@@ -989,7 +989,7 @@ void CWrapMinMaxProxy::OnBind( void *pC_BaseEntity )
 	}
 	else
 	{
-		float flResult = ( m_pSrc1->GetFloatValue() - m_flMinVal.GetFloat() ) / ( m_flMaxVal.GetFloat() - m_flMinVal.GetFloat() );
+		float flResult = ( GetSrc1Float() - m_flMinVal.GetFloat() ) / ( m_flMaxVal.GetFloat() - m_flMinVal.GetFloat() );
 
 		if ( flResult >= 0.0f )
 		{
@@ -1062,13 +1062,13 @@ void CSelectFirstIfNonZeroProxy::OnBind( void *pC_BaseEntity )
 		break;
 
 	case MATERIAL_VAR_TYPE_FLOAT:
-		if ( m_pSrc1->GetFloatValue() )
+		if ( GetSrc1Float() )
 		{
-			SetFloatResult( m_pSrc1->GetFloatValue() );
+			SetFloatResult( GetSrc1Float() );
 		}
 		else
 		{
-			SetFloatResult( m_pSrc2->GetFloatValue() );
+			SetFloatResult( GetSrc2Float() );
 		}
 		break;
 

--- a/sp/src/game/client/functionproxy.cpp
+++ b/sp/src/game/client/functionproxy.cpp
@@ -14,6 +14,51 @@
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"
 
+// Get the named material variable and the vector component, if applicable.
+static bool GetMaterialVariable(IMaterial* pMaterial, const char* pVarName,
+		IMaterialVar*& pMaterialVar, int& vecComp)
+{
+	// Look for array specification...
+	char pTemp[256];
+	if (strchr(pVarName, '['))
+	{
+		// strip off the array...
+		Q_strncpy( pTemp, pVarName, 256 );
+		char *pArray = strchr( pTemp, '[' );
+		*pArray++ = 0;
+
+		char* pIEnd;
+		vecComp = strtol( pArray, &pIEnd, 10 );
+
+		// Use the version without the array...
+		pVarName = pTemp;
+	}
+	else
+	{
+		vecComp = -1;
+	}
+
+	bool foundVar;
+	pMaterialVar = pMaterial->FindVar( pVarName, &foundVar, true );
+	return foundVar;
+}
+
+// Return the material's float value if vecComp is < 0, otherwise
+// return the given component of the material's vector.
+static float GetMaterialFloat(const IMaterialVar& material, int vecComp)
+{
+	if( vecComp < 0 )
+		return material.GetFloatValue();
+
+	int iVecSize = material.VectorSize();
+	if ( vecComp >= iVecSize )
+		return 0;
+
+	float v[4];
+	material.GetVecValue( v, iVecSize );
+	return v[vecComp];
+}
+
 //-----------------------------------------------------------------------------
 // Helper class to deal with floating point inputs
 //-----------------------------------------------------------------------------
@@ -36,30 +81,7 @@ bool CFloatInput::Init( IMaterial *pMaterial, KeyValues *pKeyValues, const char 
 				return true;
 			}
 
-			// Look for array specification...
-			char pTemp[256];
-			if (strchr(pVarName, '['))
-			{		 
-				// strip off the array...
-				Q_strncpy( pTemp, pVarName, 256 );
-				char *pArray = strchr( pTemp, '[' );
-				*pArray++ = 0;
-
-				char* pIEnd;
-				m_FloatVecComp = strtol( pArray, &pIEnd, 10 );
-
-				// Use the version without the array...
-				pVarName = pTemp;
-			}
-			else
-			{
-				m_FloatVecComp = -1;
-			}
-
-			bool bFoundVar;
-			m_pFloatVar = pMaterial->FindVar( pVarName, &bFoundVar, true );
-			if (!bFoundVar)
-				return false;
+			return GetMaterialVariable(pMaterial, pVarName, m_pFloatVar, m_FloatVecComp);
 		}
 		else
 		{
@@ -109,36 +131,11 @@ CResultProxy::~CResultProxy()
 
 bool CResultProxy::Init( IMaterial *pMaterial, KeyValues *pKeyValues )
 {
-	char const* pResult = pKeyValues->GetString( "resultVar" );
-	if( !pResult )
+	char const* pVarName = pKeyValues->GetString( "resultVar" );
+	if( !pVarName )
 		return false;
 
-	// Look for array specification...
-	char pTemp[256];
-	if (strchr(pResult, '['))
-	{		 
-		// strip off the array...
-		Q_strncpy( pTemp, pResult, 256 );
-		char *pArray = strchr( pTemp, '[' );
-		*pArray++ = 0;
-
-		char* pIEnd;
-		m_ResultVecComp = strtol( pArray, &pIEnd, 10 );
-
-		// Use the version without the array...
-		pResult = pTemp;
-	}
-	else
-	{
-		m_ResultVecComp = -1;
-	}
-
-	bool foundVar;
-	m_pResult = pMaterial->FindVar( pResult, &foundVar, true );
-	if( !foundVar )
-		return false;
-
-	return true;
+	return GetMaterialVariable(pMaterial, pVarName, m_pResult, m_ResultVecComp);
 }
 
 
@@ -206,8 +203,7 @@ bool CFunctionProxy::Init( IMaterial *pMaterial, KeyValues *pKeyValues )
 	if( !pSrcVar1 )
 		return false;
 
-	bool foundVar;
-	m_pSrc1 = pMaterial->FindVar( pSrcVar1, &foundVar, true );
+	bool foundVar = GetMaterialVariable(pMaterial, pSrcVar1, m_pSrc1, m_Src1VecComp);
 	if( !foundVar )
 		return false;
 
@@ -215,7 +211,7 @@ bool CFunctionProxy::Init( IMaterial *pMaterial, KeyValues *pKeyValues )
 	char const* pSrcVar2 = pKeyValues->GetString( "srcVar2" );
 	if( pSrcVar2 && (*pSrcVar2) )
 	{
-		m_pSrc2 = pMaterial->FindVar( pSrcVar2, &foundVar, true );
+		foundVar = GetMaterialVariable(pMaterial, pSrcVar2, m_pSrc2, m_Src2VecComp);
 		if( !foundVar )
 			return false;
 	}
@@ -257,3 +253,12 @@ void CFunctionProxy::ComputeResultType( MaterialVarType_t& resultType, int& vecS
 	}
 }
 
+float CFunctionProxy::GetSrc1Float() const
+{
+	return GetMaterialFloat(*m_pSrc1, m_Src1VecComp);
+}
+
+float CFunctionProxy::GetSrc2Float() const
+{
+	return GetMaterialFloat(*m_pSrc2, m_Src2VecComp);
+}

--- a/sp/src/game/client/functionproxy.h
+++ b/sp/src/game/client/functionproxy.h
@@ -65,9 +65,13 @@ public:
 
 protected:
 	void ComputeResultType( MaterialVarType_t& resultType, int& vecSize );
+	float GetSrc1Float() const;
+	float GetSrc2Float() const;
 
 	IMaterialVar* m_pSrc1;
 	IMaterialVar* m_pSrc2;
+	int m_Src1VecComp;
+	int m_Src2VecComp;
 };
 
 #endif // FUNCTIONPROXY_H

--- a/sp/src/game/client/mathproxy.cpp
+++ b/sp/src/game/client/mathproxy.cpp
@@ -60,7 +60,7 @@ void CAddProxy::OnBind( void *pC_BaseEntity )
 		break;
 
 	case MATERIAL_VAR_TYPE_FLOAT:
-		SetFloatResult( m_pSrc1->GetFloatValue() + m_pSrc2->GetFloatValue() );
+		SetFloatResult( GetSrc1Float() + GetSrc2Float() );
 		break;
 
 	case MATERIAL_VAR_TYPE_INT:
@@ -117,7 +117,7 @@ void CSubtractProxy::OnBind( void *pC_BaseEntity )
 		break;
 
 	case MATERIAL_VAR_TYPE_FLOAT:
-		SetFloatResult( m_pSrc1->GetFloatValue() - m_pSrc2->GetFloatValue() );
+		SetFloatResult( GetSrc1Float() - GetSrc2Float() );
 		break;
 
 	case MATERIAL_VAR_TYPE_INT:
@@ -174,7 +174,7 @@ void CMultiplyProxy::OnBind( void *pC_BaseEntity )
 		break;
 
 	case MATERIAL_VAR_TYPE_FLOAT:
-		SetFloatResult( m_pSrc1->GetFloatValue() * m_pSrc2->GetFloatValue() );
+		SetFloatResult( GetSrc1Float() * GetSrc2Float() );
 		break;
 
 	case MATERIAL_VAR_TYPE_INT:
@@ -232,13 +232,13 @@ void CDivideProxy::OnBind( void *pC_BaseEntity )
 		break;
 
 	case MATERIAL_VAR_TYPE_FLOAT:
-		if (m_pSrc2->GetFloatValue() != 0)
+		if (GetSrc2Float() != 0)
 		{
-			SetFloatResult( m_pSrc1->GetFloatValue() / m_pSrc2->GetFloatValue() );
+			SetFloatResult( GetSrc1Float() / GetSrc2Float() );
 		}
 		else
 		{
-			SetFloatResult( m_pSrc1->GetFloatValue() );
+			SetFloatResult( GetSrc1Float() );
 		}
 		break;
 
@@ -328,7 +328,7 @@ void CClampProxy::OnBind( void *pC_BaseEntity )
 
 	case MATERIAL_VAR_TYPE_FLOAT:
 		{
-			float src = m_pSrc1->GetFloatValue();
+			float src = GetSrc1Float();
 			if (src < flMin)
 				src = flMin;
 			else if (src > flMax)
@@ -413,7 +413,7 @@ void CSineProxy::OnBind( void *pC_BaseEntity )
 	// get a value in [min,max]	
 	flValue = ( flSineMax - flSineMin ) * flValue + flSineMin;
 	
-	SetFloatResult( flValue );
+	SetFloatResult( 1 );
 
 	if ( ToolsEnabled() )
 	{
@@ -453,7 +453,7 @@ void CEqualsProxy::OnBind( void *pC_BaseEntity )
 		break;
 
 	case MATERIAL_VAR_TYPE_FLOAT:
-		SetFloatResult( m_pSrc1->GetFloatValue() );
+		SetFloatResult( GetSrc1Float() );
 		break;
 
 	case MATERIAL_VAR_TYPE_INT:
@@ -505,7 +505,7 @@ void CFracProxy::OnBind( void *pC_BaseEntity )
 
 	case MATERIAL_VAR_TYPE_FLOAT:
 		{
-			float a = m_pSrc1->GetFloatValue();
+			float a = GetSrc1Float();
 			a -= ( int )a;
 			SetFloatResult( a );
 		}
@@ -559,7 +559,7 @@ void CIntProxy::OnBind( void *pC_BaseEntity )
 
 	case MATERIAL_VAR_TYPE_FLOAT:
 		{
-			float a = m_pSrc1->GetFloatValue();
+			float a = GetSrc1Float();
 			a = ( float )( int )a;
 			SetFloatResult( a );
 		}
@@ -898,7 +898,7 @@ void CLessOrEqualProxy::OnBind( void *pC_BaseEntity )
 	Assert( m_pSrc1 && m_pSrc2 && m_pLessVar && m_pGreaterVar && m_pResult );
 
 	IMaterialVar *pSourceVar;
-	if (m_pSrc1->GetFloatValue() <= m_pSrc2->GetFloatValue())
+	if (GetSrc1Float() <= GetSrc2Float())
 	{
 		pSourceVar = m_pLessVar;
 	}
@@ -989,7 +989,7 @@ void CWrapMinMaxProxy::OnBind( void *pC_BaseEntity )
 	}
 	else
 	{
-		float flResult = ( m_pSrc1->GetFloatValue() - m_flMinVal.GetFloat() ) / ( m_flMaxVal.GetFloat() - m_flMinVal.GetFloat() );
+		float flResult = ( GetSrc1Float() - m_flMinVal.GetFloat() ) / ( m_flMaxVal.GetFloat() - m_flMinVal.GetFloat() );
 
 		if ( flResult >= 0.0f )
 		{
@@ -1062,13 +1062,13 @@ void CSelectFirstIfNonZeroProxy::OnBind( void *pC_BaseEntity )
 		break;
 
 	case MATERIAL_VAR_TYPE_FLOAT:
-		if ( m_pSrc1->GetFloatValue() )
+		if ( GetSrc1Float() )
 		{
-			SetFloatResult( m_pSrc1->GetFloatValue() );
+			SetFloatResult( GetSrc1Float() );
 		}
 		else
 		{
-			SetFloatResult( m_pSrc2->GetFloatValue() );
+			SetFloatResult( GetSrc2Float() );
 		}
 		break;
 


### PR DESCRIPTION
This change allows you to specify particular vector components in srcVar1
and srcVar2, for the CFunctionProxy family of material proxies. E.g.

"Add"
{
	"srcVar1"	"$myVectorA[0]"
	"srcVar2"	"$myVectorB[1]"
	"resultVar"	"$myVectorC[2]"
}