### PR TITLE
Fix radial fog not being enabled in 3D sky on official maps

### DIFF
--- a/src/game/server/SkyCamera.cpp
+++ b/src/game/server/SkyCamera.cpp
@@ -146,4 +146,10 @@ void CSkyCamera::Activate( )
 		}
 	}
 #endif
+
+	// matches the behavior of fog controller
+	if ( GameRules()->IsOfficialMap() )
+	{
+		m_skyboxData.fog.radial = true;
+	}
 }


### PR DESCRIPTION
Self-explanatory, [matches the fog controller](https://github.com/ValveSoftware/source-sdk-2013/blob/master/src/game/server/fogcontroller.cpp#L375)