### PR TITLE
[TF2] Update 10 second stuck MvM bots to use CommitSuicide over TakeDamage for rare spawn softlocks

### DIFF
--- a/src/game/shared/tf/tf_gamemovement.cpp
+++ b/src/game/shared/tf/tf_gamemovement.cpp
@@ -1382,7 +1382,7 @@ int CTFGameMovement::CheckStuck( void )
 						m_pTFPlayer->GetTeam()->GetName(),
 						m_pTFPlayer->GetAbsOrigin().x, m_pTFPlayer->GetAbsOrigin().y, m_pTFPlayer->GetAbsOrigin().z );
 
-					m_pTFPlayer->TakeDamage( CTakeDamageInfo( m_pTFPlayer, m_pTFPlayer, vec3_origin, m_pTFPlayer->WorldSpaceCenter(), 999999.9f, DMG_CRUSH ) );
+					m_pTFPlayer->CommitSuicide(false, true);
 				}
 				else
 				{


### PR DESCRIPTION
This is very rare to happen nowadays. But what would happen is an MvM bot would get stuck in world geometry while trying to leave spawn. If the bot stays stuck for 10 seconds, the game prints a dev message saying `A robot is interpenetrating a solid - killed!` and the game applies 999999.9 damage, the issue here is that since the bot is inside of the spawn that damage gets nullified because the bot still has the uber spawn condition. CommitSuicide does not do this and instantly kills the bot even with spawn uber protection. As such, this change is here to prevent those rare moments.

For reference on this bug, see https://github.com/ValveSoftware/Source-1-Games/issues/4620