### PR TITLE
[TF2] Fix MvM ammo canteens not affecting energy weapons

### DIFF
--- a/src/game/shared/tf/tf_item_powerup_bottle.cpp
+++ b/src/game/shared/tf/tf_item_powerup_bottle.cpp
@@ -279,7 +279,7 @@ void CTFPowerupBottle::ReapplyProvision( void )
 					// Refill weapon clips
 					for ( int i = 0; i < MAX_WEAPONS; i++ )
 					{
-						CBaseCombatWeapon *pWeapon = pTFPlayer->GetWeapon(i);
+						CTFWeaponBase *pWeapon = dynamic_cast<CTFWeaponBase*>(pTFPlayer->GetWeapon(i));
 						if ( !pWeapon )
 							continue;
 
@@ -297,7 +297,7 @@ void CTFPowerupBottle::ReapplyProvision( void )
 
 						if ( iShareBottle && pHealTarget )
 						{
-							CBaseCombatWeapon *pPatientWeapon = pHealTarget->GetWeapon(i);
+							CTFWeaponBase *pPatientWeapon = dynamic_cast<CTFWeaponBase*>(pHealTarget->GetWeapon(i));
 							if ( !pPatientWeapon )
 								continue;
 

--- a/src/game/shared/tf/tf_item_powerup_bottle.cpp
+++ b/src/game/shared/tf/tf_item_powerup_bottle.cpp
@@ -287,7 +287,8 @@ void CTFPowerupBottle::ReapplyProvision( void )
 						if ( TFGameRules() && TFGameRules()->IsMannVsMachineMode() )
 						{
 							if ( ( pWeapon->UsesPrimaryAmmo() && !pWeapon->HasPrimaryAmmo() ) ||
-								( pWeapon->UsesSecondaryAmmo() && !pWeapon->HasSecondaryAmmo() ) )
+								( pWeapon->UsesSecondaryAmmo() && !pWeapon->HasSecondaryAmmo() ) ||
+								( pWeapon->IsEnergyWeapon() && !pWeapon->Energy_HasEnergy() ) )
 							{
 								pTFPlayer->AwardAchievement( ACHIEVEMENT_TF_MVM_USE_AMMO_BOTTLE ); 
 							}

--- a/src/game/shared/tf/tf_weaponbase.cpp
+++ b/src/game/shared/tf/tf_weaponbase.cpp
@@ -424,6 +424,16 @@ void CTFWeaponBase::Activate( void )
 	GiveDefaultAmmo();
 }
 
+void CTFWeaponBase::GiveDefaultAmmo(void)
+{
+	BaseClass::GiveDefaultAmmo();
+
+	if (IsEnergyWeapon())
+	{
+		m_flEnergy = Energy_GetMaxEnergy();
+	}
+}
+
 // -----------------------------------------------------------------------------
 // Purpose:
 // -----------------------------------------------------------------------------

--- a/src/game/shared/tf/tf_weaponbase.h
+++ b/src/game/shared/tf/tf_weaponbase.h
@@ -282,6 +282,7 @@ class CTFWeaponBase : public CBaseCombatWeapon, public IHasOwner, public IHasGen
 
 	virtual void Spawn();
 	virtual void Activate( void );
+	virtual void GiveDefaultAmmo( void );
 	virtual void Precache();
 	virtual bool IsPredicted() const			{ return true; }
 	virtual void FallInit( void );


### PR DESCRIPTION
This fixes ammo canteens just not affecting energy weapons which include the Cow Mangler 5000, The Righteous Bison, and The Pomson 6000.