### PR TITLE
Fix typo in logical expression

### DIFF
--- a/mp/src/game/server/ai_behavior_assault.cpp
+++ b/mp/src/game/server/ai_behavior_assault.cpp
@@ -1257,7 +1257,7 @@ int CAI_AssaultBehavior::TranslateSchedule( int scheduleType )
 		break;
 
 	case SCHED_HOLD_RALLY_POINT:
-		if( HasCondition(COND_NO_PRIMARY_AMMO) | HasCondition(COND_LOW_PRIMARY_AMMO) )
+		if( HasCondition(COND_NO_PRIMARY_AMMO) || HasCondition(COND_LOW_PRIMARY_AMMO) )
 		{
 			return SCHED_RELOAD;
 		}

--- a/sp/src/game/server/ai_behavior_assault.cpp
+++ b/sp/src/game/server/ai_behavior_assault.cpp
@@ -1257,7 +1257,7 @@ int CAI_AssaultBehavior::TranslateSchedule( int scheduleType )
 		break;
 
 	case SCHED_HOLD_RALLY_POINT:
-		if( HasCondition(COND_NO_PRIMARY_AMMO) | HasCondition(COND_LOW_PRIMARY_AMMO) )
+		if( HasCondition(COND_NO_PRIMARY_AMMO) || HasCondition(COND_LOW_PRIMARY_AMMO) )
 		{
 			return SCHED_RELOAD;
 		}


### PR DESCRIPTION
A bitwise operator (`|`) is used instead of a logical one (`||`).
This means that the right operand will be evaluated regardless of the result of the left operand.