### PR TITLE
Add colored console chat history

### DIFF
--- a/src/game/client/hud_basechat.cpp
+++ b/src/game/client/hud_basechat.cpp
@@ -792,7 +792,8 @@ void CBaseHudChat::MsgFunc_SayText( bf_read &msg )
 	CLocalPlayerFilter filter;
 	C_BaseEntity::EmitSound( filter, SOUND_FROM_LOCAL_PLAYER, "HudChat.Message" );
 
-	Msg( "%s", szString );
+	// TERROR: color console echo
+	//Msg( "%s", szString );
 }
 
 int CBaseHudChat::GetFilterForString( const char *pString )
@@ -852,7 +853,8 @@ void CBaseHudChat::MsgFunc_SayText2( bf_read &msg )
 		// print raw chat text
 		ChatPrintf( client, iFilter, "%s", ansiString );
 
-		Msg( "%s\n", RemoveColorMarkup(ansiString) );
+		// TERROR: color console echo
+		// Msg( "%s\n", RemoveColorMarkup(ansiString) );
 
 		CLocalPlayerFilter filter;
 		C_BaseEntity::EmitSound( filter, SOUND_FROM_LOCAL_PLAYER, "HudChat.Message" );
@@ -939,7 +941,8 @@ void CBaseHudChat::MsgFunc_TextMsg( bf_read &msg )
 			Q_strncat( szString, "\n", sizeof(szString), 1 );
 		}
 		Printf( CHAT_FILTER_NONE, "%s", ConvertCRtoNL( szString ) );
-		Msg( "%s", ConvertCRtoNL( szString ) );
+		// TERROR: color console echo
+		//Msg( "%s", ConvertCRtoNL( szString ) );
 		break;
 
 	case HUD_PRINTCONSOLE:
@@ -1575,6 +1578,9 @@ void CBaseHudChatLine::Colorize( int alpha )
 			InsertColorChange( color );
 			InsertString( wText );
 
+			// TERROR: color console echo
+			ConColorMsg( color, "%ls", wText );
+
 			if ( pChat && pChat->GetChatHistory() )
 			{	
 				pChat->GetChatHistory()->InsertColorChange( color );
@@ -1589,6 +1595,9 @@ void CBaseHudChatLine::Colorize( int alpha )
 
 		}
 	}
+
+	// TERROR: color console echo
+	Msg( "\n" );
 
 	InvalidateLayout( true );
 }

--- a/src/game/server/client.cpp
+++ b/src/game/server/client.cpp
@@ -129,6 +129,9 @@ char * CheckChatText( CBasePlayer *pPlayer, char *text )
 		p[length] = 0;
 	}
 
+	// prevent sending blank text and eating color codes
+	V_StripTrailingWhitespace( p );
+
 	// Josh:
 	// Cheaters can send us whatever data they want through this channel
 	// Let's validate they aren't trying to clear the chat.
@@ -190,7 +193,7 @@ void Host_Say( edict_t *pEdict, const CCommand &args, bool teamonly )
 	{
 		if ( args.ArgC() >= 2 )
 		{
-			p = (char *)args.ArgS();
+			V_strcpy_safe( szTemp, args.ArgS() );
 		}
 		else
 		{
@@ -209,8 +212,9 @@ void Host_Say( edict_t *pEdict, const CCommand &args, bool teamonly )
 			// Just a one word command, use the first word...sigh
 			Q_snprintf( szTemp,sizeof(szTemp), "%s", ( char * )pcmd );
 		}
-		p = szTemp;
 	}
+
+	p = szTemp;
 
 	CBasePlayer *pPlayer = NULL;
 	if ( pEdict )


### PR DESCRIPTION
Self-explanatory, makes chat history in the console use colors.
![screenshot](https://i.imgur.com/pmhoPw6.png)

This PR also fixes the bug where saying a full chat message containing only spaces breaks color codes afterwards (as it made the console become solid white). One more small issue this PR addresses is removing an unsafe const cast and instead copying arguments from `say`/`say_team` command into a buffer first, since `CheckChatText` writes to it in-place,

NOTE: this PR requires the spew bug in materialsystem to be fixed as well, otherwise the console chat can bug out and be positioned out of order.