### PR TITLE
Fix smoothing groups not working on detail brushes.

### DIFF
--- a/mp/src/utils/vbsp/detail.cpp
+++ b/mp/src/utils/vbsp/detail.cpp
@@ -440,6 +440,7 @@ face_t *MakeBrushFace( side_t *originalSide, winding_t *winding )
 	f->split[0] = f->split[1] = NULL;
 	f->w = CopyWinding( winding );
 	f->originalface = originalSide;
+	f->smoothingGroups = originalSide->smoothingGroups;
 	//
 	// save material info
 	//

--- a/sp/src/utils/vbsp/detail.cpp
+++ b/sp/src/utils/vbsp/detail.cpp
@@ -440,6 +440,7 @@ face_t *MakeBrushFace( side_t *originalSide, winding_t *winding )
 	f->split[0] = f->split[1] = NULL;
 	f->w = CopyWinding( winding );
 	f->originalface = originalSide;
+	f->smoothingGroups = originalSide->smoothingGroups;
 	//
 	// save material info
 	//


### PR DESCRIPTION
Before:
![detail_before](https://cloud.githubusercontent.com/assets/3668166/18691422/6ef9dc7e-7f48-11e6-9205-f25ef2dc461d.png)

After:
![detail_after](https://cloud.githubusercontent.com/assets/3668166/18691434/7ebe992e-7f48-11e6-83d0-cccf4ff536d8.png)

This is a low risk change. As far as I can tell, there is one code path that executes the modified function.