### PR TITLE
[TF2] Fix stickybomb launcher charge sound being delayed by ping

### DIFF
--- a/src/game/shared/tf/tf_weapon_pipebomblauncher.cpp
+++ b/src/game/shared/tf/tf_weapon_pipebomblauncher.cpp
@@ -209,7 +209,10 @@ void CTFPipebombLauncher::PrimaryAttack( void )
 		SendWeaponAnim( ACT_VM_PULLBACK );
 
 #ifdef CLIENT_DLL
-		EmitSound( TF_WEAPON_PIPEBOMB_LAUNCHER_CHARGE_SOUND );
+		if ( !prediction->InPrediction() || prediction->IsFirstTimePredicted() )
+		{
+			EmitSound( TF_WEAPON_PIPEBOMB_LAUNCHER_CHARGE_SOUND );
+		}
 #endif // CLIENT_DLL
 	}
 	else


### PR DESCRIPTION
demoman is FINALLY playable

this was caused by emitsound being called repeatedly due to prediction/smoothing, which resets the sound over and over so it is audibly delayed

unfixed:

https://github.com/user-attachments/assets/46d23b2f-b884-40e4-b08f-1bb056b78a9f

fixed:

https://github.com/user-attachments/assets/33d36da2-0147-4d39-87d5-bccdb0fb99b1

(i doubt you'd even notice the difference by the first watch of these vids lol, but the difference is noticeable in-game)

partially fixes this issue: https://github.com/ValveSoftware/Source-1-Games/issues/6017

do note that this doesn't fix the charge meter being delayed as you can still see in the videos

im not super sure but as far as i can tell it's caused by subtracting a predicted timestamp (charge begin time) from an unpredicted timestamp (current time when hud is drawn), and it's an issue with like every charge meter hud element