### PR TITLE
Fix jittery model rendering when spectating a ragdoll

### DIFF
--- a/src/game/client/c_baseanimating.cpp
+++ b/src/game/client/c_baseanimating.cpp
@@ -1603,7 +1603,25 @@ void C_BaseAnimating::BuildTransformations( CStudioHdr *hdr, Vector *pos, Quater
 		}
 	}
 	
-	
+	if ( m_pRagdoll )
+	{
+		C_BasePlayer *pPlayer = C_BasePlayer::GetLocalPlayer();
+		if ( pPlayer )
+		{
+			// When the local player is spectating a ragdoll, they are copying the root physics bone
+			// Afterwards, physics simulation of ragdolls happens and updates the bones
+			// ... But after that, the ragdoll is drawn with the NEW bones
+			// which leads to the camera and rendering being out of sync with each other and causing visible jittering
+			// The workaround for this problem is to render the ragdoll with the last frame's bone data
+			C_BaseEntity* pObserverTarget = pPlayer->GetObserverTarget();
+			if ( pObserverTarget 
+				&& pObserverTarget->IsPlayer() 
+				&& static_cast< C_BasePlayer* >( pObserverTarget )->GetRepresentativeRagdoll() == m_pRagdoll )
+			{
+				m_pRagdoll->AcquireOrCopyBoneCache( m_CachedBoneData.Base(), m_CachedBoneData.Count() );
+			}
+		}
+	}
 }
 
 //-----------------------------------------------------------------------------

--- a/src/game/client/ragdoll.cpp
+++ b/src/game/client/ragdoll.cpp
@@ -28,7 +28,7 @@ CRagdoll::CRagdoll()
 	m_ragdoll.listCount = 0;
 	m_vecLastOrigin.Init();
 	m_flLastOriginChangeTime = - 1.0f;
-	
+	m_flBoneCacheTime = -FLT_MAX;
 	m_lastUpdate = -FLT_MAX;
 }
 
@@ -171,6 +171,31 @@ void CRagdoll::RagdollBone( C_BaseEntity *ent, mstudiobone_t *pbones, int boneCo
 		{
 			boneSimulated[m_ragdoll.boneIndex[i]] = true;
 		}
+	}
+}
+
+void CRagdoll::AcquireOrCopyBoneCache( matrix3x4_t* pOutBonesToWorld, int boneCount )
+{
+	// acquire cache if not setup
+	if ( m_BoneCache.Count() != boneCount )
+	{
+		m_BoneCache.CopyArray( pOutBonesToWorld, boneCount );
+		m_flBoneCacheTime = gpGlobals->curtime;
+	}
+	// copy cache out if called again in same frame
+	else if ( gpGlobals->curtime == m_flBoneCacheTime )
+	{
+		memcpy( pOutBonesToWorld, m_BoneCache.Base(), boneCount * sizeof(matrix3x4_t) );
+	}
+	// copy out our cache and acquire the old one
+	else
+	{
+		size_t uBoneDataSize = boneCount * sizeof(matrix3x4_t);
+		matrix3x4_t* pTempBoneData = (matrix3x4_t*)stackalloc( uBoneDataSize );
+		memcpy( pTempBoneData, pOutBonesToWorld, uBoneDataSize );
+		memcpy( pOutBonesToWorld, m_BoneCache.Base(), uBoneDataSize );
+		memcpy( m_BoneCache.Base(), pTempBoneData, uBoneDataSize );
+		m_flBoneCacheTime = gpGlobals->curtime;
 	}
 }
 

--- a/src/game/client/ragdoll.h
+++ b/src/game/client/ragdoll.h
@@ -60,10 +60,10 @@ public:
 		bool bFixedConstraints=false );
 
 	virtual void RagdollBone( C_BaseEntity *ent, mstudiobone_t *pbones, int boneCount, bool *boneSimulated, CBoneAccessor &pBoneToWorld );
+	void    AcquireOrCopyBoneCache( matrix3x4_t* pBonesToWorld, int boneCount );
 	virtual const Vector& GetRagdollOrigin( );
 	virtual void GetRagdollBounds( Vector &theMins, Vector &theMaxs );
 	void	BuildRagdollBounds( C_BaseEntity *ent );
-	
 	virtual IPhysicsObject *GetElement( int elementNum );
 	virtual IPhysicsConstraintGroup *GetConstraintGroup() { return m_ragdoll.pGroup; }
 	virtual void DrawWireframe();
@@ -101,6 +101,8 @@ private:
 	bool		m_allAsleep;
 	Vector		m_vecLastOrigin;
 	float		m_flLastOriginChangeTime;
+	CUtlVector< matrix3x4_t > m_BoneCache;
+	float		m_flBoneCacheTime;
 
 #if RAGDOLL_VISUALIZE
 	matrix3x4_t			m_savedBone1[MAXSTUDIOBONES];


### PR DESCRIPTION
A long-standing bug in every Source game when spectating ragdolls is that it appears jittery at high velocities. The reason is simple:

At the start of each rendering frame:
1. Camera is setup in `CBasePlayer::CalcView`, which fetches root bone of the ragdoll to align camera with
2. Physics simulation of all ragdolls happens (`CPhysicsSystem::PhysicsSimulate`), and bones are updated
3. All entities are rendered... but the ragdolls are drawn with the new bones

Since the camera is effectively using stale bone information from last frame, they become desynced which leads to the jitter effect. The workaround applied is when setting up ragdoll bones, if the local player is spectating this ragdoll, it will copy the previous frame's bone information, with the new one data preserved for next frame.

Before:

https://github.com/user-attachments/assets/7a5bb086-f377-4dac-b7d5-48f13eac5dca

After:

https://github.com/user-attachments/assets/9633ba68-73b7-4909-aa6b-8b04475d4699

