### PR TITLE
Prevent identifying cloaked enemy spies through inspection

### DIFF
--- a/src/game/client/tf/tf_hud_inspectpanel.cpp
+++ b/src/game/client/tf/tf_hud_inspectpanel.cpp
@@ -239,8 +239,9 @@ C_TFPlayer *CHudInspectPanel::GetInspectTarget( C_TFPlayer *pLocalTFPlayer )
 			// Get the player under our crosshair
 			pTargetPlayer = ToTFPlayer( pEntity );
 
+			// Preventing players from identifying a cloaked enemy spy through inspection
 			// Fix up if it's a spy disguised as my team
-			if ( pLocalTFPlayer->m_Shared.IsSpyDisguisedAsMyTeam( pTargetPlayer ) )
+			if ( !pTargetPlayer->m_Shared.IsStealthed() && pLocalTFPlayer->m_Shared.IsSpyDisguisedAsMyTeam( pTargetPlayer ) )
 			{
 				// Get the player that the spy is disguised as
 				C_TFPlayer *pDisguiseTarget = pTargetPlayer->m_Shared.GetDisguiseTarget();

--- a/src/game/client/tf/tf_hud_inspectpanel.cpp
+++ b/src/game/client/tf/tf_hud_inspectpanel.cpp
@@ -241,7 +241,7 @@ C_TFPlayer *CHudInspectPanel::GetInspectTarget( C_TFPlayer *pLocalTFPlayer )
 
 			// Preventing players from identifying a cloaked enemy spy through inspection
 			// Fix up if it's a spy disguised as my team
-			if ( !pTargetPlayer->m_Shared.IsStealthed() && pLocalTFPlayer->m_Shared.IsSpyDisguisedAsMyTeam( pTargetPlayer ) )
+			if ( pLocalTFPlayer->m_Shared.IsSpyDisguisedAsMyTeam( pTargetPlayer ) && !pTargetPlayer->m_Shared.IsStealthed() )
 			{
 				// Get the player that the spy is disguised as
 				C_TFPlayer *pDisguiseTarget = pTargetPlayer->m_Shared.GetDisguiseTarget();


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
There is an exploit where a disguised enemy spy can still be identified through inspection, even while cloaked. This PR fixes the exploit by adding a check for the cloak state when the target is a disguised enemy spy.