### PR TITLE
[TF2] Add ConVar to enable/disable MvM upgrade sorting by price

### DIFF
--- a/src/game/client/tf/player_vs_environment/c_tf_upgrades.cpp
+++ b/src/game/client/tf/player_vs_environment/c_tf_upgrades.cpp
@@ -41,6 +41,7 @@
 extern CAchievementMgr g_AchievementMgrTF;
 
 ConVar tf_mvm_tabs_discovered( "tf_mvm_tabs_discovered", "0", FCVAR_ARCHIVE, "Remember how many times players have clicked tabs." );
+ConVar tf_mvm_sort_upgrades( "tf_mvm_sort_upgrades", "1", FCVAR_NOTIFY, "Sort upgrades by price." );
 
 Color CUpgradeBuyPanel::m_rgbaDefaultFG( 0, 0, 0, 255 );
 Color CUpgradeBuyPanel::m_rgbaDefaultBG( 0, 0, 0, 255 );
@@ -1098,6 +1099,7 @@ void CHudUpgradePanel::UpdateUpgradeButtons( void )
 			}
 
 			pItemSlotBuyPanel->upgradeBuyPanels.RemoveAll();
+			pItemSlotBuyPanel->upgradeBuyPanels.RedoSort();	// Make sure m_bNeedsSort is false. Other methods would require modifying CUtlSortVector
 
 			FOR_EACH_VEC( g_MannVsMachineUpgrades.m_Upgrades, i )
 			{
@@ -1158,7 +1160,14 @@ void CHudUpgradePanel::UpdateUpgradeButtons( void )
 					continue;
 				}
 
-				pItemSlotBuyPanel->upgradeBuyPanels.Insert( pUpgradeBuyPanel );
+				if ( tf_mvm_sort_upgrades.GetBool() )
+				{
+					pItemSlotBuyPanel->upgradeBuyPanels.Insert( pUpgradeBuyPanel );
+				}
+				else
+				{
+					pItemSlotBuyPanel->upgradeBuyPanels.InsertNoSort( pUpgradeBuyPanel );
+				}
 
 				float flValue = pUpgrade->flIncrement;
 				int iFormat = pAttribDef->GetDescriptionFormat();


### PR DESCRIPTION
Currently custom upgrade files that change the price of upgrades will cause upgrades to show up in different places and throw off players who often buy upgrades by muscle memory. This PR addresses that by adding ConVar that allows disabling the sorting. If disabled, the upgrades will appear in the order defined in the upgrades file.

Default behaviour with custom upgrade file:

![kuva](https://github.com/user-attachments/assets/40255daa-5cfa-4a91-a595-b469c7d313ca)

Sorting disabled and upgrades re-ordered in the upgrade file:

![kuva](https://github.com/user-attachments/assets/decac2df-a58a-45d0-9cf8-ecb1c50642fe)

The convar flags may need to be changed.
