### PR TITLE
[TF2] Fix huntsman arrows treating hitboxes as axis-aligned boxes rather than as oriented boxes

### DIFF
--- a/src/game/server/tf/tf_projectile_arrow.cpp
+++ b/src/game/server/tf/tf_projectile_arrow.cpp
@@ -832,7 +832,7 @@ void CTFProjectile_Arrow::ArrowTouch( CBaseEntity *pOther )
 			Ray_t ray;
 			ray.Init( start, position );
 			trace_t tr;
-			IntersectRayWithBox( ray, position+pbox->bbmin, position+pbox->bbmax, 0.f, &tr );
+			IntersectRayWithOBB( ray, position, angles, pbox->bbmin, pbox->bbmax, 0.f, &tr );
 			float dist = tr.endpos.DistTo( start );
 
 			if ( dist < closest_dist )


### PR DESCRIPTION
fixes ValveSoftware/Source-1-Games/issues/5904

unfixed:

https://github.com/user-attachments/assets/fc104f0a-b448-422c-9851-449a9d989a83

fixed:

https://github.com/user-attachments/assets/bb9ccfe9-05a7-493f-aa5d-44d73efc6c97