### PR TITLE
Add convar to customize maximum MvM robots

### DIFF
--- a/src/game/server/tf/player_vs_environment/tf_population_manager.cpp
+++ b/src/game/server/tf/player_vs_environment/tf_population_manager.cpp
@@ -2626,7 +2626,7 @@ void CPopulationManager::AllocateBots()
 		Warning( "%d bots were already allocated some how before CPopulationManager::AllocateBots was called\n", botVector.Count() );
 	}
 
-	for ( int i = nNumEnemyBots; i < MVM_INVADERS_TEAM_SIZE; ++i )
+	for ( int i = nNumEnemyBots; i < tf_mvm_max_invaders.GetInt(); ++i )
 	{
 		CTFBot* newBot = NextBotCreatePlayerBot< CTFBot >( "TFBot", false );
 		if ( newBot )

--- a/src/game/server/tf/player_vs_environment/tf_population_manager.h
+++ b/src/game/server/tf/player_vs_environment/tf_population_manager.h
@@ -137,8 +137,6 @@ public:
 	bool IsBonusRound() const { return m_bBonusRound; }
 	CBaseCombatCharacter* GetBonusBoss() const { return m_hBonusBoss; }
 
-	enum { MVM_INVADERS_TEAM_SIZE = 22 };
-
 	static bool GetWavesUseReadyBetween() { return true; }
 
 	void SetDefaultEventChangeAttributesName( const char* pszDefaultEventChangeAttributesName ) { m_defaultEventChangeAttributesName = pszDefaultEventChangeAttributesName; }

--- a/src/game/server/tf/player_vs_environment/tf_populator_spawners.cpp
+++ b/src/game/server/tf/player_vs_environment/tf_populator_spawners.cpp
@@ -1014,7 +1014,7 @@ bool CTFBotSpawner::Spawn( const Vector &rawHere, EntityHandleVector_t *result )
 
 			nNumEnemyBots = botVector.Count();
 
-			if ( nNumEnemyBots >= CPopulationManager::MVM_INVADERS_TEAM_SIZE )
+			if ( nNumEnemyBots >= tf_mvm_max_invaders.GetInt() )
 			{
 				// no room for more
 				if ( tf_populator_debug.GetBool() ) 
@@ -1023,10 +1023,10 @@ bool CTFBotSpawner::Spawn( const Vector &rawHere, EntityHandleVector_t *result )
 				}
 
 				// extra guard if we're over full on bots
-				if ( nNumEnemyBots > CPopulationManager::MVM_INVADERS_TEAM_SIZE )
+				if ( nNumEnemyBots > tf_mvm_max_invaders.GetInt() )
 				{
 					// Kick bots until we are at the proper number starting with spectator bots
-					int iNumberToKick = nNumEnemyBots - CPopulationManager::MVM_INVADERS_TEAM_SIZE;
+					int iNumberToKick = nNumEnemyBots - tf_mvm_max_invaders.GetInt();
 					int iKickedBots = 0;
 
 					// loop through spectators and invaders in that order

--- a/src/game/server/tf/player_vs_environment/tf_populators.cpp
+++ b/src/game/server/tf/player_vs_environment/tf_populators.cpp
@@ -741,7 +741,7 @@ bool CMissionPopulator::UpdateMission( CTFBot::MissionType mission )
 	// are there enough free slots?
 	int currentEnemyCount = GetGlobalTeam( TF_TEAM_PVE_INVADERS )->GetNumPlayers();
 
-	if ( currentEnemyCount + m_desiredCount > CPopulationManager::MVM_INVADERS_TEAM_SIZE )
+	if ( currentEnemyCount + m_desiredCount > tf_mvm_max_invaders.GetInt() )
 	{
 		// not enough slots yet
 		if ( tf_populator_debug.GetBool() ) 
@@ -1578,7 +1578,7 @@ void CWaveSpawnPopulator::Update( void )
 
 				int currentEnemyCount = GetGlobalTeam( TF_TEAM_PVE_INVADERS )->GetNumPlayers();
 
-				if ( currentEnemyCount + m_spawnCount + m_reservedPlayerSlotCount > CPopulationManager::MVM_INVADERS_TEAM_SIZE )
+				if ( currentEnemyCount + m_spawnCount + m_reservedPlayerSlotCount > tf_mvm_max_invaders.GetInt() )
 				{
 					// no space right now
 					return;

--- a/src/game/shared/tf/tf_gamerules.cpp
+++ b/src/game/shared/tf/tf_gamerules.cpp
@@ -875,6 +875,7 @@ ConVar tf_raid_allow_overtime( "tf_raid_allow_overtime", "0"/*, FCVAR_CHEAT*/ );
 
 ConVar tf_mvm_defenders_team_size( "tf_mvm_defenders_team_size", "6", FCVAR_REPLICATED | FCVAR_NOTIFY, "Maximum number of defenders in MvM" );
 ConVar tf_mvm_max_connected_players( "tf_mvm_max_connected_players", "10", FCVAR_GAMEDLL, "Maximum number of connected real players in MvM" );
+ConVar tf_mvm_max_invaders( "tf_mvm_max_invaders", "22", FCVAR_GAMEDLL, "Maximum number of invaders in MvM" );
 
 ConVar tf_mvm_min_players_to_start( "tf_mvm_min_players_to_start", "3", FCVAR_REPLICATED | FCVAR_NOTIFY, "Minimum number of players connected to start a countdown timer" );
 ConVar tf_mvm_respec_enabled( "tf_mvm_respec_enabled", "1", FCVAR_CHEAT | FCVAR_REPLICATED, "Allow players to refund credits spent on player and item upgrades." );

--- a/src/game/shared/tf/tf_gamerules.h
+++ b/src/game/shared/tf/tf_gamerules.h
@@ -97,6 +97,7 @@ class CMannVsMachineUpgrades;
 //extern ConVar tf_populator_damage_multiplier;
 
 extern ConVar tf_mvm_defenders_team_size;
+extern ConVar tf_mvm_max_invaders;
 
 const int kLadder_TeamSize_6v6 = 6;
 const int kLadder_TeamSize_9v9 = 9;


### PR DESCRIPTION
Currently the number of maximum robots in MvM is hardcoded to 22, which is unfortunate given TF2 supports 101 players. This PR makes the limit controlled by a convar named `tf_mvm_max_invaders`