### PR TITLE
scratchpad3d: Fix leaks of heap-allocated CBaseCommand children deleted by base pointer

### DIFF
--- a/src/public/scratchpad3d.h
+++ b/src/public/scratchpad3d.h
@@ -51,7 +51,7 @@ public:
 							m_pCachedRenderData = NULL;
 						}
 
-						~CBaseCommand()
+						virtual ~CBaseCommand()
 						{
 							ReleaseCachedRenderData();
 						}


### PR DESCRIPTION
Closes #745 