### PR TITLE
Fix debug build crash and CUtlBuffer assertion spam

### DIFF
--- a/src/game/shared/tf/tf_item_inventory.cpp
+++ b/src/game/shared/tf/tf_item_inventory.cpp
@@ -965,7 +965,9 @@ void CTFPlayerInventory::LoadLocalLoadout()
 
 					CEconItemView *pItem = GetInventoryItemByItemID(uItemId);
 					if (pItem) {
-						pItem->GetSOCData()->Equip(iClass, iSlot);
+						CEconItem* socData = pItem->GetSOCData();
+						if (socData)
+							socData->Equip(iClass, iSlot);
 					}
 				}
 			}

--- a/src/tier1/utlbuffer.cpp
+++ b/src/tier1/utlbuffer.cpp
@@ -219,7 +219,7 @@ CUtlBuffer::CUtlBuffer( int growSize, int initSize, int nFlags ) :
 CUtlBuffer::CUtlBuffer( const void *pBuffer, int nSize, int nFlags ) :
 	m_Memory( (unsigned char*)pBuffer, nSize ), m_Error(0)
 {
-	Assert( nSize != 0 );
+	Assert( nSize >= 0 );
 
 	m_Get = 0;
 	m_Put = 0;


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
Fixes CUtlBuffer assertion spam (https://developer.valvesoftware.com/wiki/SDK_Known_Issues_List#Assertion_Failed_in_utlbuffer.cpp) and makes failing to retrieve CEcomItem fail gracefully, allowing debug builds to run without crashing until the underlying issue with the inventory is fixed.
