### PR TITLE
[TF2] fix: cheat-protect commands which control panel visibility

### DIFF
--- a/src/game/client/game_controls/baseviewport.cpp
+++ b/src/game/client/game_controls/baseviewport.cpp
@@ -79,7 +79,7 @@ void hud_autoreloadscript_callback( IConVar *var, const char *pOldValue, float f
 
 static ConVar cl_leveloverviewmarker( "cl_leveloverviewmarker", "0", FCVAR_CHEAT );
 
-CON_COMMAND( showpanel, "Shows a viewport panel <name>" )
+CON_COMMAND_F( showpanel, "Shows a viewport panel <name>", FCVAR_CHEAT )
 {
 	if ( !gViewPortInterface )
 		return;
@@ -90,7 +90,7 @@ CON_COMMAND( showpanel, "Shows a viewport panel <name>" )
 	 gViewPortInterface->ShowPanel( args[ 1 ], true );
 }
 
-CON_COMMAND( hidepanel, "Hides a viewport panel <name>" )
+CON_COMMAND_F( hidepanel, "Hides a viewport panel <name>", FCVAR_CHEAT )
 {
 	if ( !gViewPortInterface )
 		return;


### PR DESCRIPTION
some VGUI exploits to gain information which you normally cannot see (explained outside of commit)

ValveSoftware/Source-1-Games#2488

should also be done for vgui_togglepanel: https://github.com/mastercomfig/tf2-patches-old/commit/a02595b7aa1bb909e0734a37358863c145c99470