### PR TITLE
Client Crash: Creating bugbait at particle limit

### DIFF
--- a/mp/src/game/client/c_smoke_trail.cpp
+++ b/mp/src/game/client/c_smoke_trail.cpp
@@ -950,7 +950,10 @@ void C_SporeExplosion::OnDataChanged( DataUpdateType_t updateType )
 		m_teParticleSpawn.Init( m_flSpawnRate );
 	}
 
-	m_pSporeEffect->SetDontRemove( m_bDontRemove );
+	if( m_pSporeEffect.IsValid() )
+	{
+		m_pSporeEffect->SetDontRemove( m_bDontRemove );
+	}
 }
 
 //-----------------------------------------------------------------------------
@@ -981,6 +984,11 @@ void C_SporeExplosion::Start( CParticleMgr *pParticleMgr, IPrototypeArgAccess *p
 //-----------------------------------------------------------------------------
 void C_SporeExplosion::AddParticles( void )
 {
+	if( !m_pSporeEffect )
+	{
+		return;
+	}
+
 	//Spores
 	Vector	offset;
 	Vector	dir;

--- a/mp/src/game/client/c_smoke_trail.h
+++ b/mp/src/game/client/c_smoke_trail.h
@@ -249,7 +249,7 @@ private:
 	PMaterialHandle		m_hMaterial;
 	TimedEvent			m_teParticleSpawn;
 
-	SporeEffect			*m_pSporeEffect;
+	CSmartPtr<SporeEffect> m_pSporeEffect;
 	CParticleMgr		*m_pParticleMgr;
 };
 

--- a/sp/src/game/client/c_smoke_trail.cpp
+++ b/sp/src/game/client/c_smoke_trail.cpp
@@ -950,7 +950,10 @@ void C_SporeExplosion::OnDataChanged( DataUpdateType_t updateType )
 		m_teParticleSpawn.Init( m_flSpawnRate );
 	}
 
-	m_pSporeEffect->SetDontRemove( m_bDontRemove );
+	if( m_pSporeEffect.IsValid() )
+	{
+		m_pSporeEffect->SetDontRemove( m_bDontRemove );
+	}
 }
 
 //-----------------------------------------------------------------------------
@@ -981,6 +984,11 @@ void C_SporeExplosion::Start( CParticleMgr *pParticleMgr, IPrototypeArgAccess *p
 //-----------------------------------------------------------------------------
 void C_SporeExplosion::AddParticles( void )
 {
+	if( !m_pSporeEffect )
+	{
+		return;
+	}
+
 	//Spores
 	Vector	offset;
 	Vector	dir;

--- a/sp/src/game/client/c_smoke_trail.h
+++ b/sp/src/game/client/c_smoke_trail.h
@@ -249,7 +249,7 @@ private:
 	PMaterialHandle		m_hMaterial;
 	TimedEvent			m_teParticleSpawn;
 
-	SporeEffect			*m_pSporeEffect;
+	CSmartPtr<SporeEffect> m_pSporeEffect;
 	CParticleMgr		*m_pParticleMgr;
 };
 


### PR DESCRIPTION
Crash in client.dll via dangling pointer dereference when bugbait's spore particle effect is created when at the old particle system's max particle limit. SporeEffect object needed to be wrapped in CSmartPtr<>, just as the other particle objects are in the same file. CSmartPtr allows detection to check if the child particle effect was freed. Just as the other effects do. Added similar null checks missing in OnDataChanged() and AddParticles() Appears to be a simple oversight.

Discovered: Played with around 50 players on server. Many throwing bugbait. Gathered crash dumps from some affected players.
Test Case: Spawn around ~40 bots, bot_mimic 1, give weapon_bugbait, throw a few bugbaits to quickly induce crash