### PR TITLE
Set m_mousespeed default value to 0 (disable mouse acceleration entirely)

### DIFF
--- a/src/game/client/in_mouse.cpp
+++ b/src/game/client/in_mouse.cpp
@@ -98,7 +98,7 @@ static ConVar m_customaccel_scale( "m_customaccel_scale", "0.04", FCVAR_ARCHIVE,
 static ConVar m_customaccel_max( "m_customaccel_max", "0", FCVAR_ARCHIVE, "Max mouse move scale factor, 0 for no limit" );
 static ConVar m_customaccel_exponent( "m_customaccel_exponent", "1", FCVAR_ARCHIVE, "Mouse move is raised to this power before being scaled by scale factor.", true, 1.0f, false, 0.0f);
 
-static ConVar m_mousespeed( "m_mousespeed", "1", FCVAR_ARCHIVE, "Windows mouse acceleration (0 to disable, 1 to enable [Windows 2000: enable initial threshold], 2 to enable secondary threshold [Windows 2000 only]).", true, 0, true, 2 );
+static ConVar m_mousespeed( "m_mousespeed", "0", FCVAR_ARCHIVE, "Windows mouse acceleration (0 to disable, 1 to enable [Windows 2000: enable initial threshold], 2 to enable secondary threshold [Windows 2000 only]).", true, 0, true, 2 );
 static ConVar m_mouseaccel1( "m_mouseaccel1", "0", FCVAR_ARCHIVE, "Windows mouse acceleration initial threshold (2x movement).", true, 0, false, 0.0f );
 static ConVar m_mouseaccel2( "m_mouseaccel2", "0", FCVAR_ARCHIVE, "Windows mouse acceleration secondary threshold (4x movement).", true, 0, false, 0.0f );
 


### PR DESCRIPTION
This makes sures no other ConVar related to mouse acceleration is enabled by default. Related ConVars are disabled by default, with the exception of `m_mousespeed` that is addressed in this PR.

This is an addition to `m_rawinput` being enabled by default.

---------

For reference, a popular FPS config. for TF2, called "mastercomfig", has an add-on called Flat Mouse, which disables all acceleration-related mouse ConVars.

https://github.com/mastercomfig/mastercomfig/blob/7eb031ad8cd8e096b623819909e18a64c88ec16a/config/cfg/addons/flat-mouse.cfg

It also used to enable `m_rawinput` when its default was `0`.
