### PR TITLE
[TF2] Fix prediction for cow mangler charged shot

### DIFF
--- a/src/game/shared/tf/tf_weapon_particle_cannon.cpp
+++ b/src/game/shared/tf/tf_weapon_particle_cannon.cpp
@@ -40,6 +40,9 @@ BEGIN_NETWORK_TABLE( CTFParticleCannon, DT_ParticleCannon )
 END_NETWORK_TABLE()
 
 BEGIN_PREDICTION_DATA( CTFParticleCannon )
+#ifdef CLIENT_DLL
+	DEFINE_PRED_FIELD( m_flChargeBeginTime, FIELD_FLOAT, FTYPEDESC_INSENDTABLE ),
+#endif
 END_PREDICTION_DATA()
 
 LINK_ENTITY_TO_CLASS( tf_weapon_particle_cannon, CTFParticleCannon );


### PR DESCRIPTION
fixes this issue partially: https://github.com/ValveSoftware/Source-1-Games/issues/6017

makes your camera no longer rubberband when you do charged shots while moving

unfixed:

https://github.com/user-attachments/assets/c044bf2c-d5ec-4014-be25-ff0c8b62c4bb

fixed:

https://github.com/user-attachments/assets/bd95cdc8-b6f7-4b9f-90b0-b08a73b0ca7d