### PR TITLE
Move cursor to the actual center of the chat box

### DIFF
--- a/mp/src/game/client/hud_basechat.cpp
+++ b/mp/src/game/client/hud_basechat.cpp
@@ -1203,7 +1203,7 @@ void CBaseHudChat::StartMessageMode( int iMessageModeType )
 
 	//Place the mouse cursor near the text so people notice it.
 	int x, y, w, h;
-	GetChatHistory()->GetBounds( x, y, w, h );
+	GetBounds( x, y, w, h );
 	vgui::input()->SetCursorPos( x + ( w/2), y + (h/2) );
 
 	m_flHistoryFadeTime = gpGlobals->curtime + CHAT_HISTORY_FADE_TIME;


### PR DESCRIPTION
Move cursor to the center of the chat box relative to the viewport, instead of to the center of the chat history box relative to the chat box.