### PR TITLE
[TF2] Add new MvM keyvalues, fix support not giving money

### DIFF
--- a/src/game/server/tf/player_vs_environment/tf_populators.h
+++ b/src/game/server/tf/player_vs_environment/tf_populators.h
@@ -228,6 +228,8 @@ public:
 	CUtlString m_name;
 	CUtlString m_waitForAllSpawned;
 	CUtlString m_waitForAllDead;
+    CUtlString m_spawnUntilAllSpawned;
+    CUtlString m_spawnUntilAllDead;
 
 	bool IsDone( void ) const
 	{
@@ -247,6 +249,9 @@ public:
 		m_remainingCount = m_totalCount;
 		m_state = PENDING; 
 	}
+
+	// Mark the populator finished
+	void Finish(void);
 
 	bool IsSupportWave( void ) const { return m_bSupportWave; }
 	bool IsLimitedSupportWave( void ) const { return m_bLimitedSupport; }


### PR DESCRIPTION
Adds two new keyvalues to Mvm: SpawnUntilAllSpawned and SpawnUntilAllDead. These allow support robots to spawn only while another subwave is active. This behaviour is otherwise impossible to achieve.

Also fixes bug where populator marked Support does not give its money at the end of the wave if it never started spawning, eg. had state PENDING or PRE_SPAWN_DELAY.