### PR TITLE
[TF2] Fix for Casual late-joiners seeing Competitive logo on Match Status HUD doors

### DIFF
--- a/src/game/client/tf/tf_hud_match_status.cpp
+++ b/src/game/client/tf/tf_hud_match_status.cpp
@@ -575,7 +575,7 @@ void CTFHudMatchStatus::FireGameEvent( IGameEvent * event )
 
 		const IMatchGroupDescription* pMatchDesc = GetMatchGroupDescription( TFGameRules()->GetCurrentMatchGroup() );
 
-		//FIX: Refresh versus doors so Casual late-joiners do not see the wrong skin
+		// FIX: Refresh versus doors so late-joiners do not see the wrong skin
 		int nSkin = 0;
 		int nSubModel = 0;
 		if (pMatchDesc->BGetRoundDoorParameters(nSkin, nSubModel))

--- a/src/game/client/tf/tf_hud_match_status.cpp
+++ b/src/game/client/tf/tf_hud_match_status.cpp
@@ -574,6 +574,17 @@ void CTFHudMatchStatus::FireGameEvent( IGameEvent * event )
 		}
 
 		const IMatchGroupDescription* pMatchDesc = GetMatchGroupDescription( TFGameRules()->GetCurrentMatchGroup() );
+
+		//FIX: Refresh versus doors so Casual late-joiners do not see the wrong skin
+		int nSkin = 0;
+		int nSubModel = 0;
+		if (pMatchDesc->BGetRoundDoorParameters(nSkin, nSubModel))
+		{
+			m_pMatchStartModelPanel->SetBodyGroup( "logos", nSubModel );
+			m_pMatchStartModelPanel->UpdateModel();
+			m_pMatchStartModelPanel->SetSkin( nSkin );
+		}
+
 		bool bForceDoors = false;
 		if ( bForceDoors || ( pMatchDesc && pMatchDesc->BUsesPostRoundDoors() ) )
 		{


### PR DESCRIPTION
Fixes https://github.com/ValveSoftware/Source-1-Games/issues/3516

Code has been updated to refresh the Match Status HUD doors' skin and submodel at the conclusion of a match. Check is similar to what is performed at start of match.

Due to Casual Mode's original behavior (no late joining, no abandoning) skin and submodel are currently only set at the beginning of a match for all gamemodes that support it. Late-joiners in Casual mode will see the Competitive logo at the end of the match if the model was not updated at the start of a previous match.

![image](https://github.com/user-attachments/assets/fadaf685-ceb5-4af2-894f-0a9757569324)
