### PR TITLE
Fix middle mouse kicking players out of the server in PASS Time

### DIFF
--- a/src/game/client/tf/c_tf_player.cpp
+++ b/src/game/client/tf/c_tf_player.cpp
@@ -6050,7 +6050,7 @@ void C_TFPlayer::ClientThink()
 		// 
 		// Passtime ask for ball button
 		//
-	    if ( m_nButtons & IN_ATTACK3 )
+	    if ( m_afButtonPressed & IN_ATTACK3 )
 	    {
 		    engine->ClientCmd("voicemenu 1 8");
 	    }


### PR DESCRIPTION
Pressing middle mouse click (mouse3) in the PASS Time gamemode kicks the client immediately. This is because it sends a voicecommand every frame when the button is pressed, for which the server then promptly kicks the client for spamming commands. The PR fixes this by only sending the voicecommand when mouse3 is pressed, not held.