### PR TITLE
Fix misspelled platform in HUD layout.

### DIFF
--- a/sp/game/mod_episodic/scripts/HudLayout.res
+++ b/sp/game/mod_episodic/scripts/HudLayout.res
@@ -436,7 +436,7 @@
 		"wide"	 "248"
 		"tall"	 "320"
 
-		"history_gap"	"56" [!$OS]
+		"history_gap"	"56" [!$OSX]
 		"history_gap"	"64" [$OSX]
 		"icon_inset"	"38"
 		"text_inset"	"36"


### PR DESCRIPTION
This should probably be named OSX, as in mod_hl2's HUD layout. 

https://github.com/ValveSoftware/source-sdk-2013/blob/0d8dceea4310fde5706b3ce1c70609d72a38efdf/sp/game/mod_hl2/scripts/HudLayout.res#L422

This should fix items and weapon icons sometimes appearing cut half height at the bottom of pickup history.