### PR TITLE
Fix most medigun prediction errors

### DIFF
--- a/src/game/shared/tf/tf_weapon_medigun.cpp
+++ b/src/game/shared/tf/tf_weapon_medigun.cpp
@@ -1252,7 +1252,6 @@ bool CWeaponMedigun::FindAndHealTargets( void )
 
 			if ( pTFPlayer && weapon_medigun_charge_rate.GetFloat() )
 			{
-#ifdef GAME_DLL
 				int iBoostMax = floor( pTFPlayer->m_Shared.GetMaxBuffedHealth() * 0.95);
 				float flChargeModifier = 1.f;
 
@@ -1309,7 +1308,7 @@ bool CWeaponMedigun::FindAndHealTargets( void )
 
 				CALL_ATTRIB_HOOK_FLOAT_ON_OTHER( pOwner, flChargeAmount, mult_medigun_uberchargerate );
 
-
+#ifdef GAME_DLL
 				// Apply any bonus our target gives us.
 				if ( pTarget )
 				{
@@ -1322,6 +1321,7 @@ bool CWeaponMedigun::FindAndHealTargets( void )
 						CALL_ATTRIB_HOOK_FLOAT_ON_OTHER( pTarget, flChargeAmount, mult_uberchargerate_for_healer );
 					}
 				}
+#endif
 				if ( TFGameRules() )
 				{
 					if ( TFGameRules()->IsQuickBuildTime() )
@@ -1333,7 +1333,6 @@ bool CWeaponMedigun::FindAndHealTargets( void )
 						flChargeAmount *= 3.f;
 					}
 				}
-#endif
 
 				float flNewLevel = MIN( m_flChargeLevel + flChargeAmount, 1.0 );
 


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
Currently, healing people with any medigun will cause constant prediction errors, because the code which calculates how much ubercharge you get on any given tick is server only, unless you are lucky and are in a situation where you are getting exactly the default ubercharge per tick (stock medigun, damaged patient, no critheals, etc.)

This PR fixes that by making all possible server only code for this calculation also be on the client. The only exception to this is an unused weapon attribute which would modify ubercharge rate as long as you weren't in a respawn room. The functions it calls are server only, and would require changes to how respawn room entities are handled on the client to fix, so I decided that it would be out of scope for this PR.
Due to the one last part, I've simply moved the `#ifdef GAME_DLL` to only encompass that code rather than removing it entirely.

In my testing this change causes no issues.

I'm not entirely sure why it was server only in the first place? Maybe the idea was that the client doesn't really need to know the exact ubercharge percentage except in specific scenarios, but I don't think prediction errors every tick is a good tradeoff for the client running slightly less code for ubercharge calculations, especially for the medic. This bug is also known to cause heavy view jittering on listen servers, although it doesn't seem to be an issue on dedicated servers.