### PR TITLE
Add ScriptOverlayMaterialEx

### DIFF
--- a/src/game/client/c_baseplayer.cpp
+++ b/src/game/client/c_baseplayer.cpp
@@ -214,6 +214,7 @@ BEGIN_RECV_TABLE_NOBASE( CPlayerLocalData, DT_Local )
 	RecvPropInt( RECVINFO( m_audio.entIndex ) ),
 
 	RecvPropString( RECVINFO( m_szScriptOverlayMaterial ) ),
+	RecvPropArray3( RECVINFO_ARRAY( m_szScriptOverlayMaterialArray ), RecvPropString( RECVINFO_ARRAY( m_szScriptOverlayMaterialArray ) ) ),
 END_RECV_TABLE()
 
 // -------------------------------------------------------------------------------- //

--- a/src/game/client/c_baseplayer.h
+++ b/src/game/client/c_baseplayer.h
@@ -408,6 +408,14 @@ public:
 	int m_StuckLast;
 
 	const char* GetScriptOverlayMaterial() const { return m_Local.m_szScriptOverlayMaterial; }
+	const char* GetScriptOverlayMaterialEx(int index) const
+	{
+		if ( index >= MAX_SCRIPT_OVERLAYS || index < 0 )
+			return "";
+
+		const char* szMaterial = STRING(m_Local.m_szScriptOverlayMaterialArray.Get(index));
+		return !szMaterial || V_strcmp(szMaterial, "null") == 0 ? "" : szMaterial;
+	}
 	
 	// Data for only the local player
 	CNetworkVarEmbedded( CPlayerLocalData, m_Local );

--- a/src/game/client/c_playerlocaldata.h
+++ b/src/game/client/c_playerlocaldata.h
@@ -37,6 +37,11 @@ public:
 		m_bPrevForceLocalPlayerDraw = false;
 
 		m_szScriptOverlayMaterial.GetForModify()[0] = '\0';
+
+		for (int i = 0; i < MAX_SCRIPT_OVERLAYS; i++)
+		{
+			m_szScriptOverlayMaterialArray.Set(i, NULL_STRING);
+		}
 	}
 
 	unsigned char			m_chAreaBits[MAX_AREA_STATE_BYTES];				// Area visibility flags.
@@ -83,6 +88,7 @@ public:
 	bool					m_bSlowMovement;
 
 	CNetworkString( m_szScriptOverlayMaterial, MAX_PATH );
+	CNetworkArray( string_t , m_szScriptOverlayMaterialArray, MAX_SCRIPT_OVERLAYS);
 };
 
 #endif // C_PLAYERLOCALDATA_H

--- a/src/game/client/viewrender.h
+++ b/src/game/client/viewrender.h
@@ -491,6 +491,9 @@ private:
 	CMaterialReference	m_ScriptOverlayMaterial;
 	char m_szCurrentScriptMaterialName[ MAX_PATH ];
 
+	CMaterialReference	m_ScriptOverlayMaterialArray[ MAX_SCRIPT_OVERLAYS ];
+	char m_szCurrentScriptMaterialArrayName[ MAX_SCRIPT_OVERLAYS ][ MAX_PATH ];
+
 	Vector			m_vecLastFacing;
 	float			m_flCheapWaterStartDistance;
 	float			m_flCheapWaterEndDistance;

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -7782,6 +7782,8 @@ BEGIN_ENT_SCRIPTDESC( CBasePlayer, CBaseCombatCharacter, "The player entity." )
 	DEFINE_SCRIPTFUNC( GetForceLocalDraw, "Gets the state of whether the player is being forced by SetForceLocalDraw to be drawn" )
 	DEFINE_SCRIPTFUNC( GetScriptOverlayMaterial, "Gets the current view overlay material" )
 	DEFINE_SCRIPTFUNC( SetScriptOverlayMaterial, "Sets a view overlay material" )
+	DEFINE_SCRIPTFUNC( GetScriptOverlayMaterialEx, "Gets a view overlay material by index" )
+	DEFINE_SCRIPTFUNC( SetScriptOverlayMaterialEx, "Sets a view overlay material by index" )
 END_SCRIPTDESC();
 
 void CStripWeapons::InputStripWeapons(inputdata_t &data)

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -1237,6 +1237,30 @@ public:
 	{
 		SetScriptOverlayMaterial( inputdata.value.String() );
 	}
+
+	const char* GetScriptOverlayMaterialEx(int index) const
+	{
+		if ( index >= MAX_SCRIPT_OVERLAYS || index < 0 )
+			return "";
+
+		const char* szMaterial = STRING(m_Local.m_szScriptOverlayMaterialArray.Get(index));
+		return !szMaterial || V_strcmp(szMaterial, "null") == 0 ? "" : szMaterial;
+	}
+	void SetScriptOverlayMaterialEx( const char *pszMaterial, const int index )
+	{
+		if ( index >= MAX_SCRIPT_OVERLAYS || index < 0)
+			return;
+
+		if ( !pszMaterial || !*pszMaterial )
+		{
+			m_Local.m_szScriptOverlayMaterialArray.Set( index, AllocPooledString("null"));
+			return;
+		}
+		
+		char szMaterialName[MAX_PATH];
+		V_strncpy( szMaterialName, pszMaterial, MAX_PATH );
+		m_Local.m_szScriptOverlayMaterialArray.Set( index, AllocPooledString(szMaterialName) );
+	}
 private:
 	// NVNT member variable holding if this user is using a haptic device.
 	bool m_bhasHaptics;

--- a/src/game/server/playerlocaldata.cpp
+++ b/src/game/server/playerlocaldata.cpp
@@ -88,6 +88,8 @@ BEGIN_SEND_TABLE_NOBASE( CPlayerLocalData, DT_Local )
 	SendPropInt( SENDINFO_STRUCTELEM( m_audio.entIndex ) ),
 
 	SendPropString( SENDINFO( m_szScriptOverlayMaterial ) ),
+	SendPropArray3( SENDINFO_ARRAY3( m_szScriptOverlayMaterialArray ), SendPropString( SENDINFO_ARRAY( m_szScriptOverlayMaterialArray ) ) )
+
 END_SEND_TABLE()
 
 BEGIN_SIMPLE_DATADESC( fogplayerparams_t )
@@ -195,6 +197,11 @@ CPlayerLocalData::CPlayerLocalData()
 	m_bDrawViewmodel = true;
 
 	m_szScriptOverlayMaterial.GetForModify()[0] = '\0';
+
+	for (int i = 0; i < MAX_SCRIPT_OVERLAYS; i++)
+	{
+		m_szScriptOverlayMaterialArray.Set(i, NULL_STRING);
+	}
 }
 
 

--- a/src/game/server/playerlocaldata.h
+++ b/src/game/server/playerlocaldata.h
@@ -88,6 +88,7 @@ public:
 	CNetworkVar( bool, m_bSlowMovement );
 
 	CNetworkString( m_szScriptOverlayMaterial, MAX_PATH );
+	CNetworkArray( string_t , m_szScriptOverlayMaterialArray , MAX_SCRIPT_OVERLAYS );
 };
 
 EXTERN_SEND_TABLE(DT_Local);

--- a/src/game/shared/playernet_vars.h
+++ b/src/game/shared/playernet_vars.h
@@ -14,6 +14,7 @@
 #include "shared_classnames.h"
 
 #define NUM_AUDIO_LOCAL_SOUNDS	8
+#define MAX_SCRIPT_OVERLAYS	8
 
 // These structs are contained in each player's local data and shared by the client & server
 


### PR DESCRIPTION
Closes ValveSoftware/Source-1-Games#6112

Adds (Get/Set)ScriptOverlayMaterialEx() VScript functions, works similar to (Get/Set)ScriptOverlayMaterial() but takes an extra argument for the index in an array of materials to set.

The default script overlay array limit is 8 as that would grant an even 10 overlays to use, including the regular script overlay and r_screenoverlay/env_screenoverlay combinied.