### PR TITLE
Fix bonecache accepting validtimes set in the future.

### DIFF
--- a/src/game/client/c_baseanimating.cpp
+++ b/src/game/client/c_baseanimating.cpp
@@ -2321,7 +2321,7 @@ CBoneCache *C_BaseAnimating::GetBoneCache( CStudioHdr *pStudioHdr )
 	CBoneCache *pcache = Studio_GetBoneCache( m_hitboxBoneCacheHandle );
 	if ( pcache )
 	{
-		if ( pcache->IsValid( gpGlobals->curtime, 0.0 ) )
+		if ( pcache->IsValid( gpGlobals->curtime, 0.0 ) && pcache->m_timeValid <= gpGlobals->curtime )
 		{
 			// in memory and still valid, use it!
 			return pcache;


### PR DESCRIPTION
# Description
As mentioned in https://github.com/ValveSoftware/Source-1-Games/issues/6387, the bone cache will sometimes store a bad timestamp for validity.

This happens (iirc) whenever I.E. `C_BaseAnimating::TestHitboxes` gets called during interpolation, causing the updated bone cache to set it's valid timestamp to a future tick, which will cause subsequent cache checks (from I.E. the particle system) to assume the cache is still valid, even though it's not.

# Performance check
Obviously this will have a slight performance impact because:
- It now needs to do an extra comparison check.
- The more bad future times, the more bone setups because we can't trust the valid time.

I did do some performance checks on a listen server against 24 TFBots on `koth_viaduct` w/ `nb_update_frequency` lowered to `0.2` and `net_fakelag` set to `100` for a single round (roughly 3-6 minutes.)

**NOTE** this was taken from when the code was doing a similar full check like the server (minus the `BONE_USED_BY_BONE_MERGE` boneMask.)

```
-- Profile scopes sorted by time (without children) --
  Scope                               Calls Calls/Frame  Time+Child    Pct        Time    Pct   Avg/Frame    Avg/Call Avg-NoChild        Peak
  ----------------------------- ----------- ----------- ----------- ------ ----------- ------ ----------- ----------- ----------- -----------

-- CURRENT CODE --
    C_BaseAnimating::SetupBones     3173484      35.297   23482.872   8.05   15153.820   5.19       0.261       0.007       0.005       1.109
  C_BaseAnimating::GetBoneCache       85949       0.956     803.309   0.28      59.774   0.02       0.009       0.009       0.001       0.473

-- UPDATED CODE --
    C_BaseAnimating::SetupBones     3130401      45.331   21799.852   8.69   13954.061   5.56       0.316       0.007       0.004       1.130
  C_BaseAnimating::GetBoneCache       82985       1.202     757.432   0.30      57.675   0.02       0.011       0.009       0.001       0.520
```
# Regression check
As far as I can tell, this don't have any regression issues, I've tried it on a bot carrying the intelligence. I've tried it with a bot wearing an unusual via. itemtest. So far I've not been able to notice anything visual and/or game breaking.


Also yes I've read and understood the contributing agreement.