### PR TITLE
[TF2] Fix sniper laser dot position being calculated inaccurately on client

### DIFF
--- a/src/game/shared/tf/tf_weapon_sniperrifle.cpp
+++ b/src/game/shared/tf/tf_weapon_sniperrifle.cpp
@@ -1541,8 +1541,8 @@ bool CSniperDot::GetRenderingPositions( C_TFPlayer *pPlayer, Vector &vecAttachme
 		{
 			// Take the owning player eye position and direction.
 			vecAttachment = pPlayer->EyePosition();
-			QAngle anglesEye = pPlayer->EyeAngles();
-			AngleVectors( anglesEye, &vecDir );
+			vecDir = GetAbsOrigin() - vecAttachment;
+			VectorNormalize( vecDir );
 		}
 
 		trace_t tr;


### PR DESCRIPTION
unfixed:

https://github.com/user-attachments/assets/6fa1b486-0f5c-4557-83a8-8283d806b84a

fixed:

https://github.com/user-attachments/assets/5c947721-107b-48f8-a41f-410c98eb856d