### PR TITLE
[TF2] Rework CTFPlayer::CanAirDash and air_dash_count attribute for broader class usage

### DIFF
--- a/src/game/shared/tf/tf_gamemovement.cpp
+++ b/src/game/shared/tf/tf_gamemovement.cpp
@@ -1210,18 +1210,18 @@ bool CTFGameMovement::CheckJumpButton()
 	if ( !m_pTFPlayer->CanJump() )
 		return false;
 
-	// Check to see if the player is a scout.
-	bool bScout = m_pTFPlayer->GetPlayerClass()->IsClass( TF_CLASS_SCOUT );
+	// Check to see if the player can air dash
+	bool bCanAirDash = m_pTFPlayer->CanAirDash();
 	bool bAirDash = false;
 	bool bOnGround = ( player->GetGroundEntity() != NULL );
 
 	ToggleParachute();
 
-	// Cannot jump will ducked.
+	// Cannot jump while ducked.
 	if ( player->GetFlags() & FL_DUCKING )
 	{
-		// Let a scout do it.
-		bool bAllow = ( bScout && !bOnGround );
+		// Let airdash do it.
+		bool bAllow = ( bCanAirDash && !bOnGround );
 
 		if ( !bAllow )
 			return false;
@@ -1236,10 +1236,10 @@ bool CTFGameMovement::CheckJumpButton()
 		return false;
 
 	// In air, so ignore jumps 
-	// (unless you are a scout or ghost or parachute
+	// (unless airdash or ghost or parachute)
 	if ( !bOnGround )
 	{
-		if ( m_pTFPlayer->CanAirDash() )
+		if ( bCanAirDash )
 		{
 			bAirDash = true;
 		}

--- a/src/game/shared/tf/tf_gamerules.cpp
+++ b/src/game/shared/tf/tf_gamerules.cpp
@@ -6214,13 +6214,13 @@ bool CTFGameRules::ApplyOnDamageModifyRules( CTakeDamageInfo &info, CBaseEntity 
 			{
 				eBonusEffect = kBonusEffect_DragonsFury;
 			}
-			else if ( pTFAttacker && pTFAttacker->IsPlayerClass( TF_CLASS_SCOUT ) && !( pTFAttacker->GetFlags() & FL_ONGROUND ) )
+			else if ( pTFAttacker && !( pTFAttacker->GetFlags() & FL_ONGROUND ) )
 			{
 				// Make sure the weapon that did this damage is the same as the one that grants mini-crits
 				if ( info.GetWeapon() == pTFAttacker->GetActiveTFWeapon() )
 				{
 					int iDashCount = 0;
-					CALL_ATTRIB_HOOK_INT_ON_OTHER( pTFAttacker->GetActiveTFWeapon(), iDashCount, air_dash_count );
+					CALL_ATTRIB_HOOK_INT_ON_OTHER( pTFAttacker->GetActiveTFWeapon(), iDashCount, air_dash_count_from_weapon );
 					if ( iDashCount )
 					{
 						info.SetCritType( CTakeDamageInfo::CRIT_MINI );

--- a/src/game/shared/tf/tf_player_shared.cpp
+++ b/src/game/shared/tf/tf_player_shared.cpp
@@ -12828,36 +12828,29 @@ bool CTFPlayer::CanAirDash( void ) const
 	if ( m_Shared.InCond( TF_COND_HALLOWEEN_SPEED_BOOST ) )
 		return true;
 
-	bool bScout = GetPlayerClass()->IsClass( TF_CLASS_SCOUT );
-	if ( !bScout )
-		return false;
+	int iNoAirDash = 0;
+	CALL_ATTRIB_HOOK_INT( iNoAirDash, set_scout_doublejump_disabled );
+
+	int iDashCount = ( !iNoAirDash && GetPlayerClass()->IsClass( TF_CLASS_SCOUT ) ) ? tf_scout_air_dash_count.GetInt() : 0;
 
 	if ( m_Shared.InCond( TF_COND_SODAPOPPER_HYPE ) )
 	{
-		if ( m_Shared.GetAirDash() < 5 )
-			return true;
-		else
- 			return false;
+		iDashCount += 4;
 	}
+
+	CALL_ATTRIB_HOOK_INT( iDashCount, air_dash_count )
 
 	CTFWeaponBase *pTFActiveWeapon = GetActiveTFWeapon();
-	int iDashCount = tf_scout_air_dash_count.GetInt();
-	CALL_ATTRIB_HOOK_INT_ON_OTHER( pTFActiveWeapon, iDashCount, air_dash_count );
-
-	if ( m_Shared.GetAirDash() >= iDashCount )
-		return false;
-
 	if ( pTFActiveWeapon )
 	{
-		// TODO(driller): Hack fix to restrict this to The Atomzier (currently the only item that uses this attribute) on what would be the third jump
-		float flTimeSinceDeploy = gpGlobals->curtime - pTFActiveWeapon->GetLastDeployTime();
-		if ( iDashCount >= 2 && m_Shared.GetAirDash() == 1 && flTimeSinceDeploy < 0.7f )
-			return false;
+		// (for Atomizer): enforce that the item providing this attribute must be fully deployed to provide the bonus jumps
+		if ( gpGlobals->curtime >= m_Shared.m_flFirstPrimaryAttack )
+		{
+			CALL_ATTRIB_HOOK_INT_ON_OTHER( pTFActiveWeapon, iDashCount, air_dash_count_from_weapon );
+		}
 	}
 
-	int iNoAirDash = 0;
-	CALL_ATTRIB_HOOK_INT( iNoAirDash, set_scout_doublejump_disabled );
-	if ( 1 == iNoAirDash )
+	if ( m_Shared.GetAirDash() >= iDashCount )
 		return false;
 
 	return true;

--- a/src/game/shared/tf/tf_player_shared.cpp
+++ b/src/game/shared/tf/tf_player_shared.cpp
@@ -12828,10 +12828,16 @@ bool CTFPlayer::CanAirDash( void ) const
 	if ( m_Shared.InCond( TF_COND_HALLOWEEN_SPEED_BOOST ) )
 		return true;
 
-	int iNoAirDash = 0;
-	CALL_ATTRIB_HOOK_INT( iNoAirDash, set_scout_doublejump_disabled );
-
-	int iDashCount = ( !iNoAirDash && GetPlayerClass()->IsClass( TF_CLASS_SCOUT ) ) ? tf_scout_air_dash_count.GetInt() : 0;
+	int iDashCount = 0;
+	if ( GetPlayerClass()->IsClass( TF_CLASS_SCOUT ) )
+	{
+		int iNoAirDash = 0;
+		CALL_ATTRIB_HOOK_INT( iNoAirDash, set_scout_doublejump_disabled );
+		if ( !iNoAirDash )
+		{
+			iDashCount += tf_scout_air_dash_count.GetInt();
+		}
+	}
 
 	if ( m_Shared.InCond( TF_COND_SODAPOPPER_HYPE ) )
 	{

--- a/src/game/shared/tf/tf_player_shared.cpp
+++ b/src/game/shared/tf/tf_player_shared.cpp
@@ -12831,11 +12831,17 @@ bool CTFPlayer::CanAirDash( void ) const
 	int iDashCount = 0;
 	if ( GetPlayerClass()->IsClass( TF_CLASS_SCOUT ) )
 	{
-		int iNoAirDash = 0;
-		CALL_ATTRIB_HOOK_INT( iNoAirDash, set_scout_doublejump_disabled );
-		if ( !iNoAirDash )
+		int iScoutDashCount = tf_scout_air_dash_count.GetInt();
+		// allow negative cvar values to 'eat' jumps
+		if ( iScoutDashCount != 0 )
 		{
-			iDashCount += tf_scout_air_dash_count.GetInt();
+			int iNoAirDash = 0;
+			CALL_ATTRIB_HOOK_INT( iNoAirDash, set_scout_doublejump_disabled );
+			// attribute nullifies the effect of cvar if nonzero
+			if ( !iNoAirDash )
+			{
+				iDashCount += iScoutDashCount;
+			}
 		}
 	}
 


### PR DESCRIPTION
This changes the requirements for a given class/player to air dash:
* Halloween Speed Boost condition allows air dash at all times for any class (unchanged)
  * All classes can now air dash while ducking if they are able to air dash
* All classes may air dash if they have nonzero air dash count from attributes/conditions 
* Scouts have base air dash count dictated by tf_scout_air_dash_count cvar, other classes have 0 
* set_scout_doublejump_disabled attribute nullifies the effect of tf_scout_air_dash_count cvar; this can now take on values other than 1 and still take effect (e.g. if multiple items are equipped with this attribute)
* Soda Popper Hype condition adds 4 to air dash count 
* air_dash_count attribute further adds to air dash count, increasing the number of dashes available 
* air_dash_count_from_weapon further adds to air dash count, but only if the current active weapon is able to attack (via m_flFirstPrimaryAttack)
  * note that this replaces the 0.7s hack for the Atomizer's full deploy behavior
  * this also currently handles the minicrit-while-airborne behavior, though that should probably be made its own attribute
  * this also requires a schema change for the Atomizer to use this new attribute class in order to preserve stock behavior

Differences from stock behavior:
* set_scout_doublejump_disabled previously disabled air dashes entirely unless the player had Halloween Speed Boost or Soda Popper Hype, now it only disables the base air dash count that Scouts get from the cvar
* Soda Popper condition and the air_dash_count attribute allow any class to gain air dashes, instead of only Scout
* In stock behavior, the Atomizer is considered fully deployed after 0.75s but the triple jump is allowed after 0.7s. With this patch, those are unified to the same timing, so if it's necessary to keep them separate, an additional attribute or a 0.05s offset on m_flFirstPrimaryAttack is necessary to maintain behavior. If 0.7s is fine for both, the **"single wep deploy time increased" attribute value should be changed to 1.4** alongside the other items_game.txt changes. If 0.75s is fine for both, no further changes are needed from this PR (recommendation is to change to 1.4, historically folks haven't been happy with nerfs as a part of fixes 🚀 ).
* Halloween Speed Boost now allows ducking during air dash

Other than the 0.75s/0.7s timing and Halloween condition, stock servers should function the same as before (where players cannot obtain Hype or air_dash_count if they are not a Scout, and cannot obtain set_scout_doublejump_disabled at all since it was removed from the Sandman)

### This MUST be accompanied by schema changes in order to maintain stock behavior:
```diff
diff --git a/scripts/items/items_game.txt b/scripts/items/items_game.txt
index eae0400..7542d5d 100644
--- a/scripts/items/items_game.txt
+++ b/scripts/items/items_game.txt
@@ -37928,9 +37928,9 @@
 			}
 			"attributes"
 			{
-				"air dash count"
+				"air dash count from weapon"
 				{
-					"attribute_class"	"air_dash_count"
+					"attribute_class"	"air_dash_count_from_weapon"
 					"value"	"1"
 				}
 				"single wep deploy time increased"
@@ -222018,6 +222018,16 @@
 			"armory_desc"	"on_wearer"
 			"stored_as_integer"	"0"
 		}
+		"882"
+		{
+			"name"	"air dash count from weapon"
+			"attribute_class"	"air_dash_count_from_weapon"
+			"description_string"	"#Attrib_AirDashCountIncreased"
+			"description_format"	"value_is_additive"
+			"hidden"	"0"
+			"effect_type"	"positive"
+			"stored_as_integer"	"0"
+		}
 
 
 		"1000"
```