### PR TITLE
Fix for MvM Administrator lines being truncated by countdown

### DIFF
--- a/src/game/client/tf/tf_hud_tournament.cpp
+++ b/src/game/client/tf/tf_hud_tournament.cpp
@@ -35,6 +35,7 @@
 #include "c_tf_objective_resource.h"
 #include "tf_time_panel.h"
 #include "tf_hud_match_status.h"
+#include "engine/IEngineSound.h"
 
 #include "tf_gc_client.h"
 #include "tf_lobby_server.h"
@@ -162,32 +163,36 @@ void CHudTournament::PlaySounds( int nTime )
 		}
 		case 10:
 		{
+			const char* pszEntryName = "";
 			if ( TFGameRules() && TFGameRules()->IsMannVsMachineMode() )
 			{
 				if ( TFObjectiveResource()->GetMannVsMachineWaveCount() >= TFObjectiveResource()->GetMannVsMachineMaxWaveCount() )
 				{
-					pLocalPlayer->EmitSound( "Announcer.MVM_Final_Wave_Start" );
+					pszEntryName = UTIL_GetRandomSoundFromEntry( "Announcer.MVM_Final_Wave_Start" );
 				}
 				else if ( TFObjectiveResource()->GetMannVsMachineWaveCount() <= 1 )
 				{
 					if ( GTFGCClientSystem()->GetLobby() && IsMannUpGroup( GTFGCClientSystem()->GetLobby()->GetMatchGroup() ) )
 					{
-						pLocalPlayer->EmitSound( "Announcer.MVM_Manned_Up" );
+						pszEntryName = UTIL_GetRandomSoundFromEntry( "Announcer.MVM_Manned_Up" );
 					}
 					else
 					{
-						pLocalPlayer->EmitSound( "Announcer.MVM_First_Wave_Start" );
+						pszEntryName = UTIL_GetRandomSoundFromEntry( "Announcer.MVM_First_Wave_Start" );
 					}
 				}
 				else
 				{
-					pLocalPlayer->EmitSound( "Announcer.MVM_Wave_Start" );
+					pszEntryName = UTIL_GetRandomSoundFromEntry( "Announcer.MVM_Wave_Start" );
 				}
 			}
 			else
 			{
-				pLocalPlayer->EmitSound( bCompetitiveMode ? "Announcer.CompGame1Begins10Seconds" : "Announcer.RoundBegins10Seconds" );
+				pszEntryName = UTIL_GetRandomSoundFromEntry( bCompetitiveMode ? "Announcer.CompGame1Begins10Seconds" : "Announcer.RoundBegins10Seconds" );
 			}
+			float flDelay = enginesound->GetSoundDuration(pszEntryName); // Pulling sound length
+			pLocalPlayer->EmitSound(pszEntryName); // Playing sound
+			m_flNextActionTime = gpGlobals->curtime + flDelay; // Determining min time for admin to not talk over herself
 			break;
 		}
 		case 9:
@@ -227,27 +232,27 @@ void CHudTournament::PlaySounds( int nTime )
 		}
 		case 5:
 		{
-			pLocalPlayer->EmitSound( bCompetitiveMode ? "Announcer.CompGameBegins05Seconds" : "Announcer.RoundBegins5Seconds" );
+			if (gpGlobals->curtime > m_flNextActionTime) pLocalPlayer->EmitSound( bCompetitiveMode ? "Announcer.CompGameBegins05Seconds" : "Announcer.RoundBegins5Seconds" );
 			break;
 		}
 		case 4:
 		{
-			pLocalPlayer->EmitSound( bCompetitiveMode ? "Announcer.CompGameBegins04Seconds" : "Announcer.RoundBegins4Seconds" );
+			if (gpGlobals->curtime > m_flNextActionTime) pLocalPlayer->EmitSound( bCompetitiveMode ? "Announcer.CompGameBegins04Seconds" : "Announcer.RoundBegins4Seconds" );
 			break;
 		}
 		case 3:
 		{
-			pLocalPlayer->EmitSound( bCompetitiveMode ? "Announcer.CompGameBegins03Seconds" : "Announcer.RoundBegins3Seconds" );
+			if (gpGlobals->curtime > m_flNextActionTime) pLocalPlayer->EmitSound( bCompetitiveMode ? "Announcer.CompGameBegins03Seconds" : "Announcer.RoundBegins3Seconds" );
 			break;
 		}
 		case 2:
 		{
-			pLocalPlayer->EmitSound( bCompetitiveMode ? "Announcer.CompGameBegins02Seconds" : "Announcer.RoundBegins2Seconds" );
+			if (gpGlobals->curtime > m_flNextActionTime) pLocalPlayer->EmitSound( bCompetitiveMode ? "Announcer.CompGameBegins02Seconds" : "Announcer.RoundBegins2Seconds" );
 			break;
 		}
 		case 1:
 		{
-			pLocalPlayer->EmitSound( bCompetitiveMode ? "Announcer.CompGameBegins01Seconds" : "Announcer.RoundBegins1Seconds" );
+			if (gpGlobals->curtime > m_flNextActionTime) pLocalPlayer->EmitSound( bCompetitiveMode ? "Announcer.CompGameBegins01Seconds" : "Announcer.RoundBegins1Seconds" );
 			break;
 		}
 	}

--- a/src/game/client/tf/tf_hud_tournament.h
+++ b/src/game/client/tf/tf_hud_tournament.h
@@ -60,6 +60,7 @@ private:
 	bool			m_bShouldBeVisible;
 
 	float			m_flNextUpdate;
+	float			m_flNextActionTime;	// new addition for bugfix
 
 	bool			m_bTeamReady[MAX_TEAMS];
 


### PR DESCRIPTION
This fix is intended to resolve MvM announcer lines being truncated by the final 5 seconds of setup countdown. This was achieved by adding code to ensure that the announcer wave start line has finished playing before playing countdown audio.

Video of fixed bug:
https://github.com/user-attachments/assets/6ead54a2-ebd9-4e98-a4f9-ec398e3f8947

