### PR TITLE
zip_utils: CZipFile::ParseXZipCommentString should read alignment as unsigned int

### DIFF
--- a/src/public/zip_utils.cpp
+++ b/src/public/zip_utils.cpp
@@ -1331,9 +1331,7 @@ void CZipFile::ParseXZipCommentString( const char *pCommentString )
 		// parse out the alignement configuration
 		if ( !m_bForceAlignment )
 		{
-			m_AlignmentSize = 0;
-			sscanf( pCommentString + 4, "%d", &m_AlignmentSize );
-			if ( !IsPowerOfTwo( m_AlignmentSize ) )
+			if ( sscanf( pCommentString + 4, "%u", &m_AlignmentSize ) != 1 || !IsPowerOfTwo( m_AlignmentSize ) )
 			{
 				m_AlignmentSize = 0;
 			}


### PR DESCRIPTION
Closes #756 