### PR TITLE
[TF2] Allow set_scattergun_has_knockback attribute to take on values greater than 1 - no prediction fix

### DIFF
--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -997,7 +997,7 @@ CTFPlayer::CTFPlayer()
 	m_flNextChangeClassTime = 0.0f;
 	m_flNextChangeTeamTime = 0.0f;
 
-	m_bScattergunJump = false;
+	m_iScattergunJump = false;
 	m_iOldStunFlags = 0;
 	m_iLastWeaponSlot = 1;
 	m_iNumberofDominations = 0;
@@ -3781,7 +3781,7 @@ void CTFPlayer::Spawn()
 
 	m_Shared.SetFeignDeathReady( false );
 
-	m_bScattergunJump = false;
+	m_iScattergunJump = false;
 	m_iOldStunFlags = 0;
 
 	m_flAccumulatedHealthRegen = 0;

--- a/src/game/server/tf/tf_player.h
+++ b/src/game/server/tf/tf_player.h
@@ -938,7 +938,7 @@ public:
 
 	bool				m_bSuicideExplode;
 
-	bool				m_bScattergunJump;
+	int					m_iScattergunJump;
 	int					m_iOldStunFlags;
 
 	bool				m_bFlipViewModels;

--- a/src/game/shared/tf/tf_gamemovement.cpp
+++ b/src/game/shared/tf/tf_gamemovement.cpp
@@ -2958,7 +2958,7 @@ void CTFGameMovement::SetGroundEntity( trace_t *pm )
 			m_pTFPlayer->SpeakConceptIfAllowed( MP_CONCEPT_DOUBLE_JUMP, "started_jumping:0" );
 		}
 		m_pTFPlayer->m_Shared.SetWeaponKnockbackID( -1 );
-		m_pTFPlayer->m_bScattergunJump = false;
+		m_pTFPlayer->m_iScattergunJump = 0;
 #endif // GAME_DLL
 		m_pTFPlayer->m_Shared.SetAirDash( 0 );
 		m_pTFPlayer->m_Shared.SetAirDucked( 0 );

--- a/src/game/shared/tf/tf_quest_restriction.cpp
+++ b/src/game/shared/tf/tf_quest_restriction.cpp
@@ -1144,7 +1144,7 @@ protected:
 
 		int nNumJumps = pNonConstPlayer->GetGroundEntity() == NULL ? 1 : 0;
 		nNumJumps += pPlayer->m_Shared.GetAirDash();
-		nNumJumps += pPlayer->m_bScattergunJump;
+		nNumJumps += pPlayer->m_iScattergunJump;
 
 		if ( m_eJumpingState == JUMPING_STATE_IS_NOT_JUMPING )
 		{
@@ -3027,7 +3027,7 @@ bool CTFJumpStateQuestModifier::BPassesModifier( const CTFPlayer *pOwner, Invali
 #else
 	int nNumJumps = const_cast< CTFPlayer* >( pOwner )->GetGroundEntity() == NULL ? 1 : 0;
 	nNumJumps += pOwner->m_Shared.GetAirDash();
-	nNumJumps += pOwner->m_bScattergunJump;
+	nNumJumps += pOwner->m_iScattergunJump;
 
 	// If we want them on the ground, make sure they're on the ground
 	if ( m_nJumpCount == 0 )

--- a/src/game/shared/tf/tf_weapon_shotgun.cpp
+++ b/src/game/shared/tf/tf_weapon_shotgun.cpp
@@ -317,7 +317,11 @@ extern float AirBurstDamageForce( const Vector &size, float damage, float scale 
 void CTFScatterGun::FireBullet( CTFPlayer *pPlayer )
 {
 #ifndef CLIENT_DLL
-	if ( HasKnockback() )
+	// see CTFScatterGun::HasKnockback
+	int iKnockbackCount = 0;
+	CALL_ATTRIB_HOOK_INT( iKnockbackCount, set_scattergun_has_knockback );
+
+	if ( iKnockbackCount > 0 )
 	{
 		// Perform some knock back.
 		CTFPlayer *pOwner = ToTFPlayer( GetPlayerOwner() );
@@ -329,9 +333,9 @@ void CTFScatterGun::FireBullet( CTFPlayer *pPlayer )
 			return;
 
 		// Knock the firer back!
-		if ( !(pOwner->GetFlags() & FL_ONGROUND) && !pPlayer->m_bScattergunJump )
+		if ( !(pOwner->GetFlags() & FL_ONGROUND) && pPlayer->m_iScattergunJump < iKnockbackCount )
 		{
-			pPlayer->m_bScattergunJump = true;
+			pPlayer->m_iScattergunJump += 1;
 
 			pOwner->m_Shared.StunPlayer( 0.3f, 1.f, TF_STUN_MOVEMENT | TF_STUN_MOVEMENT_FORWARD_ONLY );
 
@@ -434,9 +438,9 @@ void CTFScatterGun::FinishReload( void )
 //-----------------------------------------------------------------------------
 bool CTFScatterGun::HasKnockback( void )
 {
-	int iWeaponMod = 0;
-	CALL_ATTRIB_HOOK_INT( iWeaponMod, set_scattergun_has_knockback );
-	if ( iWeaponMod == 1 )
+	int iKnockbackCount = 0;
+	CALL_ATTRIB_HOOK_INT( iKnockbackCount, set_scattergun_has_knockback );
+	if ( iKnockbackCount > 0 )
 		return true;
 	else
 		return false;


### PR DESCRIPTION
This is an implementation of https://github.com/ValveSoftware/source-sdk-2013/pull/772 that does not include the prediction fixes for Scattergun jumps from #682, for projects that do not include that commit to use (it is highly recommended to use that fix, though).

Instead of the relevant changes in CTFPlayerShared, the modified scattergun jump property is in CTFPlayer.