### PR TITLE
[HL2MP] Fix compile error in HL2MP when using GLOWS_ENABLE

### DIFF
--- a/src/game/client/c_team_train_watcher.cpp
+++ b/src/game/client/c_team_train_watcher.cpp
@@ -8,10 +8,10 @@
 #include "c_team_train_watcher.h"
 #include "igameevents.h"
 #include "c_team_objectiveresource.h"
+#include "teamplayroundbased_gamerules.h"
 
 #ifdef TF_CLIENT_DLL
 #include "tf_shareddefs.h"
-#include "teamplayroundbased_gamerules.h"
 #endif
 
 // memdbgon must be the last include file in a .cpp file!!!


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
This pull request fixes a compile error in HL2MP when using the `GLOWS_ENABLE` preprocessor.

`GLOWS_ENABLE` enables code that can add glow outline effects on entities. It is used in TF2 by default, but it can be enabled for any SDK project. However, while it can be compiled as-is under base HL2, there is a dependency within an `#ifdef TF_CLIENT_DLL` in `c_team_train_watcher.cpp` which prevents it from compiling under HL2MP.

As this dependency (`teamplayroundbased_gamerules.h`) is not necessarily TF2-specific, this pull request moves the dependency outside of the `#ifdef`.