### PR TITLE
[TF2] Add FCVAR_SERVER_CANNOT_QUERY to cl_disablehtmlmotd

### DIFF
--- a/src/game/client/game_controls/vguitextwindow.cpp
+++ b/src/game/client/game_controls/vguitextwindow.cpp
@@ -32,7 +32,7 @@ extern INetworkStringTable *g_pStringTableInfoPanel;
 
 #define TEMP_HTML_FILE	"textwindow_temp.html"
 
-ConVar cl_disablehtmlmotd( "cl_disablehtmlmotd", "0", FCVAR_ARCHIVE, "Disable HTML motds." );
+ConVar cl_disablehtmlmotd( "cl_disablehtmlmotd", "0", FCVAR_ARCHIVE | FCVAR_SERVER_CANNOT_QUERY, "Disable HTML motds." );
 
 //=============================================================================
 // HPE_BEGIN:


### PR DESCRIPTION
Updates cl_disablehtmlmotd by adding the `FCVAR_SERVER_CANNOT_QUERY` flag to prevent community servers from "nagging" for it to be enabled.

Originally I proposed disabling the cvar outright by adding dev only, however the discussion below made it clear that several other useful features rely on html motds. This updated proposal will hopefully serve as an acceptable compromise.

<details>
<summary> Original Proposal </summary>
Also requires removing/commenting out this option in `user_default.scr` (outside this repo):

```
// To be removed from user_default.scr L601-L607
	"cl_disablehtmlmotd"
	{
		"#Valve_DisableHTMLMOTD"
		"#Tooltip_DisableHTMLMOTD"
		{ BOOL }
		{ "0" }
	}
```

This PR proposes changing `cl_disablehtmlmotd` to a dev-only cvar forced to 1, preventing forced advertising within community servers.

In practice, HTML Motds are slow to load, and are used for two purposes:

- Communicating server info like the rules (which can be done with a non-html motd).
- Advertising to players.

Even when users have set `cl_disablehtmlmotd 1`, they are often nagged to revert this cvar. For this reason, I believe just changing the cvar's default to 1 is insufficient; the dev-only flag is required to dissuade this practice entirely.

Example of advertising with HTML Motd:

![image](https://github.com/user-attachments/assets/781350c2-b3d5-489b-87e6-3330033d459e)

Examples of nags:

![image](https://github.com/user-attachments/assets/535b9583-1e25-48c9-9d23-d58e8a50fa2e)

![Screenshot 2025-02-20 230751](https://github.com/user-attachments/assets/21b3604f-5753-409f-862d-69c04fa88db8)
</details>