### PR TITLE
bsplib: Do not leak g_pBSPHeader when map processing failed

### DIFF
--- a/src/utils/common/bsplib.cpp
+++ b/src/utils/common/bsplib.cpp
@@ -4803,6 +4803,7 @@ bool SwapBSPFile( const char *pInFilename, const char *pOutFilename, bool bSwapO
 	CRC32_Init(&mapCRC);
 	if ( !CRC_MapFile( &mapCRC, pInFilename ) )
 	{
+		CloseBSPFile();
 		Warning( "Failed to CRC the bsp\n" );
 		return false;
 	}
@@ -5096,6 +5097,7 @@ bool SetPakFileLump( const char *pBSPFilename, const char *pNewFilename, void *p
 	g_hBSPFile = SafeOpenWrite( pNewFilename );
 	if ( !g_hBSPFile )
 	{
+		CloseBSPFile();
 		return false;
 	}
 


### PR DESCRIPTION
Closes #806 