### PR TITLE
Fix segfault in NDebugOverlay::Circle when debugoverlay is nullptr

### DIFF
--- a/mp/src/game/shared/debugoverlay_shared.cpp
+++ b/mp/src/game/shared/debugoverlay_shared.cpp
@@ -639,8 +639,11 @@ void NDebugOverlay::Circle( const Vector &position, const Vector &xAxis, const V
 
 		// If we have an alpha value, then draw the fan
 		if ( a && i > 1 )
-		{		
-			debugoverlay->AddTriangleOverlay( vecStart, vecLastPosition, vecPosition, r, g, b, a, bNoDepthTest, flDuration );
+		{
+			if ( debugoverlay )
+			{
+				debugoverlay->AddTriangleOverlay( vecStart, vecLastPosition, vecPosition, r, g, b, a, bNoDepthTest, flDuration );
+			}
 		}
 	}
 }

--- a/sp/src/game/shared/debugoverlay_shared.cpp
+++ b/sp/src/game/shared/debugoverlay_shared.cpp
@@ -639,8 +639,11 @@ void NDebugOverlay::Circle( const Vector &position, const Vector &xAxis, const V
 
 		// If we have an alpha value, then draw the fan
 		if ( a && i > 1 )
-		{		
-			debugoverlay->AddTriangleOverlay( vecStart, vecLastPosition, vecPosition, r, g, b, a, bNoDepthTest, flDuration );
+		{
+			if ( debugoverlay )
+			{
+				debugoverlay->AddTriangleOverlay( vecStart, vecLastPosition, vecPosition, r, g, b, a, bNoDepthTest, flDuration );
+			}
 		}
 	}
 }


### PR DESCRIPTION
The `debugoverlay` interface global is initialized to `nullptr` in the dedicated server. All of the `NDebugOverlay` functions which call into `debugoverlay` make sure to check whether it's `nullptr` before calling, with the exception of `NDebugOverlay::Circle`, which does no such check.

This means that enabling certain debug convars on a dedicated server can cause the server to crash instead of just doing nothing (anything that tries to draw circles has this problem, e.g. `nb_debug LOOK_AT`).

It can be desirable to enable some debug convars on a dedicated server purely for the text output, but this becomes infeasible if the same debug convar also tries to draw circle overlays, crashing everything.

This patch adds a nullptr check to `NDebugOverlay::Circle` to fix the problem.
