### PR TITLE
Commented out false sharing debug counters

### DIFF
--- a/mp/src/raytrace/raytrace.cpp
+++ b/mp/src/raytrace/raytrace.cpp
@@ -233,7 +233,7 @@ void CacheOptimizedTriangle::ChangeIntoIntersectionFormat(void)
 
 }
 
-int n_intersection_calculations=0;
+//int n_intersection_calculations=0;
 
 int CacheOptimizedTriangle::ClassifyAgainstAxisSplit(int split_plane, float split_value)
 {
@@ -476,7 +476,7 @@ void RayTracingEnvironment::Trace4Rays(const FourRays &rays, fltx4 TMin, fltx4 T
 				TriIntersectData_t const *tri = &( OptimizedTriangleList[tnum].m_Data.m_IntersectData );
 				if ( ( mailboxids[mbox_slot] != tnum ) && ( tri->m_nTriangleID != skip_id ) )
 				{
-					n_intersection_calculations++;
+					//n_intersection_calculations++;
 					mailboxids[mbox_slot] = tnum;
 					// compute plane intersection
 

--- a/sp/src/raytrace/raytrace.cpp
+++ b/sp/src/raytrace/raytrace.cpp
@@ -233,7 +233,7 @@ void CacheOptimizedTriangle::ChangeIntoIntersectionFormat(void)
 
 }
 
-int n_intersection_calculations=0;
+//int n_intersection_calculations=0;
 
 int CacheOptimizedTriangle::ClassifyAgainstAxisSplit(int split_plane, float split_value)
 {
@@ -476,7 +476,7 @@ void RayTracingEnvironment::Trace4Rays(const FourRays &rays, fltx4 TMin, fltx4 T
 				TriIntersectData_t const *tri = &( OptimizedTriangleList[tnum].m_Data.m_IntersectData );
 				if ( ( mailboxids[mbox_slot] != tnum ) && ( tri->m_nTriangleID != skip_id ) )
 				{
-					n_intersection_calculations++;
+					//n_intersection_calculations++;
 					mailboxids[mbox_slot] = tnum;
 					// compute plane intersection
 


### PR DESCRIPTION
These changes fix the false sharing of a debug counter in the triangle intersection test of the ray tracer (which is heavily used, particularly for ambient lighting, in vrad.exe). Note that the debug counter doesn't work correctly regardless as the memory operations are non-atomic, thus it's completely useless.

(Note: For testing purposes, max thread count was increased to 32 on both branches, but not included in this pull request. I'd request that would also be done. MAX_THREADS and MAX_TOOLS_THREADS need to be increased from '16' to '32'.)

As threads cross CCX boundaries, cache coherency traffic from false sharing becomes a major bottleneck and overall execution times slow down. Similar effects are seen on dual socket Xeon configurations. On lower core count processors without a split cache hierarchy, only diminishing returns are seen with increased thread counts (thus poor but not negative scaling). This largely solves the scaling problem and even makes multi-socket configurations viable for vrad.

Below: Testing on a Ryzen Threadripper (16 cores, 32 threads) with map "nmo_cleopas" in No More Room in Hell. Build options: -threads 32 -both -final -StaticPropPolys

![vrad_thread_scaling](https://user-images.githubusercontent.com/8517067/31126393-a6dd77ae-a819-11e7-876a-3aec40d88c75.png)

Note: In all of the above tests, affinity masks are set in Process Lasso to simulate the behavior of different CPU core topologies. '8 threads' test is masked to 1 CCX (simulating a typical quad core), '16 threads' test is masked to 2 Ryzen CCX (simulating a Ryzen 7 1800x), 32 threads map to all 4 CCX's (representing a 16 core Threadripper 1950x) 

- One user reports a performance improvement of 100% on a 6 core AMD FX-6300.

- Another user testing this fix reports a performance improvement of ~38% on an i7-7700k on their own test map (outdoor maps generally see the most benefit due to large number of ambient light sampling).

Thus, even on lower core count configurations or CPU configurations with poor cache performance (like AMD FX), performance improvement can be significant, especially when using -final in vrad compile options. Ryzen CPUs benefit the most due to their unusual cache topology.