### PR TITLE
bsplib: Ensure WriteBSPFile resets g_pBSPHeader as it points to a local function variable

### DIFF
--- a/src/utils/common/bsplib.cpp
+++ b/src/utils/common/bsplib.cpp
@@ -2738,6 +2738,8 @@ void WriteBSPFile( const char *filename, char *pUnused )
 	g_pFileSystem->Seek( g_hBSPFile, 0, FILESYSTEM_SEEK_HEAD );
 	WriteData( g_pBSPHeader );
 	g_pFileSystem->Close( g_hBSPFile );
+
+	g_pBSPHeader = nullptr;
 }
 
 // Generate the next clear lump filename for the bsp file


### PR DESCRIPTION
Closes #758 