### PR TITLE
dispcoll_common: Fix destruction of CDispCollTree children by base CDispCollTree pointer deletion

### DIFF
--- a/src/public/dispcoll_common.h
+++ b/src/public/dispcoll_common.h
@@ -158,7 +158,7 @@ public:
 
 	// Creation/Destruction.
 	CDispCollTree();
-	~CDispCollTree();
+	virtual ~CDispCollTree();
 	virtual bool Create( CCoreDispInfo *pDisp );
 
 	// Raycasts.


### PR DESCRIPTION
Closes #782 