### PR TITLE
all: Ensure pointers casted from one type to another have same underlying alignment

### DIFF
--- a/src/public/tier0/memoverride.cpp
+++ b/src/public/tier0/memoverride.cpp
@@ -594,7 +594,7 @@ ALLOC_CALL void *__cdecl _aligned_malloc_base( size_t size, size_t align )
 
 inline void *MemAlloc_Unalign( void *pMemBlock )
 {
-	unsigned *pAlloc = (unsigned *)pMemBlock;
+	alignas(unsigned **) unsigned *pAlloc = (unsigned *)pMemBlock;
 
 	// pAlloc points to the pointer to starting of the memory block
 	pAlloc = (unsigned *)(((size_t)pAlloc & ~(sizeof( void * ) - 1)) - sizeof( void * ));

--- a/src/tier1/checksum_md5.cpp
+++ b/src/tier1/checksum_md5.cpp
@@ -259,7 +259,7 @@ char *MD5_Print( unsigned char *hash, int hashlen )
 unsigned int MD5_PseudoRandom(unsigned int nSeed)
 {
 	MD5Context_t ctx;
-	unsigned char digest[MD5_DIGEST_LENGTH]; // The MD5 Hash
+	alignas(unsigned int) unsigned char digest[MD5_DIGEST_LENGTH]; // The MD5 Hash
 
 	memset( &ctx, 0, sizeof( ctx ) );
 		

--- a/src/tier1/utlsymbol.cpp
+++ b/src/tier1/utlsymbol.cpp
@@ -338,7 +338,7 @@ FileNameHandle_t CUtlFilenameSymbolTable::FindOrAddFileName( const char *pFileNa
 	Q_strncpy( filename, fn + Q_strlen( basepath ), sizeof( filename ) );
 
 	// not found, lock and look again
-	FileNameHandleInternal_t handle;
+	alignas(FileNameHandle_t) FileNameHandleInternal_t handle;
 	m_lock.LockForWrite();
 	handle.path = m_Strings->Insert( basepath ) + 1;
 	handle.file = m_Strings->Insert( filename ) + 1;
@@ -380,7 +380,7 @@ FileNameHandle_t CUtlFilenameSymbolTable::FindFileName( const char *pFileName )
 	char filename[ MAX_PATH ];
 	Q_strncpy( filename, fn + Q_strlen( basepath ), sizeof( filename ) );
 
-	FileNameHandleInternal_t handle;
+	alignas(FileNameHandle_t) FileNameHandleInternal_t handle;
 
 	Assert( (uint16)(m_Strings->InvalidHandle() + 1) == 0 );
 


### PR DESCRIPTION
Closes #817 