### PR TITLE
[TF2] gameplay: automatically collect MvM money in respawn room

### DIFF
--- a/src/game/server/tf/entity_currencypack.cpp
+++ b/src/game/server/tf/entity_currencypack.cpp
@@ -17,6 +17,7 @@
 #include "particle_parse.h"
 #include "player_vs_environment/tf_population_manager.h"
 #include "collisionutils.h"
+#include "func_respawnroom.h"
 #include "tf_objective_resource.h"
 
 //=============================================================================
@@ -207,6 +208,19 @@ void CCurrencyPack::ComeToRest( void )
 				m_bTouched = true;
 				UTIL_Remove( this );
 			}
+		}
+	}
+	// Or a func_respawnroom (robots can drop money in their own spawn)
+	for ( int i = 0; i < IFuncRespawnRoomAutoList::AutoList().Count(); i++ )
+	{
+		CFuncRespawnRoom *pRespawnRoom = static_cast<CFuncRespawnRoom*>( IFuncRespawnRoomAutoList::AutoList()[i] );
+		Vector vecMins, vecMaxs;
+		pRespawnRoom->GetCollideable()->WorldSpaceSurroundingBounds( &vecMins, &vecMaxs );
+		if ( IsPointInBox( GetCollideable()->GetCollisionOrigin(), vecMins, vecMaxs ) )
+		{
+			TFGameRules()->DistributeCurrencyAmount( m_nAmount );
+			m_bTouched = true;
+			UTIL_Remove( this );
 		}
 	}
 }


### PR DESCRIPTION
MvM money is automatically collected in various cases where its position is unfair for players to collect themselves.

There is a case where robots can drop money in their own spawn, which can prove hard or impossible to acquire, so add an additional check for money that is in a spawn room, just like it is already done for trigger_hurt.