### PR TITLE
[TF2] gameplay: sniper reload upgrade doesn't apply without auto rezoom

### DIFF
--- a/src/game/shared/tf/tf_weapon_sniperrifle.cpp
+++ b/src/game/shared/tf/tf_weapon_sniperrifle.cpp
@@ -501,19 +501,19 @@ void CTFSniperRifle::ZoomOutIn( void )
 	ZoomOut();
 
 	CTFPlayer *pPlayer = GetTFPlayerOwner();
+	float flRezoomDelay = 0.9f;
+	if ( !UsesClipsForAmmo1() )
+	{
+		// Since sniper rifles don't actually use clips the fast reload hook also affects unzoom and zoom delays
+		ApplyScopeSpeedModifications( flRezoomDelay );
+	}
 	if ( pPlayer && pPlayer->ShouldAutoRezoom() )
 	{
-		float flRezoomDelay = 0.9f;
-		if ( !UsesClipsForAmmo1() )
-		{
-			// Since sniper rifles don't actually use clips the fast reload hook also affects unzoom and zoom delays
-			ApplyScopeSpeedModifications( flRezoomDelay );
-		}
 		m_flRezoomTime = gpGlobals->curtime + flRezoomDelay;
 	}
 	else
 	{
-		m_flNextSecondaryAttack = gpGlobals->curtime + 1.0f;
+		m_flNextSecondaryAttack = gpGlobals->curtime + flRezoomDelay + 0.1f;
 	}
 }
 


### PR DESCRIPTION
Snipers who use the reload speed upgrade don't get unless they use the auto rezoom advanced option.

I've decided to only apply the speedup to the shared 0.9 second delay between auto rezoom and non-autorezoom for regression considerations. You could possibly remove the + 0.1f for them to have equal delay, but I'm sure there's a good reason why there's differences.

ref: ValveSoftware/Source-1-Games#4657