### PR TITLE
[TF2] Fix Minigun barrel movement being updated multiple times per tick

### DIFF
--- a/src/game/shared/tf/tf_weapon_minigun.cpp
+++ b/src/game/shared/tf/tf_weapon_minigun.cpp
@@ -1095,6 +1095,11 @@ void CTFMinigun::StandardBlendingRules( CStudioHdr *hdr, Vector pos[], Quaternio
 //-----------------------------------------------------------------------------
 void CTFMinigun::UpdateBarrelMovement()
 {
+	if ( !prediction->IsFirstTimePredicted() )
+	{
+		return;
+	}
+
 	if ( m_flBarrelCurrentVelocity != m_flBarrelTargetVelocity )
 	{
 		float flBarrelAcceleration = CanHolsterWhileSpinning() ? 0.5f : 0.1f;


### PR DESCRIPTION
Fixes the minigun viewmodel having crazy high barrel spin velocities on high latency servers.

Unfixed behavior:

https://github.com/user-attachments/assets/af1d8046-454d-455a-a353-174e339dd80f

Fixed behavior:

https://github.com/user-attachments/assets/a7b333b4-16ab-43c5-a072-4c428819d6ac
