### PR TITLE
[TF2] Fix player not being able to deploy parachute after landing and becoming airborne without jump button

### DIFF
--- a/src/game/shared/tf/tf_gamemovement.cpp
+++ b/src/game/shared/tf/tf_gamemovement.cpp
@@ -1142,9 +1142,10 @@ void CTFGameMovement::ToggleParachute()
 		}
 		else
 		{
+			bool bOnGround = ( player->GetGroundEntity() != NULL );
 			int iParachuteDisabled = 0;
 			CALL_ATTRIB_HOOK_INT_ON_OTHER( m_pTFPlayer, iParachuteDisabled, parachute_disabled );
-			if ( !iParachuteDisabled && ( tf_parachute_deploy_toggle_allowed.GetBool() || !m_pTFPlayer->m_Shared.InCond( TF_COND_PARACHUTE_DEPLOYED ) ) )
+			if ( !bOnGround && !iParachuteDisabled && ( tf_parachute_deploy_toggle_allowed.GetBool() || !m_pTFPlayer->m_Shared.InCond( TF_COND_PARACHUTE_DEPLOYED ) ) )
 			{
 				m_pTFPlayer->m_Shared.AddCond( TF_COND_PARACHUTE_ACTIVE );
 				m_pTFPlayer->m_Shared.AddCond( TF_COND_PARACHUTE_DEPLOYED );

--- a/src/game/shared/tf/tf_gamemovement.cpp
+++ b/src/game/shared/tf/tf_gamemovement.cpp
@@ -1142,7 +1142,7 @@ void CTFGameMovement::ToggleParachute()
 		}
 		else
 		{
-			bool bOnGround = ( player->GetGroundEntity() != NULL );
+			bool bOnGround = ( m_pTFPlayer->GetFlags() & FL_ONGROUND );
 			int iParachuteDisabled = 0;
 			CALL_ATTRIB_HOOK_INT_ON_OTHER( m_pTFPlayer, iParachuteDisabled, parachute_disabled );
 			if ( !bOnGround && !iParachuteDisabled && ( tf_parachute_deploy_toggle_allowed.GetBool() || !m_pTFPlayer->m_Shared.InCond( TF_COND_PARACHUTE_DEPLOYED ) ) )

--- a/src/game/shared/tf/tf_gamemovement.cpp
+++ b/src/game/shared/tf/tf_gamemovement.cpp
@@ -1116,12 +1116,6 @@ void CTFGameMovement::PreventBunnyJumping()
 //-----------------------------------------------------------------------------
 void CTFGameMovement::ToggleParachute()
 {
-	if ( ( m_pTFPlayer->GetFlags() & FL_ONGROUND ) )
-	{
-		m_pTFPlayer->m_Shared.RemoveCond( TF_COND_PARACHUTE_DEPLOYED );
-		return;
-	}
-
 	if ( mv->m_nOldButtons & IN_JUMP )
 		return;
 

--- a/src/game/shared/tf/tf_player_shared.cpp
+++ b/src/game/shared/tf/tf_player_shared.cpp
@@ -3102,14 +3102,8 @@ void CTFPlayerShared::ConditionThink( void )
 		RemoveCond( TF_COND_KNOCKED_INTO_AIR );
 		RemoveCond( TF_COND_AIR_CURRENT );
 
-		if ( InCond( TF_COND_PARACHUTE_ACTIVE ) )
-		{
-			RemoveCond( TF_COND_PARACHUTE_ACTIVE );
-		}
-		if ( InCond( TF_COND_PARACHUTE_DEPLOYED ) )
-		{
-			RemoveCond( TF_COND_PARACHUTE_DEPLOYED );
-		}
+		RemoveCond( TF_COND_PARACHUTE_ACTIVE );
+		RemoveCond( TF_COND_PARACHUTE_DEPLOYED );
 
 		if ( InCond( TF_COND_ROCKETPACK ) )
 		{

--- a/src/game/shared/tf/tf_player_shared.cpp
+++ b/src/game/shared/tf/tf_player_shared.cpp
@@ -3106,6 +3106,10 @@ void CTFPlayerShared::ConditionThink( void )
 		{
 			RemoveCond( TF_COND_PARACHUTE_ACTIVE );
 		}
+		if ( InCond( TF_COND_PARACHUTE_DEPLOYED ) )
+		{
+			RemoveCond( TF_COND_PARACHUTE_DEPLOYED );
+		}
 
 		if ( InCond( TF_COND_ROCKETPACK ) )
 		{


### PR DESCRIPTION
Fixes https://github.com/ValveSoftware/Source-1-Games/issues/2455

As described in above bug, TF_COND_PARACHUTE_DEPLOYED is not removed upon landing, but only upon using the jump button while grounded. This can lead to a case where the player has used the parachute, landed, and then becomes airborne without the jump button again, resulting in them being unable to deploy the parachute despite being fully grounded.

This patch moves the removal of the condition to the same case as TF_COND_PARACHUTE_ACTIVE's removal when grounded. It also prevents using the jump button to add the parachute conditions while grounded, in order to prevent the client from receiving the parachute condition for a frame every time they jump.