### PR TITLE
tf2: Add convar to allow inspecting MvM upgrades

### DIFF
--- a/src/game/client/tf/tf_hud_inspectpanel.cpp
+++ b/src/game/client/tf/tf_hud_inspectpanel.cpp
@@ -29,6 +29,8 @@
 #include "tier0/memdbgon.h"
 
 
+extern ConVar tf_mvm_allow_upgrade_inspect;
+
 DECLARE_HUDELEMENT( CHudInspectPanel );
 
 static float s_flLastInspectDownTime = 0.f;
@@ -171,7 +173,7 @@ void CHudInspectPanel::UserCmd_InspectTarget( void )
 			// Inspect a player
 			else if ( pTargetPlayer && ( pTargetPlayer->GetTeamNumber() != TF_TEAM_PVE_INVADERS ) )
 			{
-				if ( !GetClientModeTFNormal()->BIsFriendOrPartyMember( pTargetPlayer ) )
+				if ( tf_mvm_allow_upgrade_inspect.GetInt() == 0 || ( tf_mvm_allow_upgrade_inspect.GetInt() == -1 && !GetClientModeTFNormal()->BIsFriendOrPartyMember( pTargetPlayer ) ) )
 				{
 					internalCenterPrint->Print( "#TF_Invalid_Inspect_Target" );
 					return;

--- a/src/game/shared/tf/tf_gamerules.cpp
+++ b/src/game/shared/tf/tf_gamerules.cpp
@@ -883,7 +883,7 @@ ConVar tf_mvm_respec_limit( "tf_mvm_respec_limit", "0", FCVAR_CHEAT | FCVAR_REPL
 ConVar tf_mvm_respec_credit_goal( "tf_mvm_respec_credit_goal", "2000", FCVAR_CHEAT | FCVAR_REPLICATED, "When tf_mvm_respec_limit is non-zero, the total amount of money the team must collect to earn a respec credit." );
 ConVar tf_mvm_buybacks_method( "tf_mvm_buybacks_method", "0", FCVAR_REPLICATED | FCVAR_HIDDEN, "When set to 0, use the traditional, currency-based system.  When set to 1, use finite, charge-based system.", true, 0.0, true, 1.0 );
 ConVar tf_mvm_buybacks_per_wave( "tf_mvm_buybacks_per_wave", "3", FCVAR_REPLICATED | FCVAR_HIDDEN, "The fixed number of buybacks players can use per-wave." );
-
+ConVar tf_mvm_allow_upgrade_inspect( "tf_mvm_allow_upgrade_inspect", "-1", FCVAR_REPLICATED, "Allow inspecting upgrades of other players. (-1 = Allow for friends and party members, 0 = Never allow, 1 = Always allow" );
 
 #ifdef GAME_DLL
 enum { kMVM_CurrencyPackMinSize = 1, };

--- a/src/game/shared/tf/tf_gamerules.cpp
+++ b/src/game/shared/tf/tf_gamerules.cpp
@@ -883,7 +883,7 @@ ConVar tf_mvm_respec_limit( "tf_mvm_respec_limit", "0", FCVAR_CHEAT | FCVAR_REPL
 ConVar tf_mvm_respec_credit_goal( "tf_mvm_respec_credit_goal", "2000", FCVAR_CHEAT | FCVAR_REPLICATED, "When tf_mvm_respec_limit is non-zero, the total amount of money the team must collect to earn a respec credit." );
 ConVar tf_mvm_buybacks_method( "tf_mvm_buybacks_method", "0", FCVAR_REPLICATED | FCVAR_HIDDEN, "When set to 0, use the traditional, currency-based system.  When set to 1, use finite, charge-based system.", true, 0.0, true, 1.0 );
 ConVar tf_mvm_buybacks_per_wave( "tf_mvm_buybacks_per_wave", "3", FCVAR_REPLICATED | FCVAR_HIDDEN, "The fixed number of buybacks players can use per-wave." );
-ConVar tf_mvm_allow_upgrade_inspect( "tf_mvm_allow_upgrade_inspect", "-1", FCVAR_REPLICATED, "Allow inspecting upgrades of other players. (-1 = Allow for friends and party members, 0 = Never allow, 1 = Always allow" );
+ConVar tf_mvm_allow_upgrade_inspect( "tf_mvm_allow_upgrade_inspect", "-1", FCVAR_REPLICATED, "Allow inspecting upgrades of other players. (-1 = Allow for friends and party members, 0 = Never allow, 1 = Always allow)" );
 
 #ifdef GAME_DLL
 enum { kMVM_CurrencyPackMinSize = 1, };


### PR DESCRIPTION
Currently you can only inspect the upgrades of Steam friends or matchmaking party members. This behavior is undesirable for community MvM servers and there is currently no way to change it.

This PR adds a new convar `tf_mvm_allow_upgrade_inspect` to allow server operators to modify the default behavior.

`-1` (default) = Current behavior (show only for friends and party members)
`0` = Never allow
`1` = Always allow