### PR TITLE
[TF2] Fix prediction for hud charge meters of stickybomb launcher, loose cannon, huntsman, etc

### DIFF
--- a/src/game/client/tf/tf_hud_bowcharge.cpp
+++ b/src/game/client/tf/tf_hud_bowcharge.cpp
@@ -229,29 +229,8 @@ void CHudBowChargeMeter::OnTick( void )
 	CTFWeaponBase *pWpn = pPlayer->GetActiveTFWeapon();
 	ITFChargeUpWeapon *pChargeupWeapon = dynamic_cast< ITFChargeUpWeapon *>( pWpn );
 
-	if ( !pWpn || !pChargeupWeapon )
+	if ( !pWpn || !pChargeupWeapon || !m_pChargeMeter || !pChargeupWeapon->GetChargeMaxTime() )
 		return;
 
-	if ( m_pChargeMeter )
-	{
-		float flChargeMaxTime = pChargeupWeapon->GetChargeMaxTime();
-
-		if ( flChargeMaxTime != 0 )
-		{
-			float flChargeBeginTime = pChargeupWeapon->GetChargeBeginTime();
-
-			if ( flChargeBeginTime > 0 )
-			{
-				float flTimeCharged = MAX( 0, gpGlobals->curtime - flChargeBeginTime );
-				flTimeCharged = MIN( flTimeCharged, 1.f );
-				float flPercentCharged = MIN( 1.0, flTimeCharged / flChargeMaxTime );
-
-				m_pChargeMeter->SetProgress( flPercentCharged );
-			}
-			else
-			{
-				m_pChargeMeter->SetProgress( 0.0f );
-			}
-		}
-	}
+	m_pChargeMeter->SetProgress( pChargeupWeapon->GetPercentProgress() );
 }

--- a/src/game/client/tf/tf_hud_demomancharge.cpp
+++ b/src/game/client/tf/tf_hud_demomancharge.cpp
@@ -115,28 +115,8 @@ void CHudDemomanChargeMeter::OnTick( void )
 	
 
 	ITFChargeUpWeapon *pChargeupWeapon = dynamic_cast< ITFChargeUpWeapon *>( pWpn );
-	if ( !pWpn || !pChargeupWeapon || !pChargeupWeapon->CanCharge() )
+	if ( !pWpn || !pChargeupWeapon || !pChargeupWeapon->CanCharge() || !m_pChargeMeter || !pChargeupWeapon->GetChargeMaxTime() )
 		return;
-
-	if ( m_pChargeMeter )
-	{
-		float flChargeMaxTime = pChargeupWeapon->GetChargeMaxTime();
-
-		if ( flChargeMaxTime != 0 )
-		{
-			float flChargeBeginTime = pChargeupWeapon->GetChargeBeginTime();
-
-			if ( flChargeBeginTime > 0 )
-			{
-				float flTimeCharged = MAX( 0, gpGlobals->curtime - flChargeBeginTime );
-				float flPercentCharged = MIN( 1.0, flTimeCharged / flChargeMaxTime );
-
-				m_pChargeMeter->SetProgress( flPercentCharged );
-			}
-			else
-			{
-				m_pChargeMeter->SetProgress( 0.0f );
-			}
-		}
-	}
+	
+	m_pChargeMeter->SetProgress( pChargeupWeapon->GetPercentProgress() );
 }

--- a/src/game/client/tf/tf_hud_flamerocketcharge.cpp
+++ b/src/game/client/tf/tf_hud_flamerocketcharge.cpp
@@ -119,28 +119,8 @@ void CHudFlameRocketChargeMeter::OnTick( void )
 	CTFWeaponBase *pWpn = pPlayer->GetActiveTFWeapon();
 	ITFChargeUpWeapon *pChargeupWeapon = dynamic_cast< ITFChargeUpWeapon *>( pWpn );
 
-	if ( !pWpn || !pChargeupWeapon )
+	if ( !pWpn || !pChargeupWeapon || !m_pChargeMeter || !pChargeupWeapon->GetChargeMaxTime() )
 		return;
 
-	if ( m_pChargeMeter )
-	{
-		float flChargeMaxTime = pChargeupWeapon->GetChargeMaxTime();
-
-		if ( flChargeMaxTime != 0 )
-		{
-			float flChargeBeginTime = pChargeupWeapon->GetChargeBeginTime();
-
-			if ( flChargeBeginTime > 0 )
-			{
-				float flTimeCharged = MAX( 0, gpGlobals->curtime - flChargeBeginTime );
-				float flPercentCharged = MIN( 1.0, flTimeCharged / flChargeMaxTime );
-
-				m_pChargeMeter->SetProgress( flPercentCharged );
-			}
-			else
-			{
-				m_pChargeMeter->SetProgress( 0.0f );
-			}
-		}
-	}
+	m_pChargeMeter->SetProgress( pChargeupWeapon->GetPercentProgress() );
 }

--- a/src/game/client/tf/tf_hud_sapper_charge.cpp
+++ b/src/game/client/tf/tf_hud_sapper_charge.cpp
@@ -118,29 +118,8 @@ void CHudSapperChargeMeter::OnTick( void )
 	CTFWeaponBase *pWpn = pPlayer->GetActiveTFWeapon();
 	ITFChargeUpWeapon *pChargeupWeapon = dynamic_cast< ITFChargeUpWeapon *>( pWpn );
 
-	if ( !pWpn || !pChargeupWeapon )
+	if ( !pWpn || !pChargeupWeapon || !m_pChargeMeter || !pChargeupWeapon->GetChargeMaxTime() )
 		return;
 
-	if ( m_pChargeMeter )
-	{
-		float flChargeMaxTime = pChargeupWeapon->GetChargeMaxTime();
-
-		if ( flChargeMaxTime != 0 )
-		{
-			float flChargeBeginTime = pChargeupWeapon->GetChargeBeginTime();
-
-			if ( flChargeBeginTime > 0 )
-			{
-				float flTimeCharged = MAX( 0, gpGlobals->curtime - flChargeBeginTime );
-				flTimeCharged = MIN( flTimeCharged, flChargeMaxTime );
-				float flPercentCharged = MIN( 1.0, flTimeCharged / flChargeMaxTime );
-
-				m_pChargeMeter->SetProgress( flPercentCharged );
-			}
-			else
-			{
-				m_pChargeMeter->SetProgress( 0.0f );
-			}
-		}
-	}
+	m_pChargeMeter->SetProgress( pChargeupWeapon->GetPercentProgress() );
 }

--- a/src/game/shared/tf/tf_weaponbase.cpp
+++ b/src/game/shared/tf/tf_weaponbase.cpp
@@ -2462,6 +2462,31 @@ void CTFWeaponBase::ItemPostFrame( void )
 	{
 		FireFullClipAtOnce();
 	}
+
+#ifdef CLIENT_DLL
+	ITFChargeUpWeapon *pChargeupWeapon = dynamic_cast< ITFChargeUpWeapon *>( this );
+	if ( pChargeupWeapon && pChargeupWeapon->CanCharge() )
+	{
+		float flChargeMaxTime = pChargeupWeapon->GetChargeMaxTime();
+
+		if ( flChargeMaxTime != 0 )
+		{
+			float flChargeBeginTime = pChargeupWeapon->GetChargeBeginTime();
+
+			if ( flChargeBeginTime > 0 )
+			{
+				float flTimeCharged = MAX( 0, gpGlobals->curtime - flChargeBeginTime );
+				float flPercentCharged = MIN( 1.0, flTimeCharged / flChargeMaxTime );
+
+				pChargeupWeapon->SetPercentProgress( flPercentCharged );
+			}
+			else
+			{
+				pChargeupWeapon->SetPercentProgress( 0.f );
+			}
+		}
+	}
+#endif
 }
 
 

--- a/src/game/shared/tf/tf_weaponbase.h
+++ b/src/game/shared/tf/tf_weaponbase.h
@@ -118,6 +118,14 @@ public:
 	{ 
 		return ( gpGlobals->curtime - GetChargeBeginTime() ) / GetChargeMaxTime();
 	}
+
+#ifdef CLIENT_DLL
+	void SetPercentProgress( float flPercentProgress ) { m_flPercentProgress = flPercentProgress; };
+	float GetPercentProgress( void ) { return m_flPercentProgress; };
+
+private:
+	float m_flPercentProgress = 0;
+#endif
 };
 
 class CTraceFilterIgnoreTeammates : public CTraceFilterSimple


### PR DESCRIPTION
partially fixes this issue: https://github.com/ValveSoftware/Source-1-Games/issues/6017

affected items:
\- Stickybomb Launcher
\- Loose Cannon
\- Huntsman / Fortified Compound
\- Dragon's Fury (hud meter is hidden by default without a custom hud)
\- Sapper (mvm)

(btw in the vids below, red crosshair = mouse1 is held down)

unfixed, net_fakelag 200:

https://github.com/user-attachments/assets/ae9c8363-91ec-4183-be45-ed65e348c252

fixed, net_fakelag 200:

https://github.com/user-attachments/assets/650e68ed-79b3-4eb3-b103-b1908811aebb

(note: the fix from https://github.com/ValveSoftware/source-sdk-2013/pull/777 is also active in the second vid)

imo this solution doesnt feel too elegant, so tell me if u can see a better way to fix this