### PR TITLE
[TF2] Add client predicted autobhop cvars.

### DIFF
--- a/src/game/shared/tf/tf_gamemovement.cpp
+++ b/src/game/shared/tf/tf_gamemovement.cpp
@@ -57,6 +57,9 @@ ConVar  tf_parachute_maxspeed_onfire_z( "tf_parachute_maxspeed_onfire_z", "10.0f
 ConVar  tf_parachute_aircontrol( "tf_parachute_aircontrol", "2.5f", FCVAR_DEVELOPMENTONLY | FCVAR_REPLICATED, "Multiplier for how much air control players have when Parachute is deployed" );
 ConVar	tf_parachute_deploy_toggle_allowed( "tf_parachute_deploy_toggle_allowed", "0", FCVAR_REPLICATED | FCVAR_DEVELOPMENTONLY );
 
+ConVar 	sv_enablebunnyhopping( "sv_enablebunnyhopping", "0", FCVAR_REPLICATED | FCVAR_NOTIFY, "Removes speed cap from bunnyhopping." );
+ConVar 	sv_autobunnyhopping( "sv_autobunnyhopping", "0", FCVAR_REPLICATED | FCVAR_NOTIFY, "Players will automatically jump while holding space." );
+
 ConVar  tf_halloween_kart_aircontrol( "tf_halloween_kart_aircontrol", "1.2f", FCVAR_CHEAT | FCVAR_REPLICATED, "Multiplier for how much air control players have when in Kart Mode" );
 ConVar	tf_ghost_up_speed( "tf_ghost_up_speed", "300.f", FCVAR_CHEAT | FCVAR_REPLICATED, "Speed that ghost go upward while holding jump key" );
 ConVar	tf_ghost_xy_speed( "tf_ghost_xy_speed", "300.f", FCVAR_CHEAT | FCVAR_REPLICATED );
@@ -65,6 +68,7 @@ ConVar	tf_grapplinghook_use_acceleration( "tf_grapplinghook_use_acceleration", "
 ConVar	tf_grapplinghook_acceleration( "tf_grapplinghook_acceleration", "3500", FCVAR_REPLICATED | FCVAR_CHEAT );
 ConVar	tf_grapplinghook_dampening( "tf_grapplinghook_dampening", "500", FCVAR_REPLICATED | FCVAR_CHEAT );
 ConVar	tf_grapplinghook_follow_distance( "tf_grapplinghook_follow_distance", "64", FCVAR_REPLICATED | FCVAR_CHEAT );
+
 ConVar	tf_grapplinghook_jump_up_speed( "tf_grapplinghook_jump_up_speed", "375", FCVAR_REPLICATED | FCVAR_CHEAT );
 ConVar	tf_grapplinghook_prevent_fall_damage( "tf_grapplinghook_prevent_fall_damage", "0", FCVAR_REPLICATED | FCVAR_CHEAT );
 ConVar	tf_grapplinghook_medic_latch_speed_scale( "tf_grapplinghook_medic_latch_speed_scale", "0.65", FCVAR_REPLICATED | FCVAR_CHEAT );
@@ -1091,6 +1095,8 @@ void CTFGameMovement::AirDash( void )
 //-----------------------------------------------------------------------------
 void CTFGameMovement::PreventBunnyJumping()
 {
+	if ( sv_enablebunnyhopping.GetBool() )
+		return;
 	if ( m_pTFPlayer->m_Shared.InCond( TF_COND_HALLOWEEN_KART ) )
 		return;
 
@@ -1223,7 +1229,7 @@ bool CTFGameMovement::CheckJumpButton()
 	ToggleParachute();
 
 	// Cannot jump will ducked.
-	if ( player->GetFlags() & FL_DUCKING )
+	if ( player->GetFlags() & FL_DUCKING && !sv_autobunnyhopping.GetBool())
 	{
 		// Let a scout do it.
 		bool bAllow = ( bScout && !bOnGround );
@@ -1237,7 +1243,7 @@ bool CTFGameMovement::CheckJumpButton()
 		return false;
 
 	// Cannot jump again until the jump button has been released.
-	if ( mv->m_nOldButtons & IN_JUMP )
+	if ( mv->m_nOldButtons & IN_JUMP && (!sv_autobunnyhopping.GetBool() || !bOnGround ) )
 		return false;
 
 	// In air, so ignore jumps 

--- a/src/game/shared/tf/tf_gamemovement.cpp
+++ b/src/game/shared/tf/tf_gamemovement.cpp
@@ -58,7 +58,11 @@ ConVar  tf_parachute_aircontrol( "tf_parachute_aircontrol", "2.5f", FCVAR_DEVELO
 ConVar	tf_parachute_deploy_toggle_allowed( "tf_parachute_deploy_toggle_allowed", "0", FCVAR_REPLICATED | FCVAR_DEVELOPMENTONLY );
 
 ConVar 	sv_enablebunnyhopping( "sv_enablebunnyhopping", "0", FCVAR_REPLICATED | FCVAR_NOTIFY, "Removes speed cap from bunnyhopping." );
-ConVar 	sv_autobunnyhopping( "sv_autobunnyhopping", "0", FCVAR_REPLICATED | FCVAR_NOTIFY, "Players will automatically jump while holding space." );
+ConVar  sv_autobunnyhopping( "sv_autobunnyhopping", "0", FCVAR_REPLICATED | FCVAR_NOTIFY,
+	"Whether players will automatically bunnyhop whilst holding +JUMP.\n"
+	" 0   - Players will not automatically jump while holding +JUMP.\n"
+	" 1   - Players will automatically jump while holding +JUMP.\n"
+	" 2   - Players will automatically jump while holding +JUMP, and will be able to jump while crouching.\n");
 
 ConVar  tf_halloween_kart_aircontrol( "tf_halloween_kart_aircontrol", "1.2f", FCVAR_CHEAT | FCVAR_REPLICATED, "Multiplier for how much air control players have when in Kart Mode" );
 ConVar	tf_ghost_up_speed( "tf_ghost_up_speed", "300.f", FCVAR_CHEAT | FCVAR_REPLICATED, "Speed that ghost go upward while holding jump key" );
@@ -1229,7 +1233,7 @@ bool CTFGameMovement::CheckJumpButton()
 	ToggleParachute();
 
 	// Cannot jump will ducked.
-	if ( player->GetFlags() & FL_DUCKING && !sv_autobunnyhopping.GetBool())
+	if ( player->GetFlags() & FL_DUCKING && (sv_autobunnyhopping.GetInt() != 2) )
 	{
 		// Let a scout do it.
 		bool bAllow = ( bScout && !bOnGround );
@@ -1243,7 +1247,7 @@ bool CTFGameMovement::CheckJumpButton()
 		return false;
 
 	// Cannot jump again until the jump button has been released.
-	if ( mv->m_nOldButtons & IN_JUMP && (!sv_autobunnyhopping.GetBool() || !bOnGround ) )
+	if ( mv->m_nOldButtons & IN_JUMP && ( !sv_autobunnyhopping.GetBool() || !bOnGround ) )
 		return false;
 
 	// In air, so ignore jumps 

--- a/src/game/shared/tf/tf_gamemovement.cpp
+++ b/src/game/shared/tf/tf_gamemovement.cpp
@@ -57,12 +57,8 @@ ConVar  tf_parachute_maxspeed_onfire_z( "tf_parachute_maxspeed_onfire_z", "10.0f
 ConVar  tf_parachute_aircontrol( "tf_parachute_aircontrol", "2.5f", FCVAR_DEVELOPMENTONLY | FCVAR_REPLICATED, "Multiplier for how much air control players have when Parachute is deployed" );
 ConVar	tf_parachute_deploy_toggle_allowed( "tf_parachute_deploy_toggle_allowed", "0", FCVAR_REPLICATED | FCVAR_DEVELOPMENTONLY );
 
-ConVar 	sv_enablebunnyhopping( "sv_enablebunnyhopping", "0", FCVAR_REPLICATED | FCVAR_NOTIFY, "Removes speed cap from bunnyhopping." );
-ConVar  sv_autobunnyhopping( "sv_autobunnyhopping", "0", FCVAR_REPLICATED | FCVAR_NOTIFY,
-	"Whether players will automatically bunnyhop whilst holding +JUMP.\n"
-	" 0   - Players will not automatically jump while holding +JUMP.\n"
-	" 1   - Players will automatically jump while holding +JUMP.\n"
-	" 2   - Players will automatically jump while holding +JUMP, and will be able to jump while crouching.\n");
+ConVar 	sv_enablebunnyhopping( "sv_enablebunnyhopping", "0", FCVAR_REPLICATED | FCVAR_NOTIFY, "Allow player speed to exceed maximum running speed" );
+ConVar  sv_autobunnyhopping( "sv_autobunnyhopping", "0", FCVAR_REPLICATED | FCVAR_NOTIFY, "Players automatically re-jump while holding jump button (0 = disabled, 1 = not when crouching, 2 = always)");
 
 ConVar  tf_halloween_kart_aircontrol( "tf_halloween_kart_aircontrol", "1.2f", FCVAR_CHEAT | FCVAR_REPLICATED, "Multiplier for how much air control players have when in Kart Mode" );
 ConVar	tf_ghost_up_speed( "tf_ghost_up_speed", "300.f", FCVAR_CHEAT | FCVAR_REPLICATED, "Speed that ghost go upward while holding jump key" );

--- a/src/game/shared/tf/tf_gamerules.cpp
+++ b/src/game/shared/tf/tf_gamerules.cpp
@@ -18692,8 +18692,6 @@ convar_tags_t convars_to_check_for_tags[] =
 	{ "mp_fadetoblack", "fadetoblack", NULL },
 	{ "tf_weapon_criticals", "nocrits", NULL },
 	{ "mp_disable_respawn_times", "norespawntime", NULL },
-	{ "sv_enablebunnyhopping", "bhop", NULL },
-	{ "sv_autobunnyhopping", "bhop", NULL },
 	{ "tf_gamemode_arena", "arena", NULL },
 	{ "tf_gamemode_cp", "cp", NULL },
 	{ "tf_gamemode_ctf", "ctf", NULL },

--- a/src/game/shared/tf/tf_gamerules.cpp
+++ b/src/game/shared/tf/tf_gamerules.cpp
@@ -18692,6 +18692,8 @@ convar_tags_t convars_to_check_for_tags[] =
 	{ "mp_fadetoblack", "fadetoblack", NULL },
 	{ "tf_weapon_criticals", "nocrits", NULL },
 	{ "mp_disable_respawn_times", "norespawntime", NULL },
+	{ "sv_enablebunnyhopping", "bhop", NULL },
+	{ "sv_autobunnyhopping", "bhop", NULL },
 	{ "tf_gamemode_arena", "arena", NULL },
 	{ "tf_gamemode_cp", "cp", NULL },
 	{ "tf_gamemode_ctf", "ctf", NULL },


### PR DESCRIPTION
Adds two cvars based on whats seen with cs:s and csgo (for parity plus it would be VERY nice to have).
Autobunnyhopping also works whilst crouched

"sv_enablebunnyhopping" ( def. "0" )
 game notify replicated
 - Removes speed cap from bunnyhopping.

"sv_autobunnyhopping" ( def. "0")
 game notify replicated
Whether players will automatically bunnyhop whilst holding +JUMP.
   0   - Players will not automatically jump while holding +JUMP.
   1   - Players will automatically jump while holding +JUMP.
   2   - Players will automatically jump while holding +JUMP, and will be able to jump while crouching.

