### PR TITLE
[TF2] Toggleable BLU loading screen for Casual Matchmaking

### DIFF
--- a/src/game/client/tf/vgui/tf_statsummary.cpp
+++ b/src/game/client/tf/vgui/tf_statsummary.cpp
@@ -30,6 +30,8 @@
 #include "tf_gamerules.h"
 #include "tf_gc_client.h"
 
+extern ConVar tf_queue_spinner_color;
+
 using namespace vgui;
 
 #if defined( REPLAY_ENABLED )

--- a/src/game/shared/tf/tf_match_description_casual.cpp
+++ b/src/game/shared/tf/tf_match_description_casual.cpp
@@ -14,6 +14,7 @@
 	#include "tf_rating_data.h"
 #endif
 
+extern ConVar tf_queue_spinner_color;
 
 class CCasualMatchGroupDescription : public IMatchGroupDescription
 {
@@ -79,6 +80,11 @@ public:
 
 	virtual const char *GetMapLoadBackgroundOverride( bool bWidescreen ) const OVERRIDE
 	{
+		if( tf_queue_spinner_color.GetInt() != 0) // Added BLU Team representation
+		{
+			return (bWidescreen ? "../console/title_blue_widescreen" : "../console/title_blue");
+		}
+
 		return NULL;
 	}
 #endif


### PR DESCRIPTION
Updated CTFStatsSummaryPanel::UpdateMainBackground to include a check for tf_queue_spinner_color CVAR when a user is joining a Casual match.

If tf_queue_spinner_color != 0 (Blue TF2 Logo on queue UI), game will now load _console/title_blue_ loading background.

![image](https://github.com/user-attachments/assets/a93503ca-5a82-4172-991e-30edf62036d4)


https://github.com/user-attachments/assets/c07d9bad-69e6-4431-bd33-0cee33c25bc1

