### PR TITLE
[TF2] fix: scout balls computing critical hits incorrectly

### DIFF
--- a/src/game/shared/tf/tf_weapon_bat.cpp
+++ b/src/game/shared/tf/tf_weapon_bat.cpp
@@ -271,6 +271,8 @@ void CTFBat_Wood::SecondaryAttack( void )
 		SecondaryAttackAnim( pPlayer );
 		SendWeaponAnim( ACT_VM_PRIMARYATTACK );
 
+		CalcIsAttackCritical();
+
 		SetContextThink( &CTFBat_Wood::LaunchBallThink, gpGlobals->curtime + tf_scout_bat_launch_delay.GetFloat(), "LAUNCH_BALL_THINK" );
 
 		m_flNextPrimaryAttack = gpGlobals->curtime + 0.25;
@@ -508,8 +510,6 @@ CBaseEntity* CTFBat_Wood::CreateBall( void )
 	Assert( pBall );
 	if ( !pBall )
 		return NULL;
-
-	CalcIsAttackCritical();
 
 	pBall->m_iOriginalOwnerID = m_iEnemyBallID;
 	m_iEnemyBallID = 0;
@@ -1085,8 +1085,6 @@ CBaseEntity *CTFBat_Giftwrap::CreateBall( void )
 	Assert( pBall );
 	if ( !pBall )
 		return NULL;
-
-	CalcIsAttackCritical();
 
 	pBall->m_iOriginalOwnerID = m_iEnemyBallID;
 	m_iEnemyBallID = 0;

--- a/src/game/shared/tf/tf_weapon_bat.cpp
+++ b/src/game/shared/tf/tf_weapon_bat.cpp
@@ -273,9 +273,11 @@ void CTFBat_Wood::SecondaryAttack( void )
 
 		CalcIsAttackCritical();
 
-		SetContextThink( &CTFBat_Wood::LaunchBallThink, gpGlobals->curtime + tf_scout_bat_launch_delay.GetFloat(), "LAUNCH_BALL_THINK" );
+		const float fLaunchDelay = tf_scout_bat_launch_delay.GetFloat();
 
-		m_flNextPrimaryAttack = gpGlobals->curtime + 0.25;
+		SetContextThink( &CTFBat_Wood::LaunchBallThink, gpGlobals->curtime + fLaunchDelay, "LAUNCH_BALL_THINK" );
+
+		m_flNextPrimaryAttack = gpGlobals->curtime + fLaunchDelay + 0.15f;
 
 #ifdef GAME_DLL
 		if ( pPlayer->m_Shared.IsStealthed() )


### PR DESCRIPTION
Scout balls were computing crits in their own entity think outside of the player command, which made the random generation invalid, since crit calcs are only valid during attacks. This caused random crits to be computed incorrectly, and also allowed for an exploit where you could store a random crit with the ball and permanently crit every ball thereafter.

Technically, you could seed more crit chances by using primary fire and rolling more crits before the ball actually launched in the think. However in practice, there is no way to influence the crit between the secondary attack command and the ball think running, because the primary attack time is delayed by 0.25 seconds, which is longer than the launch delay.

For safety, there's two approaches that could solve this:

1. `tf_scout_bat_launch_delay` could be integrated into the primary attack delay,
2. `tf_scout_bat_launch_delay` could get a max limit of 0.25 seconds to avoid setting it higher.

But I'm not sure if this is required (as any modifications to gameplay variables should come at the risk of the community server owner / modder). Regardless, I've added option 1 as an additional commit.