### PR TITLE
Remove duplicate property text_inset entry in HudHistoryResource.

### DIFF
--- a/sp/game/mod_hl2/scripts/HudLayout.res
+++ b/sp/game/mod_hl2/scripts/HudLayout.res
@@ -423,7 +423,6 @@
 		"history_gap"	"64" [$OSX]
 		"icon_inset"	"38"
 		"text_inset"	"36"
-		"text_inset"	"26"
 		"NumberFont"	"HudNumbersSmall"
 	}
 	HudHistoryResource	[$X360]


### PR DESCRIPTION
This removes a duplicate `text_inset`. The one with value 36 is kept.

In older versions, it was set to 26. Below is the version found in Depot 212 (Base Source Engine 2).

```text
hl2/scripts/hudlayout.res
```

```text
HudHistoryResource
{
	"fieldName" "HudHistoryResource"
	"visible" "1"
	"enabled" "1"
	"xpos"	"r252"
	"ypos"	"40"
	"wide"	 "248"
	"tall"	 "320"

	"history_gap"	"56"
	"icon_inset"	"28"
	"text_inset"	"26"
	"NumberFont"	"HudNumbersSmall"
}
```

Later, it appears to have been changed to 36. Of note, Half-Life 2: Deathmatch still uses 26.

Depot 211 (Source SDK) contains a hudlayout.res file in which `text_inset` is set to 36 with no duplicate.

```text
launcher/createmodfiles/orangebox/singleplayer/scripts/hudlayout.res
```

```text
HudHistoryResource	[$WIN32]
{
	"fieldName" "HudHistoryResource"
	"visible" "1"
	"enabled" "1"
	"xpos"	"r252"
	"ypos"	"40"
	"wide"	 "248"
	"tall"	 "320"

	"history_gap"	"56"
	"icon_inset"	"38"
	"text_inset"	"36"
	"NumberFont"	"HudNumbersSmall"
}
```

mod_episodic's HUD layout has no duplicate and uses 36 as value, so this should probably be the same.

https://github.com/ValveSoftware/source-sdk-2013/blob/0d8dceea4310fde5706b3ce1c70609d72a38efdf/sp/game/mod_episodic/scripts/HudLayout.res#L429-L444