### PR TITLE
Add Python requirement to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Clone the repository using the following command:
 Requirements:
  - Source SDK 2013 Multiplayer installed via Steam
  - Visual Studio 2022
+ - Python
 
 Inside the cloned directory, navigate to `src`, run:
 ```bat

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Clone the repository using the following command:
 Requirements:
  - Source SDK 2013 Multiplayer installed via Steam
  - Visual Studio 2022
- - Python
+ - Python 3
 
 Inside the cloned directory, navigate to `src`, run:
 ```bat


### PR DESCRIPTION
Python is needed to compile the server DLLs otherwise it'll throw an error regarding the vscript nut files