### PR TITLE
imageutils: Do not leak malformed bitmap (.bmp) file handle (thanks valgrind and extension typo to find it out!)

### DIFF
--- a/src/common/imageutils.cpp
+++ b/src/common/imageutils.cpp
@@ -713,6 +713,7 @@ unsigned char *ImgUtl_ReadBMPAsRGBA( const char *bmpPath, int &width, int &heigh
 		}
 		else
 		{
+			fclose( fp );
 			errcode = CE_ERROR_PARSING_SOURCE;
 		}
 		return NULL;


### PR DESCRIPTION
Closes #850 