### PR TITLE
Fix bug where credits dropped in the robots' spawn become unobtainable in MVM

### DIFF
--- a/src/game/server/tf/entity_currencypack.h
+++ b/src/game/server/tf/entity_currencypack.h
@@ -47,6 +47,10 @@ public:
 	virtual CurrencyRewards_t	GetPackSize( void ) { return TF_CURRENCY_PACK_LARGE; }
 	virtual const char *GetDefaultPowerupModel( void ) { return "models/items/currencypack_large.mdl"; }
 
+private:
+   void DespawnAndCollect( void );
+   bool IsWithinCollidableBoundingBox( CBaseEntity *pEntity );
+
 protected:
 	virtual void ComeToRest( void );
 


### PR DESCRIPTION
In rare circumstances, a bot killed just outside of its spawn may drop credits within the robot spawn.  This can lead to the credits becoming unobtainable, sometimes even with Scout's money magnet mechanic.

This fix checks if the credits come to rest within the robots' spawn, and if they do, automatically collects them.  I also did some minor refactoring of CCurrencyPack::ComeToRest(), as I feel that the function is a bit of a mess.