### PR TITLE
[TF2] Allow players to disable weapon shell ejection

### DIFF
--- a/src/game/shared/tf/tf_weapon_minigun.cpp
+++ b/src/game/shared/tf/tf_weapon_minigun.cpp
@@ -1194,7 +1194,7 @@ void CTFMinigun::ItemPreFrame( void )
 	BaseClass::ItemPreFrame();
 }
 
-
+extern ConVar cl_ejectbrass;
 //-----------------------------------------------------------------------------
 // Purpose: 
 //-----------------------------------------------------------------------------
@@ -1204,6 +1204,9 @@ void CTFMinigun::StartBrassEffect()
 
 	m_hEjectBrassWeapon = GetWeaponForEffect();
 	if ( !m_hEjectBrassWeapon )
+		return;
+
+	if ( cl_ejectbrass.GetBool() == false )
 		return;
 
 	if ( UsingViewModel() && !g_pClientMode->ShouldDrawViewModel() )

--- a/src/game/shared/tf/tf_weaponbase.cpp
+++ b/src/game/shared/tf/tf_weaponbase.cpp
@@ -4829,6 +4829,7 @@ int CTFWeaponBase::GetSkin()
 
 #if defined( CLIENT_DLL )
 
+extern ConVar cl_ejectbrass;
 //-----------------------------------------------------------------------------
 // Purpose: 
 //-----------------------------------------------------------------------------
@@ -4836,6 +4837,9 @@ bool CTFWeaponBase::OnFireEvent( C_BaseViewModel *pViewModel, const Vector& orig
 {
 	if ( event == 6002 && ShouldEjectBrass() )
 	{
+	        if ( cl_ejectbrass.GetBool() == false )
+		        return true;
+
 		if ( UsingViewModel() && !g_pClientMode->ShouldDrawViewModel() )
 		{
 			// Prevent effects when the ViewModel is hidden with r_drawviewmodel=0


### PR DESCRIPTION
Lets players disable weapon shell ejection by using the already existing `cl_ejectbrass` convar, which does exactly this in other source games such as HL2. Closes https://github.com/ValveSoftware/Source-1-Games/issues/5949