### PR TITLE
Fix deathposes being non-functional

### DIFF
--- a/src/game/client/c_baseanimating.cpp
+++ b/src/game/client/c_baseanimating.cpp
@@ -1819,7 +1819,7 @@ void C_BaseAnimating::MaintainSequenceTransitions( IBoneSetup &boneSetup, float 
 	if ( !boneSetup.GetStudioHdr() )
 		return;
 
-	if ( prediction->InPrediction() )
+	if ( prediction->InPrediction() || IsAboutToRagdoll() )
 	{
 		m_nPrevNewSequenceParity = m_nNewSequenceParity;
 		return;


### PR DESCRIPTION
Deathposes are a special death animation which guide where ragdolls should go, the game picks one based off the hitbox and attacker direction. HL2 and CS:S use them, unfortunately this feature has been broken since Orangebox due to sequence transitions being introduced. The transitions cause the deathpose to never be applied as the old animation is still in full weight and "decaying". This PR addresses the issue by disabling sequence transitions while about to ragdoll.

NOTE: in CS:S, this requires changes to `C_CSRagdoll::CreateCSRagdoll`. The call to player's `GetRagdollInitBoneArrays` needs to be removed so it instead takes the ragdoll's version of the function. The `boneDt` value also needs to be changed to 0.1, as 0.05 applies too much force. 

Before:

https://github.com/user-attachments/assets/a1b7cb5b-7d06-4ed5-99c7-7febf162bfa4

After: (observe how the ragdolls respond to where they got hit instead of just flopping)

https://github.com/user-attachments/assets/a812286d-6c32-42ea-b87c-33255584000d

