### PR TITLE
[TF2] tf_bots work up to 100 players

### DIFF
--- a/src/game/server/tf/bot/behavior/tf_bot_behavior.cpp
+++ b/src/game/server/tf/bot/behavior/tf_bot_behavior.cpp
@@ -51,7 +51,7 @@ ConVar tf_bot_hitscan_range_limit( "tf_bot_hitscan_range_limit", "1800", FCVAR_C
 ConVar tf_bot_always_full_reload( "tf_bot_always_full_reload", "0", FCVAR_CHEAT );
 
 ConVar tf_bot_fire_weapon_allowed( "tf_bot_fire_weapon_allowed", "1", FCVAR_CHEAT, "If zero, TFBots will not pull the trigger of their weapons (but will act like they did)" );
-ConVar tf_bot_reevaluate_class_in_spawnroom( "tf_bot_reevaluate_class_in_spawnroom", "1", FCVAR_CHEAT, "If set, bots will opportunisticly switch class while in spawnrooms if their current class is no longer their first choice." );
+ConVar tf_bot_reevaluate_class_in_spawnroom( "tf_bot_reevaluate_class_in_spawnroom", "1", FCVAR_NONE, "If set, bots will opportunisticly switch class while in spawnrooms if their current class is no longer their first choice." );
 
 
 //---------------------------------------------------------------------------------------------
@@ -151,6 +151,7 @@ ActionResult< CTFBot >	CTFBotMainAction::Update( CTFBot *me, float interval )
 
 	// should I try to change class?
 	if ( tf_bot_reevaluate_class_in_spawnroom.GetBool() &&
+		 !me->GetDidReselectClass() &&
 	     !TFGameRules()->IsMannVsMachineMode() && 
 		 !TFGameRules()->IsInTraining() && 
 		 myArea && myArea->HasAttributeTF( spawnRoomFlag ) )

--- a/src/game/server/tf/bot/tf_bot.h
+++ b/src/game/server/tf/bot/tf_bot.h
@@ -366,6 +366,8 @@ public:
 	void ScriptSetMissionTarget( HSCRIPT hTarget ) { this->SetMissionTarget( ToEnt( hTarget ) ); }
 	HSCRIPT ScriptGetMissionTarget( void ) const { return ToHScript( this->GetMissionTarget() ); }
 
+	bool GetDidReselectClass(void) const;
+
 	void SetTeleportWhere( const CUtlStringList& teleportWhereName );
 	const CUtlStringList& GetTeleportWhere();
 	void ClearTeleportWhere();
@@ -619,6 +621,11 @@ inline void CTFBot::SetMissionTarget( CBaseEntity *target )
 inline CBaseEntity *CTFBot::GetMissionTarget( void ) const
 {
 	return m_missionTarget;
+}
+
+inline bool CTFBot::GetDidReselectClass(void) const
+{
+	return m_didReselectClass;
 }
 
 inline float CTFBot::GetSquadFormationError( void ) const


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

Modifies tf_bots so they work all the way up to 100 players without failing to spawn in or causing significant class imbalances.

## Implementation Details:
- `CTFBot::m_didReselectClass`
  - Added a Getter so that `CTFBotMainAction::Update` can avoid unnecessarily triggering class reevaluations.
  - Moved `false` assignment to `CTFBot::Event_Killed` to prevent an infinite loop of class reevalulation.
- CVars:
  -  `tf_bot_reevaluate_class_in_spawnroom`:  Now `FCVAR_NONE` (was `FCVAR_CHEATS`).
  - `tf_bot_spawn_use_preset_roster`: Now `FCVAR_NONE` (was `FCVAR_CHEATS`). Now defaults to 0 (was 1).
- Preset Roster (`tf_bot_spawn_use_preset_roster 1`):
  - If team size > 12, the preset roster will be reused for bots 13-24, 25-36, etc.
  - Prevents bots from failing to spawn, but may still result in imbalanced class counts. Still only intended for 12v12.
- Dynamic roster (`tf_bot_spawn_use_preset_roster 0`):
  - Now the default, as it is more dynamic and responsive to gamestate.
  - Class limits specified in rosters scale according to team size. Roster definitions assume team size of 12. Team sizes under 12 unaffected.
  - Team composition levels out with larger team sizes (prevents massive class stacks).
- ~~Added more bot names so there's a pool of at least 100 to choose from.~~ Now in a separate PR: https://github.com/ValveSoftware/source-sdk-2013/pull/892