### PR TITLE
[TF2] Allow player_sapped_object event to fire for world-built sentries, setting ownerid to -1

### DIFF
--- a/src/game/server/tf/tf_obj_sapper.cpp
+++ b/src/game/server/tf/tf_obj_sapper.cpp
@@ -193,13 +193,14 @@ void CObjectSapper::FinishedBuilding( void )
 			CBaseObject *pObject = dynamic_cast<CBaseObject *>( m_hBuiltOnEntity.Get() );
 			if ( pObject )
 			{
-				if ( GetBuilder() && pObject->GetBuilder() )
+				if ( GetBuilder() )
 				{
 					IGameEvent * event = gameeventmanager->CreateEvent( "player_sapped_object" );
 					if ( event )
 					{
+						CTFPlayer *pObjectBuilder = pObject->GetBuilder();
 						event->SetInt( "userid", GetBuilder()->GetUserID() );
-						event->SetInt( "ownerid", pObject->GetBuilder()->GetUserID() );
+						event->SetInt( "ownerid", pObjectBuilder ? pObjectBuilder->GetUserID() : -1 );
 						event->SetInt( "object", pObject->ObjectType() );
 						event->SetInt( "sapperid", entindex() );
 

--- a/src/game/shared/tf/achievements_tf_spy.cpp
+++ b/src/game/shared/tf/achievements_tf_spy.cpp
@@ -1324,10 +1324,13 @@ class CAchievementTFSpy_SpyBackstabEngySapBuilding : public CBaseTFAchievement
 			{
 				CBasePlayer *pEngy = UTIL_PlayerByIndex( engine->GetPlayerForUserID( event->GetInt( "ownerid" ) ) );
 
-				int iIndex = FindEngyInList( pEngy );
-				if ( iIndex != -1 )
+				if ( pEngy )
 				{
-					SetObjectSapped( iIndex, event->GetInt( "object" ) );
+					int iIndex = FindEngyInList( pEngy );
+					if ( iIndex != -1 )
+					{
+						SetObjectSapped( iIndex, event->GetInt( "object" ) );
+					}
 				}
 
 				CheckAchievementEarned(); // checks the achievement list, but also cleans out old entries (based on flTimeToBeat)


### PR DESCRIPTION
Fixes https://github.com/ValveSoftware/Source-1-Games/issues/4587

Adds a check against valid ownerid for the one case that's missing it.