### PR TITLE
fix sydney sleeper being able to headshot on crit and sniper crit no scope attribute being useless

### DIFF
--- a/src/game/shared/tf/tf_weapon_sniperrifle.cpp
+++ b/src/game/shared/tf/tf_weapon_sniperrifle.cpp
@@ -906,14 +906,7 @@ float CTFSniperRifle::GetProjectileDamage( void )
 //-----------------------------------------------------------------------------
 int	CTFSniperRifle::GetDamageType( void ) const
 {
-	// Only do hit location damage if we're zoomed
-	CTFPlayer *pPlayer = ToTFPlayer( GetPlayerOwner() );
-	if ( pPlayer && pPlayer->m_Shared.InCond( TF_COND_ZOOMED ) )
-		return BaseClass::GetDamageType();
-
-	int nDamageType = BaseClass::GetDamageType() & ~DMG_USE_HITLOCATIONS;
-
-	return nDamageType;
+	return BaseClass::GetDamageType();
 }
 
 //-----------------------------------------------------------------------------
@@ -1010,9 +1003,9 @@ bool CTFSniperRifle::CanFireCriticalShot( bool bIsHeadshot, CBaseEntity *pTarget
 		return false;
 
 	CTFPlayer *pPlayer = GetTFPlayerOwner();
-	if ( pPlayer && pPlayer->m_Shared.IsCritBoosted() )
+	if ( pPlayer && pPlayer->m_Shared.IsCritBoosted() && !bIsHeadshot )
 	{
-		m_bCurrentShotIsHeadshot = bIsHeadshot;
+//  	m_bCurrentShotIsHeadshot = bIsHeadshot;
 		return true;
 	}
 
@@ -1041,7 +1034,7 @@ bool CTFSniperRifle::CanFireCriticalShot( bool bIsHeadshot, CBaseEntity *pTarget
 		if ( pPlayer )
 		{
 			// no crits if they're not zoomed
-			if ( pPlayer->GetFOV() >= pPlayer->GetDefaultFOV() )
+			if ( !pPlayer->m_Shared.InCond( TF_COND_ZOOMED ) )
 			{
 				return false;
 			}


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description

The sniper rifle has a couple of issues, firstly the sydney sleeper is able to headshot if it is crit boosted, despite the weapon stat sheet saying otherwise. This is due to the CanFireCriticalShot crit check returning true always if crit boosted. CanFireCriticalShot has 2 different meanings depending on whether bIsHeadshot is true or not; If it is, then it actually is not checking for a random crit, but is checking whether this weapon is allowed to crit on headshot. If false, then this is properly being used by the crit chance calculator. To fix this issue, simply check for !bIsHeadshot alongside the crit boost to ensure that the sydney sleeper never headshots when crit boosted. Contrary to what intuition may suggest, this does not make the sydney sleeper unable to crit if it happens to hit the head, as bIsHeadshot does not actually inform CanFireCriticalShot whether the shot was a headshot, but instead it tells CanFireCriticalShot what purpose it is supposed to fulfill. Next, the sniper crit no scope attribute is entirely useless since its check runs after CTFSniperRifle::GetDamageType deletes the hitlocations bit. This is unnecessary as the CanFireCriticalShot check is enough to prevent unscoped snipers from headshotting. To allow this attribute to function properly, delete the logic inside GetDamageType and check whether the player is zoomed in CanFireCriticalShot properly

This fixes https://github.com/ValveSoftware/Source-1-Games/issues/4493 and https://github.com/ValveSoftware/Source-1-Games/issues/4570

Quick question with the above aside: Is it possible for this fix to make it into the game proper? It would be nice to have this fix in base TF2