### PR TITLE
all MP games: Fix C4293 and C4307 in SendProxy_CropFlagsToPlayerFlagBitsLength (#867)

### DIFF
--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -8103,7 +8103,7 @@ void CMovementSpeedMod::InputSpeedMod(inputdata_t &data)
 
 void SendProxy_CropFlagsToPlayerFlagBitsLength( const SendProp* pProp, const void* pStruct, const void* pVarData, DVariant* pOut, int iElement, int objectID )
 {
-	int mask = ( 1 << PLAYER_FLAG_BITS ) - 1;
+	int mask = static_cast< unsigned >( 1 << PLAYER_FLAG_BITS ) - 1;
 	int data = *( int* )pVarData;
 
 	pOut->m_Int = ( data & mask );

--- a/src/public/const.h
+++ b/src/public/const.h
@@ -163,7 +163,7 @@
 #define	FL_INWATER				(1<<10)	// In water
 
 // NOTE if you move things up, make sure to change this value
-#define PLAYER_FLAG_BITS		32
+#define PLAYER_FLAG_BITS		31
 
 #define	FL_FLY					(1<<11)	// Changes the SV_Movestep() behavior to not need to be on ground
 #define	FL_SWIM					(1<<12)	// Changes the SV_Movestep() behavior to not need to be on ground (but stay in water)


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

Follow-up to PR https://github.com/ValveSoftware/source-sdk-2013/pull/862

This PR fixes MSVC warnings [C4293](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4293?view=msvc-170) (addresses issue https://github.com/ValveSoftware/source-sdk-2013/issues/867, thanks!) and [C4307](https://learn.microsoft.com/pl-pl/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4307?view=msvc-170) in `SendProxy_CropFlagsToPlayerFlagBitsLength` (`src/game/server/player.cpp@8104`).