### PR TITLE
[TF2] Fix softlock when robots in MVM are stuck in spawn

### DIFF
--- a/src/game/shared/tf/tf_gamemovement.cpp
+++ b/src/game/shared/tf/tf_gamemovement.cpp
@@ -1382,7 +1382,7 @@ int CTFGameMovement::CheckStuck( void )
 						m_pTFPlayer->GetTeam()->GetName(),
 						m_pTFPlayer->GetAbsOrigin().x, m_pTFPlayer->GetAbsOrigin().y, m_pTFPlayer->GetAbsOrigin().z );
 
-					m_pTFPlayer->TakeDamage( CTakeDamageInfo( m_pTFPlayer, m_pTFPlayer, vec3_origin, m_pTFPlayer->WorldSpaceCenter(), 999999.9f, DMG_CRUSH ) );
+               m_pTFPlayer->CommitSuicide(true, true);
 				}
 				else
 				{


### PR DESCRIPTION
When a robot in MVM gets stuck, there is a failsafe in-place which intends to kill the robot after some time, but this is accomplished with TakeDamage(), which doesn't work when the robot has its spawning invulnerability.  This results in the bot being stuck and unable to be killed, softlocking the wave.  The only way to recover from this is to either intentionally let the bots plant the bomb, or vote to restart the mission.

This has been an issue both unintentionally when bots drop at precise angles that result in them getting stuck in work geometry, and intentionally when abused by griefers on maps like Coaltown who deliberately airblast the bot out-of-bounds to get it to respawn in world geometry and softlock the mission for the rest of the team.

This fix simply replaces TakeDamage() with CommitSuicide(), which solves the issue.