### PR TITLE
Fix match hud breaking if initially disabled by user

### DIFF
--- a/src/game/client/tf/tf_hud_match_status.cpp
+++ b/src/game/client/tf/tf_hud_match_status.cpp
@@ -269,7 +269,7 @@ CTFHudMatchStatus::CTFHudMatchStatus(const char *pElementName)
 	: CHudElement(pElementName)
 	, BaseClass(NULL, "HudMatchStatus")
 	, m_pTimePanel( NULL )
-	, m_bUseMatchHUD( false )
+	, m_nUseMatchHUD( -1 )
 	, m_eMatchGroupSettings( k_eTFMatchGroup_Invalid )
 {
 	Panel *pParent = g_pClientMode->GetViewport();
@@ -437,11 +437,11 @@ void CTFHudMatchStatus::OnThink()
 		return;
 
 	bool bReload = false;
-	bool bUseMatchHUD = ShouldUseMatchHUD();
+	char nUseMatchHUD = (char)ShouldUseMatchHUD();
 
-	if ( bUseMatchHUD != m_bUseMatchHUD )
+	if ( nUseMatchHUD != m_nUseMatchHUD )
 	{
-		m_bUseMatchHUD = bUseMatchHUD;
+		m_nUseMatchHUD = nUseMatchHUD;
 		bReload = true;
 	}
 

--- a/src/game/client/tf/tf_hud_match_status.h
+++ b/src/game/client/tf/tf_hud_match_status.h
@@ -132,7 +132,7 @@ private:
 
 	vgui::HFont					m_hPlayerListFont;
 
-	bool m_bUseMatchHUD;
+	char m_nUseMatchHUD;
 };
 
 #endif	// TF_HUD_MATCH_STATUS_H


### PR DESCRIPTION
If the user has `tf_use_match_hud` set to 0, the match HUD status at the top has a broken layout because it doesn't set itself up. This is because the code only reloads if the toggle status of the match HUD has changed, but it's initial value is false. Users typically have to run `hud_reloadscheme` to force a layout refresh. This PR addresses that by giving the state variable a value of -1 initially so that the layout is always reset the first time around.

Screenshot of how the layout gets broken currently:
![image](https://github.com/user-attachments/assets/12a561c1-8f61-48e7-8fdf-036b53f107ad)
