### PR TITLE
[TF2] Allow set_scattergun_has_knockback attribute to take on values greater than 1

### DIFF
--- a/src/game/shared/tf/achievements_tf_scout.cpp
+++ b/src/game/shared/tf/achievements_tf_scout.cpp
@@ -952,7 +952,7 @@ class CAchievementTFScout_KillFromBehind : public CBaseTFAchievement
 		if ( event->GetInt( "weaponid" ) == TF_WEAPON_SCATTERGUN )
 		{
 			CTFScatterGun *pScattergun = (CTFScatterGun *)ToTFPlayer( C_TFPlayer::GetLocalPlayer() )->Weapon_OwnsThisID( TF_WEAPON_SCATTERGUN );
-			if ( pScattergun && pScattergun->HasKnockback() &&
+			if ( pScattergun && pScattergun->GetKnockbackCount() > 0 &&
 				( DotProductToTarget( pAttacker, pVictim ) > -0.1 ) )
 			{
 				IncrementCount();

--- a/src/game/shared/tf/tf_gamemovement.cpp
+++ b/src/game/shared/tf/tf_gamemovement.cpp
@@ -2954,7 +2954,7 @@ void CTFGameMovement::SetGroundEntity( trace_t *pm )
 		}
 #endif // GAME_DLL
 		m_pTFPlayer->m_Shared.SetWeaponKnockbackID( -1 );
-		m_pTFPlayer->m_Shared.m_bScattergunJump = false;
+		m_pTFPlayer->m_Shared.m_iScattergunJump = 0;
 		m_pTFPlayer->m_Shared.SetAirDash( 0 );
 		m_pTFPlayer->m_Shared.SetAirDucked( 0 );
 

--- a/src/game/shared/tf/tf_player_shared.cpp
+++ b/src/game/shared/tf/tf_player_shared.cpp
@@ -478,7 +478,7 @@ BEGIN_PREDICTION_DATA_NO_BASE( CTFPlayerShared )
 	DEFINE_PRED_FIELD( m_flHolsterAnimTime, FIELD_FLOAT, FTYPEDESC_INSENDTABLE ),
 	DEFINE_PRED_ARRAY( m_flItemChargeMeter, FIELD_FLOAT, LAST_LOADOUT_SLOT_WITH_CHARGE_METER, FTYPEDESC_INSENDTABLE ),
 	DEFINE_PRED_FIELD( m_iStunIndex, FIELD_INTEGER, FTYPEDESC_INSENDTABLE ),
-	DEFINE_PRED_FIELD( m_bScattergunJump, FIELD_BOOLEAN, 0 ),
+	DEFINE_PRED_FIELD( m_iScattergunJump, FIELD_INTEGER, 0 ),
 END_PREDICTION_DATA()
 
 // Server specific.
@@ -791,7 +791,7 @@ CTFPlayerShared::CTFPlayerShared()
 	m_flPrevInvisibility = 0.f;
 	m_flTmpDamageBonusAmount = 1.0f;
 
-	m_bScattergunJump = false;
+	m_iScattergunJump = 0;
 
 	m_bFeignDeathReady = false;
 

--- a/src/game/shared/tf/tf_player_shared.h
+++ b/src/game/shared/tf/tf_player_shared.h
@@ -1216,7 +1216,7 @@ private:
 #endif
 
 public:
-	bool m_bScattergunJump;
+	int m_iScattergunJump;
 
 	float	m_flStunFade;
 	float	m_flStunEnd;

--- a/src/game/shared/tf/tf_quest_restriction.cpp
+++ b/src/game/shared/tf/tf_quest_restriction.cpp
@@ -1144,7 +1144,7 @@ protected:
 
 		int nNumJumps = pNonConstPlayer->GetGroundEntity() == NULL ? 1 : 0;
 		nNumJumps += pPlayer->m_Shared.GetAirDash();
-		nNumJumps += pPlayer->m_Shared.m_bScattergunJump;
+		nNumJumps += pPlayer->m_Shared.m_iScattergunJump;
 
 		if ( m_eJumpingState == JUMPING_STATE_IS_NOT_JUMPING )
 		{
@@ -3027,7 +3027,7 @@ bool CTFJumpStateQuestModifier::BPassesModifier( const CTFPlayer *pOwner, Invali
 #else
 	int nNumJumps = const_cast< CTFPlayer* >( pOwner )->GetGroundEntity() == NULL ? 1 : 0;
 	nNumJumps += pOwner->m_Shared.GetAirDash();
-	nNumJumps += pOwner->m_Shared.m_bScattergunJump;
+	nNumJumps += pOwner->m_Shared.m_iScattergunJump;
 
 	// If we want them on the ground, make sure they're on the ground
 	if ( m_nJumpCount == 0 )

--- a/src/game/shared/tf/tf_weapon_shotgun.cpp
+++ b/src/game/shared/tf/tf_weapon_shotgun.cpp
@@ -47,9 +47,9 @@ bool CanScatterGunKnockBack( CTFWeaponBase *pWeapon, float flDamage, float flDis
 {
 	int nBulletKnockBack = 0;
 	CALL_ATTRIB_HOOK_INT_ON_OTHER( pWeapon, nBulletKnockBack, set_scattergun_has_knockback );
-	if ( nBulletKnockBack != 0 )
+	if ( nBulletKnockBack > 0 )
 	{
-		if (flDamage > SCATTERGUN_KNOCKBACK_MIN_DMG && flDistanceSq < SCATTERGUN_KNOCKBACK_MIN_RANGE_SQ )
+		if ( flDamage > SCATTERGUN_KNOCKBACK_MIN_DMG && flDistanceSq < SCATTERGUN_KNOCKBACK_MIN_RANGE_SQ )
 			return true;
 
 		float flKnockbackMult = 1.0f;
@@ -316,7 +316,8 @@ extern float AirBurstDamageForce( const Vector &size, float damage, float scale 
 //-----------------------------------------------------------------------------
 void CTFScatterGun::FireBullet( CTFPlayer *pPlayer )
 {
-	if ( HasKnockback() )
+	int iKnockbackCount = GetKnockbackCount();
+	if ( iKnockbackCount > 0 )
 	{
 		// Perform some knock back.
 		CTFPlayer *pOwner = ToTFPlayer( GetPlayerOwner() );
@@ -328,9 +329,9 @@ void CTFScatterGun::FireBullet( CTFPlayer *pPlayer )
 			return;
 
 		// Knock the firer back!
-		if ( !(pOwner->GetFlags() & FL_ONGROUND) && !pPlayer->m_Shared.m_bScattergunJump )
+		if ( !(pOwner->GetFlags() & FL_ONGROUND) && pPlayer->m_Shared.m_iScattergunJump < iKnockbackCount )
 		{
-			pPlayer->m_Shared.m_bScattergunJump = true;
+			pPlayer->m_Shared.m_iScattergunJump += 1;
 
 			pOwner->m_Shared.StunPlayer( 0.3f, 1.f, TF_STUN_MOVEMENT | TF_STUN_MOVEMENT_FORWARD_ONLY );
 
@@ -369,7 +370,7 @@ void CTFScatterGun::FireBullet( CTFPlayer *pPlayer )
 void CTFScatterGun::ApplyPostHitEffects( const CTakeDamageInfo &inputInfo, CTFPlayer *pPlayer )
 {
 #ifndef CLIENT_DLL
-	if ( !HasKnockback() )
+	if ( GetKnockbackCount() <= 0 )
 		return;
 
 	CTFPlayer *pAttacker = ToTFPlayer( inputInfo.GetAttacker() );
@@ -430,14 +431,11 @@ void CTFScatterGun::FinishReload( void )
 //-----------------------------------------------------------------------------
 // Purpose:
 //-----------------------------------------------------------------------------
-bool CTFScatterGun::HasKnockback( void )
+int CTFScatterGun::GetKnockbackCount( void )
 {
-	int iWeaponMod = 0;
-	CALL_ATTRIB_HOOK_INT( iWeaponMod, set_scattergun_has_knockback );
-	if ( iWeaponMod == 1 )
-		return true;
-	else
-		return false;
+	int iKnockbackCount = 0;
+	CALL_ATTRIB_HOOK_INT( iKnockbackCount, set_scattergun_has_knockback );
+	return iKnockbackCount;
 }
 
 #ifdef GAME_DLL

--- a/src/game/shared/tf/tf_weapon_shotgun.h
+++ b/src/game/shared/tf/tf_weapon_shotgun.h
@@ -113,7 +113,7 @@ public:
 	virtual void	FireBullet( CTFPlayer *pPlayer );
 	virtual void	ApplyPostHitEffects( const CTakeDamageInfo &inputInfo, CTFPlayer *pPlayer );
 	virtual void	FinishReload( void );
-	virtual bool	HasKnockback( void );
+	virtual int		GetKnockbackCount( void );
 
 #ifdef GAME_DLL
 	virtual void	Equip( CBaseCombatCharacter *pOwner );


### PR DESCRIPTION
This increases the number of times self-knockback may be applied via the attribute.
This also changes m_bScattergunJump to m_iScattergunJump and updates any relevant code accordingly.

Changes CTFPlayerShared's bool m_bScattergunJump to int m_iScattergunJump.
Renames CTFScattergun's HasKnockback to GetKnockbackCount to return the attribute value directly.
Changes all usages of HasKnockback to `GetKnockbackCount() > 0`
Changes CTFScatterGun's FireBullet knockback logic to compare the value of m_iScattergunJump to GetKnockbackCount in order to determine whether to apply self-knockback.
Changes CanScatterGunKnockBack in tf_weapon_shotgun to be consistent with elsewhere on `> 0` check, fixing an issue where values of -1 could cause the regular-damage-zero-z-force behavior but not actually apply the extra knockback.

~~This version of the PR includes #682 for easy rebasing/inclusion in projects that already include that PR.~~
Rebased onto master now that the above PR is included in master.

_Should_ be demo-safe.

Implements https://github.com/mastercomfig/tf2-patches-old/pull/462