### PR TITLE
all MP games: Fix PLAYER_FLAG_BITS truncating CBasePlayer::m_fFlags sent to clients

### DIFF
--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -8101,14 +8101,14 @@ void CMovementSpeedMod::InputSpeedMod(inputdata_t &data)
 	}
 }
 
-
-void SendProxy_CropFlagsToPlayerFlagBitsLength( const SendProp *pProp, const void *pStruct, const void *pVarData, DVariant *pOut, int iElement, int objectID)
+void SendProxy_CropFlagsToPlayerFlagBitsLength( const SendProp* pProp, const void* pStruct, const void* pVarData, DVariant* pOut, int iElement, int objectID )
 {
-	int mask = (1<<PLAYER_FLAG_BITS) - 1;
-	int data = *(int *)pVarData;
+	int mask = ( 1 << PLAYER_FLAG_BITS ) - 1;
+	int data = *( int* )pVarData;
 
 	pOut->m_Int = ( data & mask );
 }
+
 // -------------------------------------------------------------------------------- //
 // SendTable for CPlayerState.
 // -------------------------------------------------------------------------------- //

--- a/src/public/const.h
+++ b/src/public/const.h
@@ -163,7 +163,7 @@
 #define	FL_INWATER				(1<<10)	// In water
 
 // NOTE if you move things up, make sure to change this value
-#define PLAYER_FLAG_BITS		11
+#define PLAYER_FLAG_BITS		32
 
 #define	FL_FLY					(1<<11)	// Changes the SV_Movestep() behavior to not need to be on ground
 #define	FL_SWIM					(1<<12)	// Changes the SV_Movestep() behavior to not need to be on ground (but stay in water)


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

This PR fixes an oversight in all multiplayer Source 2013 games (TF, CS:S, DoD:S, HL1MP, HL2MP) caused by `PLAYER_FLAG_BITS` being set to a lower value than needed, which resulted in some player flags not being sent to clients.

For instance, it created a desync error when a player was pushed by a `trigger_push` entity, causing the client's view to be offset from the real position and breaking some community maps (example below).

The solution is to raise the value of the `PLAYER_FLAG_BITS` macro in `src/public/const.h` to 32 bits so no flags will be truncated.

https://github-production-user-asset-6210df.s3.amazonaws.com/48454166/417359472-d2e2ad0b-bd05-413c-b1d8-0d6da6898866.mp4
##### ^ before the fix was applied

https://github-production-user-asset-6210df.s3.amazonaws.com/48454166/417361827-4f7b8ef0-a68a-43fa-a7ae-b6063949272f.mp4
##### ^ after the fix was applied

Also closes issues:
- https://github.com/ValveSoftware/Source-1-Games/issues/7076
- https://github.com/ValveSoftware/Source-1-Games/issues/7085