### PR TITLE
Fixed a memory allocation error

### DIFF
--- a/mp/src/public/tier0/memoverride.cpp
+++ b/mp/src/public/tier0/memoverride.cpp
@@ -931,9 +931,7 @@ extern "C" int __cdecl _CrtGetCheckCount( void )
 extern "C" void * __cdecl _aligned_offset_recalloc_dbg( void * memblock, size_t count, size_t size, size_t align, size_t offset, const char * f_name, int line_n )
 {
 	Assert( IsPC() || 0 );
-	void *pMem = ReallocUnattributed( memblock, size * count );
-	memset( pMem, 0, size * count );
-	return pMem;
+	return ReallocUnattributed( memblock, size * count );
 }
 
 extern "C" void * __cdecl _aligned_recalloc_dbg( void *memblock, size_t count, size_t size, size_t align, const char * f_name, int line_n )

--- a/sp/src/public/tier0/memoverride.cpp
+++ b/sp/src/public/tier0/memoverride.cpp
@@ -931,9 +931,7 @@ extern "C" int __cdecl _CrtGetCheckCount( void )
 extern "C" void * __cdecl _aligned_offset_recalloc_dbg( void * memblock, size_t count, size_t size, size_t align, size_t offset, const char * f_name, int line_n )
 {
 	Assert( IsPC() || 0 );
-	void *pMem = ReallocUnattributed( memblock, size * count );
-	memset( pMem, 0, size * count );
-	return pMem;
+	return ReallocUnattributed( memblock, size * count );
 }
 
 extern "C" void * __cdecl _aligned_recalloc_dbg( void *memblock, size_t count, size_t size, size_t align, const char * f_name, int line_n )


### PR DESCRIPTION
Fixed a case where reallocated memory would be wiped clean, breaking a
lot of code that (correctly) assumes data will still be there after the
realloc.