### PR TITLE
Fix unreliable console and chat mouse selection

### DIFF
--- a/src/vgui2/vgui_controls/RichText.cpp
+++ b/src/vgui2/vgui_controls/RichText.cpp
@@ -862,6 +862,12 @@ void RichText::Paint()
 		if ( m_LineBreaks.IsValidIndex( lineBreakIndexIndex ) && m_LineBreaks[lineBreakIndexIndex] < iLim )
 			iLim = m_LineBreaks[lineBreakIndexIndex];
 
+		// Stop in selection range
+		if ( iLim >= selection0  && i < selection0 )
+			iLim = selection0;
+		if ( iLim >= selection1 && i < selection1 && i >= selection0 )
+			iLim = selection1;
+
 		// Handle non-drawing characters specially
 		for ( int iT = i; iT < iLim; iT++ )
 		{
@@ -1233,8 +1239,6 @@ void RichText::RecalculateLineBreaks()
 	_recalcSavedRenderState = true;
 	if (!HasText())
 		return;
-	
-	int selection0 = -1, selection1 = -1;
 
 	// subtract the scrollbar width
 	if (_vertScrollBar->IsVisible())
@@ -1345,16 +1349,8 @@ void RichText::RecalculateLineBreaks()
 		}
 
 		float w = 0;
-		wchar_t wchBefore = 0;
-		wchar_t wchAfter = 0;
-
-		if ( i > 0 && i > lineStartIndex && i != selection0 && i-1 != selection1 )
-			wchBefore = m_TextStream[i-1];
-		if ( i < m_TextStream.Count() - 1 && i+1 != selection0 && i != selection1 )
-			wchAfter = m_TextStream[i+1];
-
 		float flabcA;
-		surface()->GetKernedCharWidth( font, ch, wchBefore, wchAfter, w, flabcA );
+		surface()->GetKernedCharWidth( font, ch, 0, 0, w, flabcA );
 		flLineWidthSoFar += w;
 	
 		// See if we've exceeded the width we have available, with 


### PR DESCRIPTION
The console and chat have a notorious reputation for being difficult to select on single-lines. This is due to RichText splitting the buffer when calculating line breaks, which means it doesn't account for extra splitting that happens in the line painting loop, and this makes the selection sometimes skip `RichText::DrawString`. This PR addresses the issue by making the selection buffer be split while painting instead of when calculating line breaks, and now selection works perfectly.

Before:

https://github.com/user-attachments/assets/60b8c93d-ea97-4974-8eb0-8bec08aeed7b

After:

https://github.com/user-attachments/assets/09c9dae0-2e8c-45c6-ada0-0d10f3beebc5


NOTE to anyone merging this PR: this requires GameUI to be recompiled, or overriding the console dialog yourself.
