### PR TITLE
vvis: Do not overflow portalfile buffer when command line arg length >= 1024

### DIFF
--- a/src/utils/vvis/vvis.cpp
+++ b/src/utils/vvis/vvis.cpp
@@ -1167,7 +1167,7 @@ int RunVVis( int argc, char **argv )
 	}
 	else
 	{
-		sprintf ( portalfile, "%s%s", inbase, argv[i] );
+		V_sprintf_safe ( portalfile, "%s%s", inbase, argv[i] );
 		Q_StripExtension( portalfile, portalfile, sizeof( portalfile ) );
 	}
 	strcat (portalfile, ".prt");


### PR DESCRIPTION
Closes #749 