### PR TITLE
[TF2] Adjust cl_hud_killstreak_display_* ConVars descriptions

### DIFF
--- a/src/game/client/tf/tf_hud_deathnotice.cpp
+++ b/src/game/client/tf/tf_hud_deathnotice.cpp
@@ -50,9 +50,9 @@ const char *szLocalizedObjectNames[OBJ_LAST] =
 	"#TF_object_Sapper"
 };
 
-ConVar cl_hud_killstreak_display_time( "cl_hud_killstreak_display_time", "3", FCVAR_ARCHIVE, "How long a killstreak notice stays on the screen (in seconds).  Range is from 0 to 100."  );
-ConVar cl_hud_killstreak_display_fontsize( "cl_hud_killstreak_display_fontsize", "0", FCVAR_ARCHIVE, "Adjusts font size of killstreak notices.  Range is from 0 to 2 (default is 1)." );
-ConVar cl_hud_killstreak_display_alpha( "cl_hud_killstreak_display_alpha", "120", FCVAR_ARCHIVE, "Adjusts font alpha value of killstreak notices.  Range is from 0 to 255 (default is 200)." );
+ConVar cl_hud_killstreak_display_time( "cl_hud_killstreak_display_time", "3", FCVAR_ARCHIVE, "How long a killstreak notice stays on the screen (in seconds). Range is from 0 to 100." );
+ConVar cl_hud_killstreak_display_fontsize( "cl_hud_killstreak_display_fontsize", "0", FCVAR_ARCHIVE, "Adjusts font size of killstreak notices. Range is from 0 to 2." );
+ConVar cl_hud_killstreak_display_alpha( "cl_hud_killstreak_display_alpha", "120", FCVAR_ARCHIVE, "Adjusts font alpha value of killstreak notices. Range is from 0 to 255." );
 
 const int STREAK_MIN = 5;
 const int STREAK_MIN_MVM = 20;


### PR DESCRIPTION
Fixes https://github.com/ValveSoftware/Source-1-Games/issues/4727.

Removes the default value from the description because the default value can be consulted if the value is modified.