### PR TITLE
[TF2] Add NetProps preventing Hale from earning Heavy achievements

### DIFF
--- a/src/game/client/tf/c_tf_player.cpp
+++ b/src/game/client/tf/c_tf_player.cpp
@@ -3756,6 +3756,8 @@ IMPLEMENT_CLIENTCLASS_DT( C_TFPlayer, DT_TFPlayer, CTFPlayer )
 	RecvPropInt( RECVINFO( m_iPlayerSkinOverride ) ),
 	RecvPropBool( RECVINFO( m_bViewingCYOAPDA ) ),
 	RecvPropBool( RECVINFO( m_bRegenerating ) ),
+	RecvPropInt( RECVINFO( m_nRestrictAchievements ) ),
+	RecvPropInt( RECVINFO( m_nRestrictQuests ) ),
 END_RECV_TABLE()
 
 
@@ -3941,6 +3943,9 @@ C_TFPlayer::C_TFPlayer() :
 	m_pPasstimeAskForBallReticle = NULL;
 
 	m_iPlayerSkinOverride = 0;
+
+	m_nRestrictAchievements = 0;
+	m_nRestrictQuests = 0;
 
 	ListenForGameEvent( "player_hurt" );
 	ListenForGameEvent( "hltv_changed_mode" );

--- a/src/game/client/tf/c_tf_player.h
+++ b/src/game/client/tf/c_tf_player.h
@@ -937,6 +937,10 @@ public:
 
 	int GetSkinOverride() const { return m_iPlayerSkinOverride; }
 
+	// 0 - no restrictions. 1 - restrict class-specific achievements/quests only. 2 - restrict ALL achievements/quests.
+	short GetAchievementRestrictions() const { return m_nRestrictAchievements; }
+	short GetQuestRestrictions() const { return m_nRestrictQuests; }
+
 	virtual void ClientAdjustStartSoundParams( EmitSound_t &params ) override;
 	virtual void ClientAdjustStartSoundParams( StartSoundParams_t& params ) override;
 
@@ -966,6 +970,9 @@ private:
 	float m_flTempForceDrawViewModelCycle  = 0.0f;
 
 	CNetworkVar( int, m_iPlayerSkinOverride );
+
+	CNetworkVar( short, m_nRestrictAchievements );
+	CNetworkVar( short, m_nRestrictQuests );
 };
 
 inline C_TFPlayer* ToTFPlayer( C_BaseEntity *pEntity )

--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -843,6 +843,8 @@ IMPLEMENT_SERVERCLASS_ST( CTFPlayer, DT_TFPlayer )
 	SendPropInt( SENDINFO( m_iPlayerSkinOverride ) ),
 	SendPropBool( SENDINFO( m_bViewingCYOAPDA ) ),
 	SendPropBool( SENDINFO( m_bRegenerating ) ),
+	SendPropInt( SENDINFO( m_nRestrictAchievements ), 2, SPROP_UNSIGNED ),
+	SendPropInt( SENDINFO( m_nRestrictQuests ), 2, SPROP_UNSIGNED ),
 END_SEND_TABLE()
 
 // -------------------------------------------------------------------------------- //
@@ -1104,6 +1106,9 @@ CTFPlayer::CTFPlayer()
 	m_flNextScorePointForPD = -1;
 
 	m_iPlayerSkinOverride = 0;
+
+	m_nRestrictAchievements = 0;
+	m_nRestrictQuests = 0;
 
 	m_nPrevRoundTeamNum = TEAM_UNASSIGNED;
 	m_flLastDamageResistSoundTime = -1.f;
@@ -20247,6 +20252,12 @@ int	CTFPlayer::CalculateTeamBalanceScore( void )
 //-----------------------------------------------------------------------------
 void CTFPlayer::AwardAchievement( int iAchievement, int iCount )
 {
+	// when set to 2, this netprop prevents its player from earning any achievements
+	if (m_nRestrictAchievements == 2)
+	{
+		return;
+	}
+
 	if ( TFGameRules()->State_Get() >= GR_STATE_TEAM_WIN )
 	{
 		// allow the Helltower loot island achievement during the bonus time

--- a/src/game/server/tf/tf_player.h
+++ b/src/game/server/tf/tf_player.h
@@ -1468,6 +1468,10 @@ public:
 
 	int GetSkinOverride() const { return m_iPlayerSkinOverride; }
 
+	// 0 - no restrictions. 1 - restrict class-specific achievements/quests only. 2 - restrict ALL achievements/quests.
+	short GetAchievementRestrictions() const { return m_nRestrictAchievements; }
+	short GetQuestRestrictions() const { return m_nRestrictQuests; }
+
 	bool ShouldGetBonusPointsForExtinguishEvent( int userID );
 
 	void SetLastAutobalanceTime( float flTime ) { m_flLastAutobalanceTime = flTime; }
@@ -1508,6 +1512,9 @@ private:
 	CUtlMap< CUtlString, float > m_mapCustomAttributes;
 
 	CNetworkVar( int, m_iPlayerSkinOverride );
+
+	CNetworkVar( short, m_nRestrictAchievements );
+	CNetworkVar( short, m_nRestrictQuests );
 
 	CUtlMap<int, float> m_PlayersExtinguished;	// userID and most recent time they were extinguished for bonus points
 

--- a/src/game/shared/tf/achievements_tf.cpp
+++ b/src/game/shared/tf/achievements_tf.cpp
@@ -56,6 +56,12 @@ bool CBaseTFAchievementSimple::LocalPlayerCanEarn( void )
 		}
 	}
 
+	C_TFPlayer *pLocalPlayer = C_TFPlayer::GetLocalTFPlayer();
+	if ( pLocalPlayer && pLocalPlayer->GetAchievementRestrictions() == 2 )
+	{
+		return false;
+	}
+
 	return BaseClass::LocalPlayerCanEarn();
 }
 
@@ -81,6 +87,13 @@ bool CBaseTFAchievement::LocalPlayerCanEarn( void )
 	{
 		int iClass = floor( (m_iAchievementID - ACHIEVEMENT_START_CLASS_SPECIFIC) / 100.0f ) + 1;
 		if ( !IsLocalTFPlayerClass( iClass ) )
+		{
+			return false;
+		}
+
+		// m_nRestrictAchievements set to 1 prevents from earning class-specific achievements only
+		C_TFPlayer *pLocalPlayer = C_TFPlayer::GetLocalTFPlayer();
+		if ( pLocalPlayer && pLocalPlayer->GetAchievementRestrictions() > 0 )
 		{
 			return false;
 		}

--- a/src/game/shared/tf/tf_quest_restriction.cpp
+++ b/src/game/shared/tf/tf_quest_restriction.cpp
@@ -374,6 +374,12 @@ bool CTFQuestCondition::IsValidForPlayer( const CTFPlayer *pOwner, InvalidReason
 
 		// Can only do quests on Valve servers
 		IsValidServerForQuests( steamIDOwner, invalidReasons );
+
+		// m_nRestrictQuests set to 2 prevents from earning quests
+		if ( pOwner->GetQuestRestrictions() == 2 )
+		{
+			invalidReasons.m_bits.Set( INVALID_QUEST_REASON_WRONG_CLASS );
+		}
 	}
 
 	return true;
@@ -1483,8 +1489,9 @@ private:
 	virtual bool BPlayerCheck( const CTFPlayer* pPlayer, IGameEvent *pEvent ) const OVERRIDE
 	{
 		// Check if the classes match
+		// m_nRestrictQuests set to 1 prevents from earning class-specific quests
 		int iClass = pPlayer->GetPlayerClass()->GetClassIndex();
-		return m_iClass == iClass;
+		return m_iClass == iClass && pPlayer->GetQuestRestrictions() == 0;
 	}
 
 


### PR DESCRIPTION
Custom characters, such as Saxton Hale in VSH, technically are heavily modified existing classes.

This leads to Hale earning Heavy-specific achievements, which introduces the feeling of jankiness.

To solve this, in this PR I propose two NetProps for the Player that can temporarily disable achievements and contracker quests for an individual player. The idea is to then change those NetProps on demand via VScript for the custom character.

- When those NetProps are set to 0 (the default value) they allow achievements/quests as normal.
- When set to 1, they disable class-specific achievements/quests. There's all-class achievements such as "Accumulate 1000 total kills" and it makes sense that Hale could earn them too.
- When set to 2, earning achievements/quests is disabled for that player entirely.