### PR TITLE
DRAFT: [Tier1] Add move operators

### DIFF
--- a/src/public/tier0/platform.h
+++ b/src/public/tier0/platform.h
@@ -1597,6 +1597,12 @@ inline T* CopyConstruct( T* pMemory, T const& src )
 }
 
 template <class T>
+inline T* MoveConstruct( T* pMemory, T&& src )
+{
+	return reinterpret_cast<T*>(::new( pMemory ) T(src));
+}
+
+template <class T>
 inline void Destruct( T* pMemory )
 {
 	pMemory->~T();

--- a/src/public/tier1/utlblockmemory.h
+++ b/src/public/tier1/utlblockmemory.h
@@ -18,6 +18,8 @@
 #include "tier0/platform.h"
 #include "mathlib/mathlib.h"
 
+#include "tier1/utlswap.h"
+
 #include "tier0/memalloc.h"
 #include "tier0/memdbgon.h"
 
@@ -46,6 +48,10 @@ public:
 	// constructor, destructor
 	CUtlBlockMemory( int nGrowSize = 0, int nInitSize = 0 );
 	~CUtlBlockMemory();
+
+	void Swap( CUtlBlockMemory< T, I > &mem );
+	CUtlBlockMemory( CUtlBlockMemory&& other );
+	CUtlBlockMemory& operator=( CUtlBlockMemory&& other );
 
 	// Set the size by which the memory grows - round up to the next power of 2
 	void Init( int nGrowSize = 0, int nInitSize = 0 );
@@ -80,7 +86,6 @@ public:
 	bool IsIdxValid( I i ) const;
 	static I InvalidIndex() { return ( I )-1; }
 
-	void Swap( CUtlBlockMemory< T, I > &mem );
 
 	// Size
 	int NumAllocated() const;
@@ -135,10 +140,25 @@ CUtlBlockMemory<T,I>::~CUtlBlockMemory()
 template< class T, class I >
 void CUtlBlockMemory<T,I>::Swap( CUtlBlockMemory< T, I > &mem )
 {
-	V_swap( m_pMemory, mem.m_pMemory );
-	V_swap( m_nBlocks, mem.m_nBlocks );
-	V_swap( m_nIndexMask, mem.m_nIndexMask );
-	V_swap( m_nIndexShift, mem.m_nIndexShift );
+	CUtlSwap( m_pMemory, mem.m_pMemory );
+	CUtlSwap( m_nBlocks, mem.m_nBlocks );
+	CUtlSwap( m_nIndexMask, mem.m_nIndexMask );
+	CUtlSwap( m_nIndexShift, mem.m_nIndexShift );
+}
+
+template< class T, class I >
+CUtlBlockMemory<T,I>::CUtlBlockMemory( CUtlBlockMemory< T, I > &&mem )
+: m_pMemory( 0 ), m_nBlocks( 0 ), m_nIndexMask( 0 ), m_nIndexShift( 0 )
+{
+	Init( 0, 0 );
+	Swap( mem );
+}
+
+template <class T, class I>
+CUtlBlockMemory<T, I>& CUtlBlockMemory<T, I>::operator=(CUtlBlockMemory&& other)
+{
+	Swap( other );
+	return *this;
 }
 
 
@@ -156,6 +176,10 @@ void CUtlBlockMemory<T,I>::Init( int nGrowSize /* = 0 */, int nInitSize /* = 0 *
 		nGrowSize = ( 127 + sizeof( T ) ) / sizeof( T );
 	}
 	nGrowSize = SmallestPowerOfTwoGreaterOrEqual( nGrowSize );
+
+	//	P.S. If this changes then memory needs to be purged first,
+	//	since Purge() will try to destruct the memory using the value of m_nIndexMask
+	//	to determine bounds.
 	m_nIndexMask = nGrowSize - 1;
 
 	m_nIndexShift = 0;
@@ -253,6 +277,10 @@ void CUtlBlockMemory<T,I>::ChangeSize( int nBlocks )
 		// Only possible if m_pMemory is non-NULL (and avoids PVS-Studio warning)
 		for ( int i = m_nBlocks; i < nBlocksOld; ++i )
 		{
+			//	destruct blocks before freeing
+			for ( int j = 0; j < NumElementsInBlock(); ++j )
+				m_pMemory[ i ][ j ].~T();
+			
 			UTLBLOCKMEMORY_TRACK_FREE();
 			free( (void*)m_pMemory[ i ] );
 		}
@@ -279,6 +307,11 @@ void CUtlBlockMemory<T,I>::ChangeSize( int nBlocks )
 	{
 		MEM_ALLOC_CREDIT_CLASS();
 		m_pMemory[ i ] = (T*)malloc( nBlockSize * sizeof( T ) );
+
+		//	initialize freshly-allocated blocks
+		for ( int j = 0; j < nBlockSize; ++j )
+			new (&m_pMemory[ i ][ j ]) T();
+		
 		Assert( m_pMemory[ i ] );
 	}
 }
@@ -305,6 +338,10 @@ void CUtlBlockMemory<T,I>::Purge()
 
 	for ( int i = 0; i < m_nBlocks; ++i )
 	{
+		//	destruct blocks before freeing
+		for ( int j = 0; j < NumElementsInBlock(); ++j )
+			m_pMemory[ i ][ j ].~T();
+		
 		UTLBLOCKMEMORY_TRACK_FREE();
 		free( (void*)m_pMemory[ i ] );
 	}

--- a/src/public/tier1/utlblockmemory.h
+++ b/src/public/tier1/utlblockmemory.h
@@ -176,10 +176,7 @@ void CUtlBlockMemory<T,I>::Init( int nGrowSize /* = 0 */, int nInitSize /* = 0 *
 		nGrowSize = ( 127 + sizeof( T ) ) / sizeof( T );
 	}
 	nGrowSize = SmallestPowerOfTwoGreaterOrEqual( nGrowSize );
-
-	//	P.S. If this changes then memory needs to be purged first,
-	//	since Purge() will try to destruct the memory using the value of m_nIndexMask
-	//	to determine bounds.
+	
 	m_nIndexMask = nGrowSize - 1;
 
 	m_nIndexShift = 0;
@@ -277,10 +274,6 @@ void CUtlBlockMemory<T,I>::ChangeSize( int nBlocks )
 		// Only possible if m_pMemory is non-NULL (and avoids PVS-Studio warning)
 		for ( int i = m_nBlocks; i < nBlocksOld; ++i )
 		{
-			//	destruct blocks before freeing
-			for ( int j = 0; j < NumElementsInBlock(); ++j )
-				m_pMemory[ i ][ j ].~T();
-			
 			UTLBLOCKMEMORY_TRACK_FREE();
 			free( (void*)m_pMemory[ i ] );
 		}
@@ -307,10 +300,6 @@ void CUtlBlockMemory<T,I>::ChangeSize( int nBlocks )
 	{
 		MEM_ALLOC_CREDIT_CLASS();
 		m_pMemory[ i ] = (T*)malloc( nBlockSize * sizeof( T ) );
-
-		//	initialize freshly-allocated blocks
-		for ( int j = 0; j < nBlockSize; ++j )
-			new (&m_pMemory[ i ][ j ]) T();
 		
 		Assert( m_pMemory[ i ] );
 	}
@@ -338,10 +327,6 @@ void CUtlBlockMemory<T,I>::Purge()
 
 	for ( int i = 0; i < m_nBlocks; ++i )
 	{
-		//	destruct blocks before freeing
-		for ( int j = 0; j < NumElementsInBlock(); ++j )
-			m_pMemory[ i ][ j ].~T();
-		
 		UTLBLOCKMEMORY_TRACK_FREE();
 		free( (void*)m_pMemory[ i ] );
 	}

--- a/src/public/tier1/utllinkedlist.h
+++ b/src/public/tier1/utllinkedlist.h
@@ -44,6 +44,11 @@ struct UtlLinkedListElem_t
 	I  m_Previous;
 	I  m_Next;
 
+	UtlLinkedListElem_t() = default;
+	~UtlLinkedListElem_t() = default;
+	UtlLinkedListElem_t( UtlLinkedListElem_t<T, I>&& ) = default;
+	UtlLinkedListElem_t& operator=( UtlLinkedListElem_t<T, I>&& ) = default;
+	
 private:
 	// No copy constructor for these...
 	UtlLinkedListElem_t( const UtlLinkedListElem_t& );
@@ -70,6 +75,11 @@ public:
 	// constructor, destructor
 	CUtlLinkedList( int growSize = 0, int initSize = 0 );
 	~CUtlLinkedList();
+
+	// move operators
+	void Swap( CUtlLinkedList& other );
+	CUtlLinkedList( CUtlLinkedList&& other );
+	CUtlLinkedList& operator=( CUtlLinkedList&& other );
 
 	// gets particular elements
 	T&         Element( I i );
@@ -463,6 +473,38 @@ void CUtlLinkedList<T,S,ML,I,M>::ConstructList()
 	m_ElementCount = 0;
 	m_NumAlloced = 0;
 }
+
+//-----------------------------------------------------------------------------
+// move operators
+//-----------------------------------------------------------------------------
+
+template <class T, class S, bool ML, class I, class M>
+void CUtlLinkedList<T,S,ML,I,M>::Swap( CUtlLinkedList& other ) 
+{
+	CUtlSwap( m_Memory, other.m_Memory );
+	CUtlSwap( m_Head, other.m_Head );
+	CUtlSwap( m_Tail, other.m_Tail );
+	CUtlSwap( m_FirstFree, other.m_FirstFree );
+	CUtlSwap( m_ElementCount, other.m_ElementCount );
+	CUtlSwap( m_LastAlloc, other.m_LastAlloc );
+	CUtlSwap( m_pElements, other.m_pElements );
+	CUtlSwap( m_NumAlloced, other.m_NumAlloced );
+}
+
+template <class T, class S, bool ML, class I, class M>
+CUtlLinkedList<T, S, ML, I, M>::CUtlLinkedList(CUtlLinkedList&& other)
+	: m_Memory( 0, 0 ), m_LastAlloc( m_Memory.InvalidIterator() )
+{
+	Swap( other );
+}
+
+template <class T, class S, bool ML, class I, class M>
+CUtlLinkedList<T, S, ML, I, M>& CUtlLinkedList<T, S, ML, I, M>::operator=(CUtlLinkedList&& other)
+{
+	Swap(other);
+	return *this;
+}
+
 
 
 //-----------------------------------------------------------------------------

--- a/src/public/tier1/utlmemory.h
+++ b/src/public/tier1/utlmemory.h
@@ -431,10 +431,6 @@ CUtlMemory<T,I>::CUtlMemory( int nGrowSize, int nInitAllocationCount ) : m_pMemo
 		UTLMEMORY_TRACK_ALLOC();
 		MEM_ALLOC_CREDIT_CLASS();
 		m_pMemory = (T*)malloc( m_nAllocationCount * sizeof(T) );
-
-		//	Initialize the malloc'd memory using T's default constructor
-		for (int i = 0; i < m_nAllocationCount; i++)
-			new (&m_pMemory[i]) T();
 	}
 }
 
@@ -474,10 +470,6 @@ void CUtlMemory<T,I>::Init( int nGrowSize /*= 0*/, int nInitSize /*= 0*/ )
 		UTLMEMORY_TRACK_ALLOC();
 		MEM_ALLOC_CREDIT_CLASS();
 		m_pMemory = (T*)malloc( m_nAllocationCount * sizeof(T) );
-
-		//	Initialize the malloc'd memory using T's default constructor
-		for (int i = 0; i < m_nAllocationCount; i++)
-			new (&m_pMemory[i]) T();
 	}
 }
 
@@ -798,10 +790,6 @@ void CUtlMemory<T,I>::Grow( int num )
 	{
 		MEM_ALLOC_CREDIT_CLASS();
 		m_pMemory = (T*)realloc( m_pMemory, m_nAllocationCount * sizeof(T) );
-
-		//	initialize any freshly-allocated memory
-		for (int i = nOldAllocCount; i < m_nAllocationCount; i++)
-			new (&m_pMemory[i]) T();
 		
 		Assert( m_pMemory );
 	}
@@ -810,10 +798,6 @@ void CUtlMemory<T,I>::Grow( int num )
 		MEM_ALLOC_CREDIT_CLASS();
 		m_pMemory = (T*)malloc( m_nAllocationCount * sizeof(T) );
 
-		//	initialize all memory
-		for (int i = 0; i < m_nAllocationCount; i++)
-			new (&m_pMemory[i]) T();
-		
 		Assert( m_pMemory );
 	}
 }
@@ -846,20 +830,13 @@ inline void CUtlMemory<T,I>::EnsureCapacity( int num )
 	{
 		MEM_ALLOC_CREDIT_CLASS();
 		m_pMemory = (T*)realloc( m_pMemory, m_nAllocationCount * sizeof(T) );
-
-		//	initialize any freshly-allocated memory
-		for (int i = nOldAllocCount; i < m_nAllocationCount; ++i)
-			new (&m_pMemory[i]) T();
-
+		
+		Assert( m_pMemory );
 	}
 	else
 	{
 		MEM_ALLOC_CREDIT_CLASS();
 		m_pMemory = (T*)malloc( m_nAllocationCount * sizeof(T) );
-
-		//	initialize all memory
-		for (int i = 0; i < m_nAllocationCount; ++i)
-			new (&m_pMemory[i]) T();
 
 		Assert( m_pMemory );
 	}
@@ -877,10 +854,6 @@ void CUtlMemory<T,I>::Purge()
 		if (m_pMemory)
 		{
 			UTLMEMORY_TRACK_FREE();
-
-			//	Destruct any memory that will be going goodbye :(
-			for (int i = 0; i < m_nAllocationCount; ++i)
-				m_pMemory[i].~T();
 			
 			free( (void*)m_pMemory );
 			m_pMemory = 0;
@@ -929,11 +902,7 @@ void CUtlMemory<T,I>::Purge( int numElements )
 	}
 
 	UTLMEMORY_TRACK_FREE();
-
-	//	Destruct any memory that will be going goodbye :(
-	for (int i = numElements; i < m_nAllocationCount; ++i)
-		m_pMemory[i].~T();
-
+	
 	m_nAllocationCount = numElements;
 	
 	UTLMEMORY_TRACK_ALLOC();

--- a/src/public/tier1/utlmemory.h
+++ b/src/public/tier1/utlmemory.h
@@ -502,6 +502,7 @@ template <class T, class I>
 CUtlMemory<T, I>& CUtlMemory<T, I>::operator=(CUtlMemory&& other)
 {
 	Swap( other );
+	return *this;
 }
 
 
@@ -781,7 +782,6 @@ void CUtlMemory<T,I>::Grow( int num )
 		}
 	}
 
-	int nOldAllocCount = m_nAllocationCount;
 	m_nAllocationCount = nNewAllocationCount;
 
 	UTLMEMORY_TRACK_ALLOC();
@@ -821,7 +821,6 @@ inline void CUtlMemory<T,I>::EnsureCapacity( int num )
 
 	UTLMEMORY_TRACK_FREE();
 	
-	int nOldAllocCount = m_nAllocationCount;
 	m_nAllocationCount = num;
 
 	UTLMEMORY_TRACK_ALLOC();

--- a/src/public/tier1/utlmemory.h
+++ b/src/public/tier1/utlmemory.h
@@ -56,6 +56,10 @@ public:
 	CUtlMemory( const T* pMemory, int numElements );
 	~CUtlMemory();
 
+	//	move operators
+	CUtlMemory( CUtlMemory&& other );
+	CUtlMemory& operator=( CUtlMemory&& other );
+
 	// Set the size by which the memory grows
 	void Init( int nGrowSize = 0, int nInitSize = 0 );
 
@@ -483,10 +487,31 @@ void CUtlMemory<T,I>::Init( int nGrowSize /*= 0*/, int nInitSize /*= 0*/ )
 template< class T, class I >
 void CUtlMemory<T,I>::Swap( CUtlMemory<T,I> &mem )
 {
+	//	Both buffers need to be fully owned!
+	//	if one of the buffers is eg. CUtlMemoryFixedGrowable then this
+	//	swaps the ownership of the fixed buffer. No bueno!
+	//	alternative: would it make more sense to Assert( !IsExternallyAllocated() )?
+	ConvertToGrowableMemory(m_nGrowSize);
+	mem.ConvertToGrowableMemory(mem.m_nGrowSize);
+	
 	CUtlSwap( m_nGrowSize, mem.m_nGrowSize );
 	CUtlSwap( m_pMemory, mem.m_pMemory );
 	CUtlSwap( m_nAllocationCount, mem.m_nAllocationCount );
 }
+
+template <class T, class I>
+CUtlMemory<T, I>::CUtlMemory(CUtlMemory&& other)
+	: m_pMemory( 0 ), m_nAllocationCount( 0 )
+{
+	Swap( other );
+}
+
+template <class T, class I>
+CUtlMemory<T, I>& CUtlMemory<T, I>::operator=(CUtlMemory&& other)
+{
+	Swap( other );
+}
+
 
 
 //-----------------------------------------------------------------------------

--- a/src/public/tier1/utlswap.h
+++ b/src/public/tier1/utlswap.h
@@ -1,0 +1,42 @@
+//========= Copyright Valve Corporation, All rights reserved. ============//
+//
+// Purpose: defines copy&swap semantics for template library classes
+//
+//=============================================================================
+
+#ifndef UTLSWAP_H
+#define UTLSWAP_H
+
+/// Remove a reference
+template<typename T>
+struct CUtlRemoveReference {
+    typedef typename T Type;
+};
+
+template<typename T>
+struct CUtlRemoveReference<T&> {
+    typedef typename T Type;
+};
+
+template<typename T>
+struct CUtlRemoveReference<T&&> {
+    typedef typename T Type;
+};
+
+/// A black-box that ensures the provided argument is returned as an rvalue reference
+/// Move operators only need to ensure the original copy is assignable and destructable,
+/// while copy operators are more strict: both the original and clone must be valid for all operations.
+template<typename T>
+inline typename CUtlRemoveReference<T>::Type&& CUtlMove(T&& arg) {
+    return static_cast<typename CUtlRemoveReference<T>::Type&&>(arg);
+}
+
+/// Swap two objects using their move assignment operator.
+template<typename T>
+inline void CUtlSwap(T& a, T& b) {
+    T c = CUtlMove(a);
+    a = CUtlMove(b);
+    b = CUtlMove(c);
+}
+
+#endif //UTLSWAP_H


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
This PR aims to add support for move-constructors in the tier1 template library. This PR also adds move operators for some of the tier1 classes themselves so that they can have their resources transferred without invoking expensive copies.

*Ideally* every class should also be given a move operator, using the new CUtlSwap, but that's another big change that I don't have the heart for.

## Build Status

**Currently does not build**, will update as changes are made

## Todo
- [ ] Add required operators to every server/client class
- [ ] Add required operators to vgui
- [ ] Convince someone with engine licensing to patch up the whooole engine

## Why?
The tier1 template library was made before things like move semantics existed, and so they were designed around avoiding copies as much as possible. This was a fantastic idea up until move semantics came along, which promised some pretty neat performance benefits in exchange for always keeping memory initialized. 

It's 2025. It's *way* past time time to rip the band-aid off and allow the codebase to benefit from C++11 features.