### PR TITLE
Fix for swept box rays that were never really working properly with OBBs. (IntersectRayWithOBB)

### DIFF
--- a/mp/src/public/collisionutils.cpp
+++ b/mp/src/public/collisionutils.cpp
@@ -1475,12 +1475,12 @@ bool IntersectRayWithOBB( const Ray_t &ray, const matrix3x4_t &matOBBToWorld,
 	Collision_ClearTrace( ray.m_Start + ray.m_StartOffset, ray.m_Delta, pTrace );
 
 	// Compute a bounding sphere around the bloated OBB
+	Vector vecOBBExtents;
+	VectorAdd( vecOBBMins, vecOBBMaxs, vecOBBExtents );
+	vecOBBExtents *= 0.5f;
+
 	Vector vecOBBCenter;
-	VectorAdd( vecOBBMins, vecOBBMaxs, vecOBBCenter );
-	vecOBBCenter *= 0.5f;
-	vecOBBCenter.x += matOBBToWorld[0][3];
-	vecOBBCenter.y += matOBBToWorld[1][3];
-	vecOBBCenter.z += matOBBToWorld[2][3];
+	VectorTransform( vecOBBExtents, matOBBToWorld, vecOBBCenter );
 
 	Vector vecOBBHalfDiagonal;
 	VectorSubtract( vecOBBMaxs, vecOBBMins, vecOBBHalfDiagonal );

--- a/sp/src/public/collisionutils.cpp
+++ b/sp/src/public/collisionutils.cpp
@@ -1475,12 +1475,12 @@ bool IntersectRayWithOBB( const Ray_t &ray, const matrix3x4_t &matOBBToWorld,
 	Collision_ClearTrace( ray.m_Start + ray.m_StartOffset, ray.m_Delta, pTrace );
 
 	// Compute a bounding sphere around the bloated OBB
+	Vector vecOBBExtents;
+	VectorAdd( vecOBBMins, vecOBBMaxs, vecOBBExtents );
+	vecOBBExtents *= 0.5f;
+
 	Vector vecOBBCenter;
-	VectorAdd( vecOBBMins, vecOBBMaxs, vecOBBCenter );
-	vecOBBCenter *= 0.5f;
-	vecOBBCenter.x += matOBBToWorld[0][3];
-	vecOBBCenter.y += matOBBToWorld[1][3];
-	vecOBBCenter.z += matOBBToWorld[2][3];
+	VectorTransform( vecOBBExtents, matOBBToWorld, vecOBBCenter );
 
 	Vector vecOBBHalfDiagonal;
 	VectorSubtract( vecOBBMaxs, vecOBBMins, vecOBBHalfDiagonal );


### PR DESCRIPTION
IntersectRayWithOBB has a bug where it would somehow ignore angle information inside the matrix.

Why? I don't know. Maybe some developers not wanting to use VectorTransform somehow ? (or overworked)

This is probably present in all Source games (including Source 2) if it hasn't been fixed yet. (?)

This fixes some edge cases where for example a game mod wants to have thicker bullets or other stuffs that I'm not aware of (I discovered it by accident by working on the engine).