### PR TITLE
Fix for being unable to detonate the satchel when holding a detonator (i.e. having a satchel in the world) and ready tripmine in hands.

### DIFF
--- a/mp/src/game/shared/hl2mp/weapon_slam.cpp
+++ b/mp/src/game/shared/hl2mp/weapon_slam.cpp
@@ -303,7 +303,7 @@ bool CWeapon_SLAM::AnyUndetonatedCharges(void)
 void CWeapon_SLAM::StartSatchelDetonate()
 {
 
-	if ( GetActivity() != ACT_SLAM_DETONATOR_IDLE && GetActivity() != ACT_SLAM_THROW_IDLE )
+	if ( GetActivity() != ACT_SLAM_DETONATOR_IDLE && GetActivity() != ACT_SLAM_THROW_IDLE && !m_bDetonatorArmed ) //fix for being unable to detonate when holding a detonator and ready tripmine in hand
 		 return;
 	
 	// -----------------------------------------
@@ -313,7 +313,7 @@ void CWeapon_SLAM::StartSatchelDetonate()
 	{
 		SendWeaponAnim(ACT_SLAM_DETONATOR_DETONATE);
 	}
-	else if (m_tSlamState == SLAM_SATCHEL_ATTACH)
+	else if (m_tSlamState == SLAM_SATCHEL_ATTACH || m_tSlamState == SLAM_TRIPMINE_READY) // second part of the aforementioned fix
 	{
 		SendWeaponAnim(ACT_SLAM_STICKWALL_DETONATE);
 	}


### PR DESCRIPTION
With this fix the player can detonate the satchel when holding a detonator (i.e. having a satchel in the world) and ready tripmine in hands, unlike in HL2DM
https://youtu.be/pvfdsDBldqI