### PR TITLE
Remove knockback-attribute-specific animation overrides for CTFScattergun

### DIFF
--- a/src/game/shared/tf/tf_weapon_shotgun.cpp
+++ b/src/game/shared/tf/tf_weapon_shotgun.cpp
@@ -442,61 +442,6 @@ bool CTFScatterGun::HasKnockback( void )
 		return false;
 }
 
-//-----------------------------------------------------------------------------
-// Purpose: Play animation appropriate to ball status.
-//-----------------------------------------------------------------------------
-bool CTFScatterGun::SendWeaponAnim( int iActivity )
-{
-	CTFPlayer *pPlayer = GetTFPlayerOwner();
-	if ( !pPlayer )
-		return BaseClass::SendWeaponAnim( iActivity );
-
-	if ( HasKnockback() )
-	{
-		// Knockback version uses a different model and animation set.
-		switch ( iActivity )
-		{
-		case ACT_VM_DRAW:
-			iActivity = ACT_ITEM2_VM_DRAW;
-			break;
-		case ACT_VM_HOLSTER:
-			iActivity = ACT_ITEM2_VM_HOLSTER;
-			break;
-		case ACT_VM_IDLE:
-			iActivity = ACT_ITEM2_VM_IDLE;
-			break;
-		case ACT_VM_PULLBACK:
-			iActivity = ACT_ITEM2_VM_PULLBACK;
-			break;
-		case ACT_VM_PRIMARYATTACK:
-			iActivity = ACT_ITEM2_VM_PRIMARYATTACK;
-			break;
-		case ACT_VM_SECONDARYATTACK:
-			iActivity = ACT_ITEM2_VM_SECONDARYATTACK;
-			break;
-		case ACT_VM_RELOAD:
-			iActivity = ACT_ITEM2_VM_RELOAD;
-			break;
-		case ACT_VM_DRYFIRE:
-			iActivity = ACT_ITEM2_VM_DRYFIRE;
-			break;
-		case ACT_VM_IDLE_TO_LOWERED:
-			iActivity = ACT_ITEM2_VM_IDLE_TO_LOWERED;
-			break;
-		case ACT_VM_IDLE_LOWERED:
-			iActivity = ACT_ITEM2_VM_IDLE_LOWERED;
-			break;
-		case ACT_VM_LOWERED_TO_IDLE:
-			iActivity = ACT_ITEM2_VM_LOWERED_TO_IDLE;
-			break;
-		default:
-			break;
-		}
-	}
-
-	return BaseClass::SendWeaponAnim( iActivity );
-}
-
 #ifdef GAME_DLL
 //-----------------------------------------------------------------------------
 void CTFScatterGun::Equip( CBaseCombatCharacter *pOwner )


### PR DESCRIPTION
Closes https://github.com/ValveSoftware/Source-1-Games/issues/3959 and allows for usage of the attribute in custom weapons without animation breakage.

### This MUST be accompanied by items_game.txt changes to reintroduce the animations via animation_replacement:
#### prefabs.weapon_force_a_nature.visuals.animation_replacement
```
diff --git a/tf/scripts/items/items_game.txt b/tf/scripts/items/items_game.txt
index eae0400..cc9a2bd 100644
--- a/tf/scripts/items/items_game.txt
+++ b/tf/scripts/items/items_game.txt
@@ -17977,6 +17977,17 @@

 				"animation_replacement"
 				{
+					"ACT_VM_IDLE"					"ACT_ITEM2_VM_IDLE"
+					"ACT_VM_DRAW"					"ACT_ITEM2_VM_DRAW"
+					"ACT_VM_HOLSTER"				"ACT_ITEM2_VM_HOLSTER"
+					"ACT_VM_PULLBACK"				"ACT_ITEM2_VM_PULLBACK"
+					"ACT_VM_PRIMARYATTACK"			"ACT_ITEM2_VM_PRIMARYATTACK"
+					"ACT_VM_SECONDARYATTACK"		"ACT_ITEM2_VM_SECONDARYATTACK"
+					"ACT_VM_RELOAD"					"ACT_ITEM2_VM_RELOAD"
+					"ACT_VM_DRYFIRE"				"ACT_ITEM2_VM_DRYFIRE"
+					"ACT_VM_IDLE_TO_LOWERED"		"ACT_ITEM2_VM_IDLE_TO_LOWERED"
+					"ACT_VM_IDLE_LOWERED"			"ACT_ITEM2_VM_IDLE_LOWERED"
+					"ACT_VM_LOWERED_TO_IDLE"		"ACT_ITEM2_VM_LOWERED_TO_IDLE"
 					"ACT_PRIMARY_VM_INSPECT_START"		"ACT_ITEM2_VM_INSPECT_START"
 					"ACT_PRIMARY_VM_INSPECT_IDLE"		"ACT_ITEM2_VM_INSPECT_IDLE"
 					"ACT_PRIMARY_VM_INSPECT_END"		"ACT_ITEM2_VM_INSPECT_END"
```