### PR TITLE
[TF2] Fix prediction for jumping when huntsman is charged/released

### DIFF
--- a/src/game/shared/tf/tf_player_shared.cpp
+++ b/src/game/shared/tf/tf_player_shared.cpp
@@ -12110,6 +12110,13 @@ bool CTFPlayer::CanJump() const
 	if ( m_Shared.InCond( TF_COND_TAUNTING ) )
 		return false;
 
+	CTFWeaponBase *pActiveWeapon = m_Shared.GetActiveTFWeapon();
+	if ( pActiveWeapon )
+	{
+		if ( !pActiveWeapon->OwnerCanJump() )
+			return false;
+	}
+
 	int iNoJump = 0;
 	CALL_ATTRIB_HOOK_INT( iNoJump, no_jump );
 

--- a/src/game/shared/tf/tf_weapon_compound_bow.cpp
+++ b/src/game/shared/tf/tf_weapon_compound_bow.cpp
@@ -654,26 +654,6 @@ void CTFCompoundBow::SetArrowAlight( bool bAlight )
 //-----------------------------------------------------------------------------
 // Purpose: 
 //-----------------------------------------------------------------------------
-void CTFCompoundBow::SetInternalChargeBeginTime( float flChargeBeginTime )
-{
-#ifdef GAME_DLL
-//	float flCurrentChargeBeginTime = GetInternalChargeBeginTime();
-//	if ( flCurrentChargeBeginTime == 0.f && flChargeBeginTime > 0.f )
-//	{
-//		DisableJump();
-//	}
-//	else if ( flCurrentChargeBeginTime > 0.f && flChargeBeginTime == 0.f )
-//	{
-//		EnableJump();
-//	}
-#endif // GAME_DLL
-
-	BaseClass::SetInternalChargeBeginTime( flChargeBeginTime );
-}
-
-//-----------------------------------------------------------------------------
-// Purpose: 
-//-----------------------------------------------------------------------------
 bool CTFCompoundBow::OwnerCanJump( void )
 {
 	return GetInternalChargeBeginTime() == 0.f;

--- a/src/game/shared/tf/tf_weapon_compound_bow.cpp
+++ b/src/game/shared/tf/tf_weapon_compound_bow.cpp
@@ -657,16 +657,24 @@ void CTFCompoundBow::SetArrowAlight( bool bAlight )
 void CTFCompoundBow::SetInternalChargeBeginTime( float flChargeBeginTime )
 {
 #ifdef GAME_DLL
-	float flCurrentChargeBeginTime = GetInternalChargeBeginTime();
-	if ( flCurrentChargeBeginTime == 0.f && flChargeBeginTime > 0.f )
-	{
-		DisableJump();
-	}
-	else if ( flCurrentChargeBeginTime > 0.f && flChargeBeginTime == 0.f )
-	{
-		EnableJump();
-	}
+//	float flCurrentChargeBeginTime = GetInternalChargeBeginTime();
+//	if ( flCurrentChargeBeginTime == 0.f && flChargeBeginTime > 0.f )
+//	{
+//		DisableJump();
+//	}
+//	else if ( flCurrentChargeBeginTime > 0.f && flChargeBeginTime == 0.f )
+//	{
+//		EnableJump();
+//	}
 #endif // GAME_DLL
 
 	BaseClass::SetInternalChargeBeginTime( flChargeBeginTime );
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
+bool CTFCompoundBow::OwnerCanJump( void )
+{
+	return GetInternalChargeBeginTime() == 0.f;
 }

--- a/src/game/shared/tf/tf_weapon_compound_bow.h
+++ b/src/game/shared/tf/tf_weapon_compound_bow.h
@@ -89,6 +89,8 @@ public:
 
 	void			SetArrowAlight( bool bAlight );
 
+	bool			OwnerCanJump( void );
+
 protected:
 	virtual void	SetInternalChargeBeginTime( float flChargeBeginTime ) OVERRIDE;
 

--- a/src/game/shared/tf/tf_weapon_compound_bow.h
+++ b/src/game/shared/tf/tf_weapon_compound_bow.h
@@ -91,9 +91,6 @@ public:
 
 	bool			OwnerCanJump( void );
 
-protected:
-	virtual void	SetInternalChargeBeginTime( float flChargeBeginTime ) OVERRIDE;
-
 private:
 #ifdef CLIENT_DLL
 	virtual void	StartBurningEffect( void );

--- a/src/game/shared/tf/tf_weaponbase.h
+++ b/src/game/shared/tf/tf_weaponbase.h
@@ -335,6 +335,7 @@ class CTFWeaponBase : public CBaseCombatWeapon, public IHasOwner, public IHasGen
 	void EnableDuck();
 	void DisableDuck();
 
+	virtual bool OwnerCanJump( void ) { return true; }
 	virtual bool OwnerCanTaunt( void ) { return true; }
 	virtual bool CanBeCritBoosted( void );
 	bool CanHaveRevengeCrits( void );


### PR DESCRIPTION
partially fixes this issue: https://github.com/ValveSoftware/Source-1-Games/issues/6017

(in the vids below, i press jump immediately after charging 3 times, then jump immediately after releasing 3 times, then jump immediately after holstering 3 times)

unfixed, net_fakelag 100:

https://github.com/user-attachments/assets/fca19788-6847-4e5e-b1ad-0991ddb84d9d

fixed, net_fakelag 100:

https://github.com/user-attachments/assets/f88c1153-b433-41fd-8479-9d69af8aba47

this pr adds CTFWeaponBase::OwnerCanJump (similar to the existing CTFWeaponBase::OwnerCanTaunt)