### PR TITLE
Hide voice labels for cloaked enemy spies

### DIFF
--- a/src/game/client/c_baseplayer.h
+++ b/src/game/client/c_baseplayer.h
@@ -372,7 +372,8 @@ public:
 	bool 					HintMessage( int hint, bool bForce = false, bool bOnlyIfClear = false ) { return Hints() ? Hints()->HintMessage( hint, bForce, bOnlyIfClear ) : false; }
 	void 					HintMessage( const char *pMessage ) { if (Hints()) Hints()->HintMessage( pMessage ); }
 
-	virtual	IMaterial *GetHeadLabelMaterial( void );
+	virtual	IMaterial		*GetHeadLabelMaterial( void );
+	virtual bool			ShouldShowHeadLabel() { return !IsPlayerDead(); }
 
 	// Fog
 	fogparams_t				*GetFogParams( void ) { return &m_CurrentFog; }

--- a/src/game/client/tf/c_tf_player.cpp
+++ b/src/game/client/tf/c_tf_player.cpp
@@ -9443,6 +9443,11 @@ IMaterial *C_TFPlayer::GetHeadLabelMaterial( void )
 	return BaseClass::GetHeadLabelMaterial();
 }
 
+bool C_TFPlayer::ShouldShowHeadLabel()
+{
+	return BaseClass::ShouldShowHeadLabel() && ( !m_Shared.IsStealthed() || !IsEnemyPlayer() );
+}
+
 void SetupHeadLabelMaterials( void )
 {
 	for ( int i = 0; i < 2; i++ )

--- a/src/game/client/tf/c_tf_player.h
+++ b/src/game/client/tf/c_tf_player.h
@@ -482,6 +482,7 @@ public:
 	bool ShouldShowNemesisIcon();
 
 	virtual	IMaterial *GetHeadLabelMaterial( void );
+	virtual bool ShouldShowHeadLabel();
 
 	// Spy Cigarette
 	bool CanLightCigarette( void );

--- a/src/game/shared/voice_status.cpp
+++ b/src/game/shared/voice_status.cpp
@@ -227,11 +227,10 @@ void CVoiceStatus::DrawHeadLabels()
 			continue;
 
 		C_BasePlayer *pPlayer = dynamic_cast<C_BasePlayer*>(pClient);
-		if( !pPlayer )
+		if ( !pPlayer )
 			continue;
 
-		// Don't show an icon for dead or spectating players (ie: invisible entities).
-		if( pPlayer->IsPlayerDead() )
+		if ( !pPlayer->ShouldShowHeadLabel() )
 			continue;
 
 		// Place it 20 units above his head.


### PR DESCRIPTION
When using voice chat, a sprite will appear above the player's head. Unfortunately, this does even when cloaked as a spy which obviously reveals your position. This PR changes that so the sprite does not appear for enemy spies that are cloaked.