### PR TITLE
Improve shell scripts

### DIFF
--- a/mp/src/createallprojects
+++ b/mp/src/createallprojects
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-pushd `dirname $0`
+pushd "$(dirname "$0")"
 devtools/bin/vpc /hl2mp +everything /mksln everything
 popd

--- a/mp/src/creategameprojects
+++ b/mp/src/creategameprojects
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-pushd `dirname $0`
+pushd "$(dirname "$0")"
 devtools/bin/vpc /hl2mp +game /mksln games
 popd

--- a/mp/src/devtools/bin/osx32/xcode_ccache_wrapper
+++ b/mp/src/devtools/bin/osx32/xcode_ccache_wrapper
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-exec $(dirname $0)/ccache "${DT_TOOLCHAIN_DIR}"/usr/bin/clang -Qunused-arguments "$@"
+exec "$(dirname "$0")"/ccache "${DT_TOOLCHAIN_DIR}"/usr/bin/clang -Qunused-arguments "$@"

--- a/mp/src/devtools/bin/vpc
+++ b/mp/src/devtools/bin/vpc
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-OS=`uname`
-SCRIPTPATH=`dirname $0`
+OS="$(uname)"
+SCRIPTPATH="$(dirname "$0")"
 FORCEARG=""
 
-case $OS in
+case "$OS" in
 "Darwin")
 	BINNAME=vpc_osx
 	;;
@@ -17,12 +17,4 @@ case $OS in
 	;;
 esac
 
-
-if [ $OS == "Darwin" ]; then
-	$SCRIPTPATH/$BINNAME $@
-elif [ $OS == "Linux" ]; then
-	$SCRIPTPATH/$BINNAME $@
-else
-	echo "Couldn't find appropriate VPC binary, fix the script."
-	exit -1
-fi
+"$SCRIPTPATH"/"$BINNAME" "$@"

--- a/mp/src/devtools/gendbg.sh
+++ b/mp/src/devtools/gendbg.sh
@@ -1,44 +1,42 @@
 #!/bin/bash
 
-OBJCOPY=$STEAM_RUNTIME_PATH/bin/objcopy
+OBJCOPY="$STEAM_RUNTIME_PATH"/bin/objcopy
 
 function usage {
 	echo "$0 /path/to/input/file [-o /path/to/output/file ]"
 	echo ""
 }
 
-if [ $# == 0 ]; then
+if [ "$#" = 0 ]; then
 	usage
 	exit 2
 fi
 
-if [ $(basename $1) == $1 ]; then
-	INFILEDIR=$PWD
+if [ "$(basename "$1")" = "$1" ]; then
+	INFILEDIR="$PWD"
 else
-	INFILEDIR=$(cd ${1%/*} && echo $PWD)
+	INFILEDIR="$(cd "${1%/*}" && printf '%s' "$PWD")"
 fi
-INFILE=$(basename $1)
+INFILE="$(basename "$1")"
 
-OUTFILEDIR=$INFILEDIR
-OUTFILE=$INFILE.dbg
+OUTFILEDIR="$INFILEDIR"
+OUTFILE="$INFILE".dbg
 
 while getopts "o:" opt; do
-	case $opt in
+	case "$opt" in
 		o)
-			OUTFILEDIR=$(cd ${OPTARG%/*} && echo $PWD)
-			OUTFILE=$(basename $OPTARG)
+			OUTFILEDIR="$(cd "${OPTARG%/*}" && printf '%s' "$PWD")"
+			OUTFILE="$(basename "$OPTARG")"
 			;;
 	esac
 done
 
 if [ "$OUTFILEDIR" != "$INFILEDIR" ]; then
-	INFILE=${INFILEDIR}/${INFILE}
-	OUTFILE=${OUTFILEDIR}/${OUTFILE}
+	INFILE="${INFILEDIR}"/"${INFILE}"
+	OUTFILE="${OUTFILEDIR}"/"${OUTFILE}"
 fi
 
-pushd "$INFILEDIR"	
-$OBJCOPY "$INFILE" "$OUTFILE"
-$OBJCOPY --add-gnu-debuglink="$OUTFILE" "$INFILE"
+pushd "$INFILEDIR"
+"$OBJCOPY" "$INFILE" "$OUTFILE"
+"$OBJCOPY" --add-gnu-debuglink="$OUTFILE" "$INFILE"
 popd
-
-

--- a/sp/src/createallprojects
+++ b/sp/src/createallprojects
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-pushd `dirname $0`
+pushd "$(dirname "$0")"
 devtools/bin/vpc /hl2 /episodic +everything /mksln everything
 popd

--- a/sp/src/creategameprojects
+++ b/sp/src/creategameprojects
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-pushd `dirname $0`
+pushd "$(dirname "$0")"
 devtools/bin/vpc /hl2 /episodic +game /mksln games
 popd

--- a/sp/src/devtools/bin/osx32/xcode_ccache_wrapper
+++ b/sp/src/devtools/bin/osx32/xcode_ccache_wrapper
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-exec $(dirname $0)/ccache "${DT_TOOLCHAIN_DIR}"/usr/bin/clang -Qunused-arguments "$@"
+exec "$(dirname "$0")"/ccache "${DT_TOOLCHAIN_DIR}"/usr/bin/clang -Qunused-arguments "$@"

--- a/sp/src/devtools/bin/vpc
+++ b/sp/src/devtools/bin/vpc
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-OS=`uname`
-SCRIPTPATH=`dirname $0`
+OS="$(uname)"
+SCRIPTPATH="$(dirname "$0")"
 FORCEARG=""
 
-case $OS in
+case "$OS" in
 "Darwin")
 	BINNAME=vpc_osx
 	;;
@@ -17,12 +17,4 @@ case $OS in
 	;;
 esac
 
-
-if [ $OS == "Darwin" ]; then
-	$SCRIPTPATH/$BINNAME $@
-elif [ $OS == "Linux" ]; then
-	$SCRIPTPATH/$BINNAME $@
-else
-	echo "Couldn't find appropriate VPC binary, fix the script."
-	exit -1
-fi
+"$SCRIPTPATH"/"$BINNAME" "$@"

--- a/sp/src/devtools/gendbg.sh
+++ b/sp/src/devtools/gendbg.sh
@@ -7,38 +7,36 @@ function usage {
 	echo ""
 }
 
-if [ $# == 0 ]; then
+if [ "$#" = 0 ]; then
 	usage
 	exit 2
 fi
 
-if [ $(basename $1) == $1 ]; then
-	INFILEDIR=$PWD
+if [ "$(basename "$1")" = "$1" ]; then
+	INFILEDIR="$PWD"
 else
-	INFILEDIR=$(cd ${1%/*} && echo $PWD)
+	INFILEDIR="$(cd "${1%/*}" && printf '%s' "$PWD")"
 fi
-INFILE=$(basename $1)
+INFILE="$(basename "$1")"
 
-OUTFILEDIR=$INFILEDIR
-OUTFILE=$INFILE.dbg
+OUTFILEDIR="$INFILEDIR"
+OUTFILE="$INFILE".dbg
 
 while getopts "o:" opt; do
-	case $opt in
+	case "$opt" in
 		o)
-			OUTFILEDIR=$(cd ${OPTARG%/*} && echo $PWD)
-			OUTFILE=$(basename $OPTARG)
+			OUTFILEDIR="$(cd "${OPTARG%/*}" && printf '%s' "$PWD")"
+			OUTFILE="$(basename "$OPTARG")"
 			;;
 	esac
 done
 
 if [ "$OUTFILEDIR" != "$INFILEDIR" ]; then
-	INFILE=${INFILEDIR}/${INFILE}
-	OUTFILE=${OUTFILEDIR}/${OUTFILE}
+	INFILE="${INFILEDIR}"/"${INFILE}"
+	OUTFILE="${OUTFILEDIR}"/"${OUTFILE}"
 fi
 
-pushd "$INFILEDIR"	
-$OBJCOPY "$INFILE" "$OUTFILE"
-$OBJCOPY --add-gnu-debuglink="$OUTFILE" "$INFILE"
+pushd "$INFILEDIR"
+"$OBJCOPY" "$INFILE" "$OUTFILE"
+"$OBJCOPY" --add-gnu-debuglink="$OUTFILE" "$INFILE"
 popd
-
-


### PR DESCRIPTION
- Support spaces in paths in certain places
- Remove extraneous OS check in devtools/bin/vpc
- "echo" isn't really all that portable, so I cut it out where it matters for correctness

Btw, the gendbg.sh scripts in sp and mp are not identical I've found out.
They differ in that first OBJCOPY= line.
I'm not gonna mess with that, you might have had a reason :)