### PR TITLE
Fix entity name matching

### DIFF
--- a/mp/src/game/server/baseentity.cpp
+++ b/mp/src/game/server/baseentity.cpp
@@ -2991,9 +2991,9 @@ FORCEINLINE bool NamesMatch( const char *pszQuery, string_t nameToMatch )
 		// simple ascii case conversion
 		if ( cName == cQuery )
 			;
-		else if ( cName - 'A' <= (unsigned char)'Z' - 'A' && cName - 'A' + 'a' == cQuery )
+		else if ( (unsigned char)(cName - 'A') <= (unsigned char)('Z' - 'A') && (unsigned char)(cName - 'A' + 'a') == cQuery )
 			;
-		else if ( cName - 'a' <= (unsigned char)'z' - 'a' && cName - 'a' + 'A' == cQuery )
+		else if ( (unsigned char)(cName - 'a') <= (unsigned char)('z' - 'a') && (unsigned char)(cName - 'a' + 'A') == cQuery )
 			;
 		else
 			break;

--- a/sp/src/game/server/baseentity.cpp
+++ b/sp/src/game/server/baseentity.cpp
@@ -2987,9 +2987,9 @@ FORCEINLINE bool NamesMatch( const char *pszQuery, string_t nameToMatch )
 		// simple ascii case conversion
 		if ( cName == cQuery )
 			;
-		else if ( cName - 'A' <= (unsigned char)'Z' - 'A' && cName - 'A' + 'a' == cQuery )
+		else if ( (unsigned char)(cName - 'A') <= (unsigned char)('Z' - 'A') && (unsigned char)(cName - 'A' + 'a') == cQuery )
 			;
-		else if ( cName - 'a' <= (unsigned char)'z' - 'a' && cName - 'a' + 'A' == cQuery )
+		else if ( (unsigned char)(cName - 'a') <= (unsigned char)('z' - 'a') && (unsigned char)(cName - 'a' + 'A') == cQuery )
 			;
 		else
 			break;


### PR DESCRIPTION
Entity name matching is broken with certain characters. For example, character 'X' will match to '8'. This will have unintended side-effects in the map logic. It worked fine in Source SDK 2006 because the comparison used `tolower`.
Problems caused by this is quite rare due to the fact that most maps use numbers and lowercase letters only.


Example of the problem:
```c++
#include <cstdio>

int main()
{
    auto badmatch = []( unsigned char cName, unsigned char cQuery ) {
        /* */if ( cName - 'A' <= (unsigned char)'Z' - 'A' && cName - 'A' + 'a' == cQuery )
            return true;
        else if ( cName - 'a' <= (unsigned char)'z' - 'a' && cName - 'a' + 'A' == cQuery )
            return true;
            
        return false;
    };
    
    auto goodmatch = []( unsigned char cName, unsigned char cQuery ) {
        /* */if ( (unsigned char)(cName - 'A') <= (unsigned char)('Z' - 'A') && (unsigned char)(cName - 'A' + 'a') == cQuery )
            return true;
        else if ( (unsigned char)(cName - 'a') <= (unsigned char)('z' - 'a') && (unsigned char)(cName - 'a' + 'A') == cQuery )
            return true;
            
        return false;
    };
    
    // Loop through all characters.
    for ( auto i = 0; i <= 255; i++ )
    {
        auto cQuery = (unsigned char)i;
        for ( auto j = 0; j <= 255; j++ )
        {
            auto cName = (unsigned char)j;
            
            if ( cName == cQuery )
                continue;
            
            if ( badmatch( cName, cQuery ) )
            //if ( goodmatch( cName, cQuery ) )
            {
                printf("%c (%x) matches %c (%x)\n", cName, cName, cQuery, cQuery );
            }
        }
    }
}

```
