### PR TITLE
Fixes some player's origin displacements for fire events, impulses commands…

### DIFF
--- a/mp/src/game/client/prediction.cpp
+++ b/mp/src/game/client/prediction.cpp
@@ -909,9 +909,9 @@ void CPrediction::RunCommand( C_BasePlayer *player, CUserCmd *ucmd, IMoveHelper 
 		pVehicle->ProcessMovement( player, g_pMoveData );
 	}
 
-	FinishMove( player, ucmd, g_pMoveData );
+    RunPostThink( player );
 
-	RunPostThink( player );
+	FinishMove( player, ucmd, g_pMoveData );
 
 	g_pGameMovement->FinishTrackPredictionErrors( player );
 

--- a/mp/src/game/server/player_command.cpp
+++ b/mp/src/game/server/player_command.cpp
@@ -440,6 +440,8 @@ void CPlayerMove::RunCommand ( CBasePlayer *player, CUserCmd *ucmd, IMoveHelper 
 		pVehicle->ProcessMovement( player, g_pMoveData );
 	}
 			
+    RunPostThink( player );
+
 	// Copy output
 	FinishMove( player, ucmd, g_pMoveData );
 
@@ -453,8 +455,6 @@ void CPlayerMove::RunCommand ( CBasePlayer *player, CUserCmd *ucmd, IMoveHelper 
 	VPROF_SCOPE_BEGIN( "moveHelper->ProcessImpacts" );
 	moveHelper->ProcessImpacts();
 	VPROF_SCOPE_END();
-
-	RunPostThink( player );
 
 	g_pGameMovement->FinishTrackPredictionErrors( player );
 

--- a/sp/src/game/client/prediction.cpp
+++ b/sp/src/game/client/prediction.cpp
@@ -903,9 +903,9 @@ void CPrediction::RunCommand( C_BasePlayer *player, CUserCmd *ucmd, IMoveHelper 
 		pVehicle->ProcessMovement( player, g_pMoveData );
 	}
 
-	FinishMove( player, ucmd, g_pMoveData );
+    RunPostThink( player );
 
-	RunPostThink( player );
+	FinishMove( player, ucmd, g_pMoveData );
 
 	g_pGameMovement->FinishTrackPredictionErrors( player );
 

--- a/sp/src/game/server/player_command.cpp
+++ b/sp/src/game/server/player_command.cpp
@@ -439,6 +439,8 @@ void CPlayerMove::RunCommand ( CBasePlayer *player, CUserCmd *ucmd, IMoveHelper 
 		pVehicle->ProcessMovement( player, g_pMoveData );
 	}
 			
+    RunPostThink( player );
+
 	// Copy output
 	FinishMove( player, ucmd, g_pMoveData );
 
@@ -446,8 +448,6 @@ void CPlayerMove::RunCommand ( CBasePlayer *player, CUserCmd *ucmd, IMoveHelper 
 	VPROF_SCOPE_BEGIN( "moveHelper->ProcessImpacts" );
 	moveHelper->ProcessImpacts();
 	VPROF_SCOPE_END();
-
-	RunPostThink( player );
 
 	g_pGameMovement->FinishTrackPredictionErrors( player );
 


### PR DESCRIPTION
This fixes shooting problems and others things, for example when you're running and aim perfectly at the head of someone.

https://www.youtube.com/watch?v=VPT0-CKODNc

Why is this happening?

Well, this is happening mainly because of interpolation. Let me explain.
In fact, the taken shooting position is the new one computed from the game's movement, and not the current one. You can see this happening by using timescale, and getting some speed. The game is computing the new interpolated localplayer's data (@BaseInteporlate1 from C_BaseEntity)  by getting the final predicted time (so the final predicted command) and removes a tick interval to actually take the previous final predicted time ,  _**for having data to interpolate with!**_ , and adds a tick interval where it's mulitplied by interpolation_amount (this is computed per frames, and it goes to 0.0 to 1.0) to go on the final predicted time, wich finally goes to what you should see. If you try to interpolate directly from the final predicted time, there wouldn't be any data to interpolate with, so that's why valve is removing a tick interval on the final predicted time to interpolate the localplayer.
But it makes issues on player's gameplay we must remember that since the commands are ran per ticks, the changes are instantaneous, so when you're actually firing, you're still on the previous predicted time, and not the final one.
 You see the world as it was previously and not as it was when firing.
The solution of what you would think of would be of course to disable interpolation on a player side, but that would not make a smooth gameplay (so makes still a game unplayable) and player couldn't even predict his next position to actually shoot at the head of the player correctly anyway because changes on player's will be instantaneous. (or he must be a real machine to do that). Because since the game is running the commands per ticks , you'll suddently "teleport" to the other side and see your bullet at that position, instead of seeing your shot behind, as expected and predicted by the player. So the solution is just to call PostThink, before applying the final data to the player, so interpolation is not a problem anymore, the weapons takes the right origin to shoot with, and much others stuffs! Like collision bounds, or when you're actually landing with high velocities, it stops the falling velocity at where it should and not 1 tick before. (bunny hopping purposes)

https://steamuserimages-a.akamaihd.net/ugc/909030263364841206/048560EB944800B68FF1F52920763D5B66231AE7/

Here is a view example of what is happening, blue = what the game actually see, red = what the player saw in the game.

I hope valve and people will understand what I explained and hopefully this gets fixed on all valve games so we get a proper gameplay for everyone! (Yes since I guess valve is using this code for every games, it needs to be fixed on every games)

Good day and thanks for atleast reading!

PS: Sorry for my english if it's not correct, but if I get understood, it's the more important.

