### PR TITLE
Fix incorrect plane calculation in IntersectRayWithOBB

### DIFF
--- a/mp/src/public/collisionutils.cpp
+++ b/mp/src/public/collisionutils.cpp
@@ -1666,7 +1666,7 @@ bool IntersectRayWithOBB( const Ray_t &ray, const matrix3x4_t &matOBBToWorld,
 		}
 		temp.type = 3;
 
-		MatrixITransformPlane( matOBBToWorld, temp, pTrace->plane );
+		MatrixTransformPlane( matOBBToWorld, temp, pTrace->plane );
 		return true;
 	}
 

--- a/sp/src/public/collisionutils.cpp
+++ b/sp/src/public/collisionutils.cpp
@@ -1666,7 +1666,7 @@ bool IntersectRayWithOBB( const Ray_t &ray, const matrix3x4_t &matOBBToWorld,
 		}
 		temp.type = 3;
 
-		MatrixITransformPlane( matOBBToWorld, temp, pTrace->plane );
+		MatrixTransformPlane( matOBBToWorld, temp, pTrace->plane );
 		return true;
 	}
 


### PR DESCRIPTION
Hull trace against an OBB erroneously transforms calculated normal from world to local space instead of local to world.

This code is referenced in `SweepBoxToStudio` (bone_setup.cpp) > `TraceToStudio` > `CBaseAnimating::TestHitboxes()`; however `CHL2_Player::TestHitboxes()` and `C_BaseAnimating::TestHitboxes()` have checks against hull traces, which prevents this issue from arising.