### PR TITLE
Fix the caber, and fix intended extended melee hits

### DIFF
--- a/src/game/shared/tf/achievements_tf_demoman.cpp
+++ b/src/game/shared/tf/achievements_tf_demoman.cpp
@@ -626,7 +626,8 @@ class CAchievementTFDemoman_MeleeKillWhileJumping : public CBaseTFAchievement
 		{
 			if ( m_bStickyJumping )
 			{
-				if ( event->GetInt( "weaponid" ) == TF_WEAPON_BOTTLE || event->GetInt( "weaponid" ) == TF_WEAPON_SWORD )
+				// FIX: Stickbomb counts too!
+				if ( event->GetInt( "weaponid" ) == TF_WEAPON_BOTTLE || event->GetInt( "weaponid" ) == TF_WEAPON_SWORD || event->GetInt( "weaponid" ) == TF_WEAPON_STICKBOMB )
 				{
 					IncrementCount();
 				}

--- a/src/game/shared/tf/tf_gamerules.cpp
+++ b/src/game/shared/tf/tf_gamerules.cpp
@@ -6108,7 +6108,8 @@ bool CTFGameRules::ApplyOnDamageModifyRules( CTakeDamageInfo &info, CBaseEntity 
 					eDamageBonusCond = TF_COND_OFFENSEBUFF;
 				}
 			}
-			else if ( pTFAttacker && (bitsDamage & DMG_RADIUS_MAX) && pWeapon && ( (pWeapon->GetWeaponID() == TF_WEAPON_SWORD) || (pWeapon->GetWeaponID() == TF_WEAPON_BOTTLE)|| (pWeapon->GetWeaponID() == TF_WEAPON_WRENCH) ) )
+			// FIX: We can't minicrit on a stickbomb
+			else if ( pTFAttacker && (bitsDamage & DMG_RADIUS_MAX) && pWeapon && ( (pWeapon->GetWeaponID() == TF_WEAPON_SWORD) || (pWeapon->GetWeaponID() == TF_WEAPON_BOTTLE)|| (pWeapon->GetWeaponID() == TF_WEAPON_WRENCH)|| (pWeapon->GetWeaponID() == TF_WEAPON_STICKBOMB) ) )
 			{
 				// First sword or bottle attack after a charge is a mini-crit.
 				bAllSeeCrit = true;

--- a/src/game/shared/tf/tf_weaponbase_melee.cpp
+++ b/src/game/shared/tf/tf_weaponbase_melee.cpp
@@ -78,6 +78,7 @@ void CTFWeaponBaseMelee::WeaponReset( void )
 	m_flSmackTime = -1.0f;
 	m_bConnected = false;
 	m_bMiniCrit = false;
+	m_bWasCharging = false;
 }
 
 // -----------------------------------------------------------------------------
@@ -139,6 +140,7 @@ void CTFWeaponBaseMelee::Spawn()
 // -----------------------------------------------------------------------------
 bool CTFWeaponBaseMelee::Holster( CBaseCombatWeapon *pSwitchingTo )
 {
+	m_bWasCharging = false; // Once we holster, remove the charge hit extension
 	m_flSmackTime = -1.0f;
 	if ( GetPlayerOwner() )
 	{
@@ -164,8 +166,9 @@ bool CTFWeaponBaseMelee::Holster( CBaseCombatWeapon *pSwitchingTo )
 int	CTFWeaponBaseMelee::GetSwingRange( void )
 {
 	CTFPlayer *pOwner = ToTFPlayer( GetOwner() );
-	if ( pOwner && pOwner->m_Shared.InCond( TF_COND_SHIELD_CHARGE ) )
+	if ( pOwner && (pOwner->m_Shared.InCond( TF_COND_SHIELD_CHARGE ) || m_bWasCharging) )
 	{
+		m_bWasCharging = false;
 		return 128;
 	}
 	else
@@ -198,6 +201,7 @@ void CTFWeaponBaseMelee::PrimaryAttack()
 	m_iWeaponMode = TF_WEAPON_PRIMARY_MODE;
 	m_bConnected = false;
 
+	m_bWasCharging = pPlayer->m_Shared.InCond(TF_COND_SHIELD_CHARGE);
 	pPlayer->EndClassSpecialSkill();
 
 	// Swing the weapon.

--- a/src/game/shared/tf/tf_weaponbase_melee.h
+++ b/src/game/shared/tf/tf_weaponbase_melee.h
@@ -92,6 +92,7 @@ protected:
 	float	m_flSmackTime;
 	bool	m_bConnected;
 	bool	m_bMiniCrit;
+	bool 	m_bWasCharging;
 
 #ifdef GAME_DLL
 	CUtlVector< CHandle< CTFPlayer > > m_potentialVictimVector;


### PR DESCRIPTION
In TF2, the game expects us to be charging whilst attacking to get a range bonus from 48 (Bottle)/72 (Sword) to 128
Unfortunately, this is bugged
You see, melee hits aren't instant
But your charge ends the instant you try to swing
As such, we can never use the extended range, since we aren't "charging" when the hit connects
This can be worked around by swinging as soon as we charge, but this means giving up a crit and requiring us to be very close

This pull request fixes this, by introducing a class variable called `m_bWasCharging`, which is set if you swing whilst charging, and unset when the hit is done or you swap weapons

I also fixed the caber being excluded from a few achievements