### PR TITLE
[TF2] Pyroland support [Keyvalue/Netprop]

### DIFF
--- a/src/game/shared/tf/tf_gamerules.h
+++ b/src/game/shared/tf/tf_gamerules.h
@@ -218,6 +218,7 @@ private:
 
 	bool	m_bOvertimeAllowedForCTF;
 	bool	m_bRopesHolidayLightsAllowed;
+	bool    m_bSupportsPyroland;
 #endif
 
 public: // IGameEventListener Interface
@@ -1006,6 +1007,7 @@ public:
 	bool GetOvertimeAllowedForCTF( void ){ return m_bOvertimeAllowedForCTF; }
 
 	void SetRopesHolidayLightsAllowed( bool bAllowed ) { m_bRopesHolidayLightsAllowed = bAllowed; }
+	void SetPyrovisionAllowed( bool bAllowed ) { m_bSupportsPyroland = bAllowed; }
 
 	const CUtlVector< CHandle< CBaseEntity > > &GetHealthEntityVector( void );		// return vector of health entities 
 	const CUtlVector< CHandle< CBaseEntity > > &GetAmmoEntityVector( void );		// return vector of ammo entities 
@@ -1047,6 +1049,7 @@ private:
 #endif // GAME_DLL
 
 	bool GetRopesHolidayLightsAllowed( void ) { return m_bRopesHolidayLightsAllowed; }
+	bool GetPyrovisionAllowed( void ) { return m_bSupportsPyroland; }
 
 private:
 
@@ -1201,6 +1204,7 @@ private:
 	CNetworkVar( bool, m_bTeamsSwitched );
 
 	CNetworkVar( bool, m_bRopesHolidayLightsAllowed );
+	CNetworkVar( bool, m_bSupportsPyroland );
 
 #ifdef GAME_DLL
 	float	m_flNextFlagAlarm;


### PR DESCRIPTION
# Description
Currently the only way to add maps supported for pyroland is to insert them into `mtp.cfg`, this change allows mappers and vscripters to force support on the current map if not listed.

WARNING: not every asset will be compatible, since they must be included in the replacement.txt the directory, and replacement.vmt (for each folder) to tell which materials can be replaced or not, the solution to this would be allow users pack custom lists, and add-on the base .txt file a custom list.

for example, level_sounds, can replace or add new sounds to users map, a similiar system could be developed, and replacement.vmt's could be just packe

Unrelated to the Pull, but for some reason these "texture corruptions" happend only when the vision is active in general
https://github.com/user-attachments/assets/070fd73c-e924-4b78-a943-112bcbc99e6d

d inside the map, this of course, is an extra step for the mappers themselves if they want it as a bonus feature for their level.