### PR TITLE
Allow mappers more freedom in attaching entities to player such as func_tracktrain or func_brush

### DIFF
--- a/src/game/client/c_baseentity.cpp
+++ b/src/game/client/c_baseentity.cpp
@@ -6318,52 +6318,25 @@ bool C_BaseEntity::ValidateEntityAttachedToPlayer( bool &bShouldRetry )
 	C_BaseEntity *pParent = GetRootMoveParent();
 	if ( pParent == this )
 		return true;
-
-	// Some wearables parent to the view model
-	C_TFPlayer *pPlayer = ToTFPlayer( pParent );
-	if ( pPlayer )
+	
+	if(pParent->IsPlayer())
 	{
-		if ( pPlayer->GetViewModel() == this )
-			return true;
+		const char* pszModel = modelinfo->GetModelName(GetModel());
+		if (pszModel && pszModel[0])
+		{
+			// Disallow attaching any models to players that are used in econ.
+			if (Q_strstr(pszModel, "models/player/items"))
+				return false;
 
-		if ( pPlayer->HasItem() && ( pPlayer->GetItem()->GetItemID() == TF_ITEM_CAPTURE_FLAG ) && ( pPlayer->GetItem() == this ) )
-			return true;
+			if (Q_strstr(pszModel, "models/workshop"))
+				return false;
+
+			if (Q_strstr(pszModel, "models/workshop_partner"))
+				return false;
+		}
 	}
-
-	// always allow the briefcase model
-	const char *pszModel = modelinfo->GetModelName( GetModel() );
-	if ( pszModel && pszModel[0] )
-	{
-		if ( FStrEq( pszModel, "models/flag/briefcase.mdl" ) )
-			return true;
-				
-		if ( FStrEq( pszModel, "models/props_doomsday/australium_container.mdl" ) )
-			return true;
-
-		// Temp for MVM testing
-		if ( FStrEq( pszModel, "models/buildables/sapper_placement.mdl" ) )
-			return true;
-
-		if ( FStrEq( pszModel, "models/props_td/atom_bomb.mdl" ) )
-			return true;
-
-		if ( FStrEq( pszModel, "models/props_lakeside_event/bomb_temp_hat.mdl" ) )
-			return true;
-
-		if ( FStrEq( pszModel, "models/props_moonbase/powersupply_flag.mdl" ) )
-			return true;
-
-		// The Halloween 2014 doomsday flag replacement
-		if ( FStrEq( pszModel, "models/flag/ticket_case.mdl" ) )
-			return true;
-
-		if ( FStrEq( pszModel, "models/weapons/c_models/c_grapple_proj/c_grapple_proj.mdl" ) )
-			return true;
-	}
-
-	// Any entity that's not an item parented to a player is invalid.
-	// This prevents them creating some other entity to pretend to be a cosmetic item.
-	return !pParent->IsPlayer();
+	
+	return true;
 }
 #endif // TF_CLIENT_DLL
 


### PR DESCRIPTION

m_bValidatedAttachedEntity exists only on CEconEntity, therefore you can't set it to true on things like func_tracktrain, prop_dynamic or func_brush so that they are visible while parented to player,

Many CS:S-era minigame servers with mg_ maps took advantage of such features to create fun mechanics in maps. At the moment if you try doing it, you're out of luck.

This PR should resolve that, 

```cpp
#ifdef TF_CLIENT_DLL
bool C_BaseEntity::ValidateEntityAttachedToPlayer( bool &bShouldRetry )
{
	bShouldRetry = false;
	C_BaseEntity *pParent = GetRootMoveParent();
	if ( pParent == this )
		return true;
	
	if(pParent->IsPlayer())
	{
		const char* pszModel = modelinfo->GetModelName(GetModel());
		if (pszModel && pszModel[0])
		{
			// Disallow attaching any models to players that are used in econ.
			if (Q_strstr(pszModel, "models/player/items"))
				return false;

			if (Q_strstr(pszModel, "models/workshop"))
				return false;

			if (Q_strstr(pszModel, "models/workshop_partner"))
				return false;
		}
	}
	
	return true;
}
#endif // TF_CLIENT_DLL
```

And since already existing m_bValidatedAttachedEntity lets vscript maps/servers give players any cosmetic/weapon they want anyways, 

I see no reason why func_brush, func_tracktrain and other entities should be discriminated against just because they are not from CEconEntity family tree 😆