### PR TITLE
sp/src/game/shared/ragdoll_shared.cpp: PVS-Studio: NULL Pointer Dereference

### DIFF
--- a/sp/src/game/shared/ragdoll_shared.cpp
+++ b/sp/src/game/shared/ragdoll_shared.cpp
@@ -877,15 +877,16 @@ void CRagdollLRURetirement::Update( float frametime ) // EPISODIC VERSION
 	
 		for ( i = m_LRU.Head(); i < m_LRU.InvalidIndex(); i = next )
 		{
-			CBaseAnimating *pRagdoll = m_LRU[i].Get();
-
 			next = m_LRU.Next(i);
-			IPhysicsObject *pObject = pRagdoll->VPhysicsGetObject();
-			if ( pRagdoll && (pRagdoll->GetEffectEntity() || ( pObject && !pObject->IsAsleep()) ) )
-				continue;
+
+			CBaseAnimating *pRagdoll = m_LRU[i].Get();
 
 			if ( pRagdoll )
 			{
+				IPhysicsObject *pObject = pRagdoll->VPhysicsGetObject();
+				if ( pRagdoll->GetEffectEntity() || ( pObject && !pObject->IsAsleep()) )
+					continue;
+				
 				// float distToPlayer = (pPlayer->GetAbsOrigin() - pRagdoll->GetAbsOrigin()).LengthSqr();
 				float distToPlayer = (PlayerOrigin - pRagdoll->GetAbsOrigin()).LengthSqr();
 
@@ -920,10 +921,13 @@ void CRagdollLRURetirement::Update( float frametime ) // EPISODIC VERSION
 
 			CBaseAnimating *pRagdoll = m_LRU[i].Get();
 
-			//Just ignore it until we're done burning/dissolving.
-			IPhysicsObject *pObject = pRagdoll->VPhysicsGetObject();
-			if ( pRagdoll && (pRagdoll->GetEffectEntity() || ( pObject && !pObject->IsAsleep()) ) )
-				continue;
+			if ( pRagdoll )
+			{
+				//Just ignore it until we're done burning/dissolving.
+				IPhysicsObject *pObject = pRagdoll->VPhysicsGetObject();
+				if ( pRagdoll->GetEffectEntity() || ( pObject && !pObject->IsAsleep()) )
+					continue;
+			}
 
 	#ifdef CLIENT_DLL
 			m_LRU[ i ]->SUB_Remove();


### PR DESCRIPTION
We have found and fixed a bug using PVS-Studio tool. PVS-Studio is a static code analyzer for C, C++ and C#: https://www.viva64.com/en/pvs-studio/

Analyzer warnings: 

- V595 The 'pRagdoll' pointer was utilized before it was verified against nullptr. Check lines: 883, 884. ragdoll_shared.cpp 883
- V595 The 'pRagdoll' pointer was utilized before it was verified against nullptr. Check lines: 924, 925. ragdoll_shared.cpp 924

We suggests having a look at the emails, sent from @pvs-studio.com.