### PR TITLE
fix: add autogenerated build files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,12 +21,19 @@ ipch
 *.sln
 
 # OSX/Linux build products
+*.a
+game/*_linux64
 *.mak
 *.mak.vpc_crc
 *.xcodeproj/
 obj*/
 !devtools/*.mak
 !utils/smdlexp/smdlexp.mak
+
+# ninja files
+.ninja_deps
+.ninja_log
+compile_commands.json
 
 # Specific Source build products
 client.pdb


### PR DESCRIPTION
Linux compilation creates some files that were not covered by the gitignore:

```
../game/mod_hl2mp_linux64
../game/mod_tf_linux64
.ninja_deps
.ninja_log
compile_commands.json
lib/public/linux64/mathlib.a
lib/public/linux64/raytrace.a
lib/public/linux64/tier1.a
lib/public/linux64/vgui_controls.a
```