### PR TITLE
Fix sdk_container script causing the linux build to fail

### DIFF
--- a/src/sdk_container
+++ b/src/sdk_container
@@ -24,13 +24,14 @@ function run_in_sniper() {
 
         image="registry.gitlab.steamos.cloud/steamrt/sniper/sdk:latest"
         echo "Running script inside $image"
+        mkdir ~/.ccache #create directory because it might not exists which causes the mount to fail
         exec podman run \
             --env "$check_env=$script_file" \
             --env "CCACHE_DIR=${CCACHE_DIR:-$HOME/.ccache}" \
             --userns=keep-id \
             --rm -it \
-            --mount type=bind,\"source="${CCACHE_DIR:-$HOME/.ccache}"\",\"target="${CCACHE_DIR:-$HOME/.ccache}"\" \
-            --mount type=bind,\"source="$mod_base_dir"\",target=/my_mod/ \
+            --mount type=bind,source="${CCACHE_DIR:-$HOME/.ccache}",target="${CCACHE_DIR:-$HOME/.ccache}" \
+            --mount type=bind,source="$mod_base_dir",target=/my_mod/ \
             "$image" \
             /my_mod/"$mod_src_dir_name"/"$script_file" \
             "$@"

--- a/src/sdk_container
+++ b/src/sdk_container
@@ -24,7 +24,7 @@ function run_in_sniper() {
 
         image="registry.gitlab.steamos.cloud/steamrt/sniper/sdk:latest"
         echo "Running script inside $image"
-        mkdir ~/.ccache #create directory because it might not exists which causes the mount to fail
+        mkdir -p "${CCACHE_DIR:-$HOME/.ccache}"
         exec podman run \
             --env "$check_env=$script_file" \
             --env "CCACHE_DIR=${CCACHE_DIR:-$HOME/.ccache}" \


### PR DESCRIPTION
The podman run command had an invalid syntax for the mount options which caused the script to fail, and the .ccache directory might not have been created which also caused the command to fail. This pull request fixes this