### PR TITLE
[TF2] gameplay: detonator jumps aren't considered self dmg jumps

### DIFF
--- a/src/game/shared/tf/tf_gamerules.cpp
+++ b/src/game/shared/tf/tf_gamerules.cpp
@@ -7405,7 +7405,8 @@ float CTFGameRules::ApplyOnDamageAliveModifyRules( const CTakeDamageInfo &info, 
 			}
 		}
 
-		if ( pAttacker == pVictimBaseEntity && (info.GetDamageType() & DMG_BLAST) &&
+		if ( pAttacker == pVictimBaseEntity &&
+			 (info.GetDamageType() & DMG_BLAST || info.GetDamageCustom() == TF_DMG_CUSTOM_FLARE_EXPLOSION) &&
 			 info.GetDamagedOtherPlayers() == 0 && (info.GetDamageCustom() != TF_DMG_CUSTOM_TAUNTATK_GRENADE) )
 		{
 			// If we attacked ourselves, hurt no other players, and it is a blast,


### PR DESCRIPTION
Only blast damage is considered for the `bSelfBlastDmg` modifier. This affects a few things: applying the `rocket_jump_dmg_reduction` attribute, blocking self bleed, but most importantly, it allows to bypass the no knockback attribute on QuickFix ubers. Before this change, Pyros would be blocked from blast jumping with their own Detonator flares while under QuickFix uber.