### PR TITLE
gameplay: allow non-giants to be tickled in MvM

### DIFF
--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -1220,7 +1220,7 @@ void CTFPlayer::SetGrapplingHookTarget( CBaseEntity *pTarget, bool bShouldBleed 
 //-----------------------------------------------------------------------------
 bool CTFPlayer::CanBeForcedToLaugh( void )
 {
-	if ( TFGameRules() && TFGameRules()->IsMannVsMachineMode() && IsBot() && ( GetTeamNumber() == TF_TEAM_PVE_INVADERS ) )
+	if ( TFGameRules() && TFGameRules()->IsMannVsMachineMode() && IsBot() && ( GetTeamNumber() == TF_TEAM_PVE_INVADERS ) && IsMiniBoss() )
 		return false;
 
 	return true;


### PR DESCRIPTION
Holiday Punch is currently completely non-functional in the mode otherwise, and common bots can already be stunned by other sources. it's only giants that are supposed to be immune.