### PR TITLE
tf2: In medieval mode autochat replacement word's first letter should match case of the replaced word

### DIFF
--- a/src/game/client/tf/tf_autorp.cpp
+++ b/src/game/client/tf/tf_autorp.cpp
@@ -547,7 +547,7 @@ void CTFAutoRP::ModifySpeech( const char *pszInText, char *pszOutText, int iOutL
 				{
 					szStoredWord[0] = toupper( szStoredWord[0] );
 				}
-				else if ( pszCurWord[0] >= 'a' && pszCurWord[0] <= 'a' )
+				else if ( pszCurWord[0] >= 'a' && pszCurWord[0] <= 'z' )
 				{
 					szStoredWord[0] = tolower( szStoredWord[0] );
 				}


### PR DESCRIPTION
Closes #834 