### PR TITLE
Team Fortress 2: Visibly show other sappers

### DIFF
--- a/src/game/client/tf/c_obj_sapper.cpp
+++ b/src/game/client/tf/c_obj_sapper.cpp
@@ -42,6 +42,12 @@ void C_ObjectSapper::ClientThink( void )
 	}
 }
 
+bool C_ObjectSapper::ValidateEntityAttachedToPlayer( bool &bShouldRetry )
+{
+	bShouldRetry = false;
+	return true;
+}
+
 float C_ObjectSapper::GetReversesBuildingConstructionSpeed( void )
 {
 	float flReverseSpeed = 0.0f;

--- a/src/game/client/tf/c_obj_sapper.h
+++ b/src/game/client/tf/c_obj_sapper.h
@@ -26,6 +26,7 @@ public:
 
 	virtual void ClientThink( void );
 	virtual void OnDataChanged( DataUpdateType_t type );
+	virtual bool ValidateEntityAttachedToPlayer( bool &bShouldRetry );
 
 	virtual bool	IsHostileUpgrade( void ) { return true; }
 


### PR DESCRIPTION
When a sapper is built on a player, only the default sapper is visible. Let the other sappers visibly appear as well.

This is a bug fix for a minor problem that is currently only present in Mann vs. Machine Mode.