### PR TITLE
[TF2] Fix engineer bots softlocking on CTF maps

### DIFF
--- a/src/game/server/tf/bot/behavior/engineer/tf_bot_engineer_build_teleport_entrance.cpp
+++ b/src/game/server/tf/bot/behavior/engineer/tf_bot_engineer_build_teleport_entrance.cpp
@@ -29,7 +29,8 @@ ActionResult< CTFBot >	CTFBotEngineerBuildTeleportEntrance::OnStart( CTFBot *me,
 ActionResult< CTFBot >	CTFBotEngineerBuildTeleportEntrance::Update( CTFBot *me, float interval )
 {
 	CTeamControlPoint *point = me->GetMyControlPoint();
-	if ( !point )
+	CCaptureZone *zone = me->GetFlagCaptureZone();
+	if ( !point && !zone )
 	{
 		// wait until a control point becomes available
 		return Continue();
@@ -64,7 +65,14 @@ ActionResult< CTFBot >	CTFBotEngineerBuildTeleportEntrance::Update( CTFBot *me, 
 	if ( !m_path.IsValid() )
 	{
 		CTFBotPathCost cost( me, FASTEST_ROUTE );
-		m_path.Compute( me, point->GetAbsOrigin(), cost );
+		if ( point )
+		{
+			m_path.Compute( me, point->GetAbsOrigin(), cost );
+		}
+		else if ( zone )
+		{
+			m_path.Compute( me, zone->WorldSpaceCenter(), cost );
+		}
 	}
 
 	m_path.Update( me );


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
Fixes engineer bots standing in their spawn without doing anything on Capture the Flag maps, by letting them head to their flag capture zone instead of waiting for a control point that doesn't exist.