### PR TITLE
perf: use static ConVarRefs during relatively hot functions

### DIFF
--- a/src/game/client/in_steamcontroller.cpp
+++ b/src/game/client/in_steamcontroller.cpp
@@ -69,8 +69,8 @@ void CInput::ApplySteamControllerCameraMove( QAngle& viewangles, CUserCmd *cmd, 
 	//roll the view angles so roll is 0 (the HL2 assumed state) and mouse adjustments are relative to the screen.
 	//Assuming roll is unchanging, we want mouse left to translate to screen left at all times (same for right, up, and down)	
 
-	ConVarRef cl_pitchdown ( "cl_pitchdown" );
-	ConVarRef cl_pitchup ( "cl_pitchup" );
+	static ConVarRef cl_pitchdown ( "cl_pitchdown" );
+	static ConVarRef cl_pitchup ( "cl_pitchup" );
 
 	// Scale yaw and pitch inputs by sensitivity, and make sure they are within acceptable limits (important to avoid exploits, e.g. during Demoman charge we must restrict allowed yaw).
 	float yaw = CAM_CapYaw( sc_yaw_sensitivity.GetFloat() * vecPosition.x );

--- a/src/game/client/tf/tf_hud_notification_panel.cpp
+++ b/src/game/client/tf/tf_hud_notification_panel.cpp
@@ -101,7 +101,7 @@ void CHudNotificationPanel::MsgFunc_HudNotify( bf_read &msg )
 	// Ignore notifications in minmode
 	if ( !bForceShow )
 	{
-		ConVarRef cl_hud_minmode( "cl_hud_minmode", true );
+		static ConVarRef cl_hud_minmode( "cl_hud_minmode", true );
 		if ( cl_hud_minmode.IsValid() && cl_hud_minmode.GetBool() )
 			return;
 	}
@@ -140,7 +140,7 @@ void CHudNotificationPanel::MsgFunc_HudNotify( bf_read &msg )
 void CHudNotificationPanel::MsgFunc_HudNotifyCustom( bf_read &msg )
 {
 	// Ignore notifications in minmode
-	ConVarRef cl_hud_minmode( "cl_hud_minmode", true );
+	static ConVarRef cl_hud_minmode( "cl_hud_minmode", true );
 	if ( cl_hud_minmode.IsValid() && cl_hud_minmode.GetBool() )
 		return;
 

--- a/src/game/shared/achievementmgr.cpp
+++ b/src/game/shared/achievementmgr.cpp
@@ -1087,7 +1087,7 @@ bool CAchievementMgr::CheckAchievementsEnabled()
 		return false;
 	}
 
-	ConVarRef tf_bot_offline_practice( "tf_bot_offline_practice" );
+	static ConVarRef tf_bot_offline_practice( "tf_bot_offline_practice" );
 	// no achievements for offline practice
 	if ( tf_bot_offline_practice.GetInt() != 0 )
 	{


### PR DESCRIPTION
instead of doing a O(n) lookup per frame in some cases, we can just init the ConVarRef once

these ones are just possible during runtime or called relatively more compared to other non-static ConVarRefs

there is one in `R_LoadSkys` for skyname as well, but not sure if that was fixed or not