### PR TITLE
Fix memory leak from unreleased script variants

### DIFF
--- a/src/game/server/vscript_server.cpp
+++ b/src/game/server/vscript_server.cpp
@@ -1159,22 +1159,27 @@ bool ScriptSendGlobalGameEvent( const char *szName, HSCRIPT params )
 			if ( vKey.GetType() != FIELD_CSTRING )
 			{
 				Log_Msg( LOG_VScript, "VSCRIPT: ScriptSendRealGameEvent: Key must be a FIELD_CSTRING" );
-				continue;
 			}
-			const char *pszKeyName = (const char *)vKey;
-			switch ( vValue.GetType() )
+			else
 			{
-				case FIELD_BOOLEAN: event->SetBool  ( pszKeyName, (bool)vValue );         break;
-				case FIELD_FLOAT:   event->SetFloat ( pszKeyName, (float)vValue );        break;
-				case FIELD_INTEGER: event->SetInt   ( pszKeyName, (int)vValue );          break;
-				case FIELD_CSTRING: event->SetString( pszKeyName, (const char *)vValue ); break;
-				case FIELD_UINT64:  event->SetUint64( pszKeyName, (uint64)vValue );       break;
-				default:
+				const char *pszKeyName = (const char *)vKey;
+				switch ( vValue.GetType() )
 				{
-					Log_Msg( LOG_VScript, "VSCRIPT: ScriptSendRealGameEvent: Don't understand FIELD_TYPE of value for key %s.", pszKeyName );
-					break;
+					case FIELD_BOOLEAN: event->SetBool  ( pszKeyName, (bool)vValue );         break;
+					case FIELD_FLOAT:   event->SetFloat ( pszKeyName, (float)vValue );        break;
+					case FIELD_INTEGER: event->SetInt   ( pszKeyName, (int)vValue );          break;
+					case FIELD_CSTRING: event->SetString( pszKeyName, (const char *)vValue ); break;
+					case FIELD_UINT64:  event->SetUint64( pszKeyName, (uint64)vValue );       break;
+					default:
+					{
+						Log_Msg( LOG_VScript, "VSCRIPT: ScriptSendRealGameEvent: Don't understand FIELD_TYPE of value for key %s.", pszKeyName );
+						break;
+					}
 				}
 			}
+
+			g_pScriptVM->ReleaseValue( vKey );
+			g_pScriptVM->ReleaseValue( vValue );
 		}
 	}
 
@@ -1809,15 +1814,31 @@ static bool Script_TraceLineEx( HSCRIPT hTable )
 	bool bNoParams = false;
 
 	if (g_pScriptVM->GetValue( hTable, "start", &rval ) )
+	{
 		vStart = rval;
+		g_pScriptVM->ReleaseValue( rval );
+	}
 	else
+	{
 		bNoParams = true;
+	}
+
 	if (g_pScriptVM->GetValue( hTable, "end", &rval ) )
+	{
 		vEnd = rval;
+		g_pScriptVM->ReleaseValue( rval );
+	}
 	else
+	{
 		bNoParams = true;
+	}
+
 	if (g_pScriptVM->GetValue( hTable, "mask", &rval ))
+	{
 		mask = rval;
+		g_pScriptVM->ReleaseValue( rval );
+	}
+
 	if (bNoParams)
 	{
 		Warning("Didnt supply start and end to Script TraceLine call, failing, setting called to false\n");
@@ -1827,6 +1848,7 @@ static bool Script_TraceLineEx( HSCRIPT hTable )
 	if (g_pScriptVM->GetValue( hTable, "ignore", &rval ))
 	{
 		pIgnoreEnt = ToEnt((HSCRIPT)rval);
+		g_pScriptVM->ReleaseValue( rval );
 	}
 	trace_t tr;
 	UTIL_TraceLine( vStart, vEnd, mask, pIgnoreEnt, coll, &tr );
@@ -1848,24 +1870,44 @@ static bool Script_TraceHull( HSCRIPT hTable )
 	bool bNoParams = false;
 
 	if (g_pScriptVM->GetValue( hTable, "start", &rval ) )
+	{
 		vStart = rval;
+		g_pScriptVM->ReleaseValue( rval );
+	}
 	else
+	{
 		bNoParams = true;
+	}
 
 	if (g_pScriptVM->GetValue( hTable, "end", &rval ) )
+	{
 		vEnd = rval;
+		g_pScriptVM->ReleaseValue( rval );
+	}
 	else
+	{
 		bNoParams = true;
+	}
 
 	if (g_pScriptVM->GetValue( hTable, "hullmin", &rval ) )
+	{
 		vHullMin = rval;
+		g_pScriptVM->ReleaseValue( rval );
+	}
 	else
+	{
 		bNoParams = true;
+	}
 
 	if (g_pScriptVM->GetValue( hTable, "hullmax", &rval ) )
+	{
 		vHullMax = rval;
+		g_pScriptVM->ReleaseValue( rval );
+	}
 	else
+	{
 		bNoParams = true;
+	}
 
 	if (bNoParams)
 	{
@@ -1877,11 +1919,13 @@ static bool Script_TraceHull( HSCRIPT hTable )
 	if (g_pScriptVM->GetValue( hTable, "mask", &rval ))
 	{
 		mask = rval;
+		g_pScriptVM->ReleaseValue( rval );
 	}
 
 	if (g_pScriptVM->GetValue( hTable, "ignore", &rval ))
 	{
 		pIgnoreEnt = ToEnt((HSCRIPT)rval);
+		g_pScriptVM->ReleaseValue( rval );
 	}
 
 	trace_t tr;


### PR DESCRIPTION
Various VScript-related routines are leaking memory due to not releasing script variants. This is due to either failing to call `g_pScriptVM->ReleaseValue` or anything that called `g_pScriptVM->SetValue` with a temporary object. Notable functions affected are `TraceHull`, `TraceLineEx`, `EmitSoundEx` and `OnTakeDamage` hook. This has been observed to cause issues with servers running out of memory when hosting maps that called these functions repeatedly in scripts.

This PR addresses the issue by calling `ReleaseValue` where appropriate, adding an overload to `SetValue` that automatically releases temporary objects, and releasing values in the `Get` helper.