### PR TITLE
gdvar: Do not overflow when copying kv buffer[512] to gdvar buffer[129]

### DIFF
--- a/src/fgdlib/gdvar.cpp
+++ b/src/fgdlib/gdvar.cpp
@@ -591,7 +591,7 @@ void GDinputvariable::FromKeyValue(MDkeyvalue *pkv)
 
 	if (eStoreAs == STRING)
 	{
-		strcpy(m_szValue, pkv->szValue);
+		V_strcpy_safe(m_szValue, pkv->szValue);
 	}
 	else if (eStoreAs == INTEGER)
 	{


### PR DESCRIPTION
Closes #832 