### PR TITLE
Fix Vaccinator charge sounds playing multiple times per tick

### DIFF
--- a/src/game/shared/tf/tf_weapon_medigun.cpp
+++ b/src/game/shared/tf/tf_weapon_medigun.cpp
@@ -1357,7 +1357,7 @@ bool CWeaponMedigun::FindAndHealTargets( void )
 				}
 
 #ifdef CLIENT_DLL
-					if ( GetMedigunType() == MEDIGUN_RESIST )
+					if ( GetMedigunType() == MEDIGUN_RESIST && prediction->IsFirstTimePredicted() )
 					{
 						// Play a sound when we tick over to a new charge level
 						int nChargeLevel = int(floor(flNewLevel/flMinChargeAmount));


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
Due to prediction, the `PrimaryAttack()` function runs multiple times every tick. Every time the function runs on a tick where the player gains a vaccinator charge, it will attempt to play the sound for reaching that charge, quickly stacking many of them in a single tick and becoming extremely loud. Commonly this will play 2 or 3, but in testing I've seen upwards of 7 or 8 playing at the same time.

This PR fixes this by adding the `IsFirstTimePredicted()` function to the code which checks if it should play the sound, preventing it from running except for the first time it is run during prediction on a tick. This function is already used in the medigun code to prevent other sounds related issues it seems, like playing the "deny" sound when attempting to use a vaccinator charge when you already have one of that effect, or when stopping playing the healing noise with auto-healing enabled.

This PR seems to work better in conjunction with #899, since prediction errors appear to cause the `PrimaryAttack()` function to run again with the "First Time Predicted" variable set to true again, causing it to play another sound even with this code.

In technicality, this does mean that this PR doesn't totally fix this issue, as prediction errors due to network instability may still cause the issue.
I'm not sure there is a proper way to fix that caveat, I previously had "fixed" it along with playing the sounds more than once with a bandaid fix I detailed in https://github.com/ValveSoftware/Source-1-Games/issues/4479, in which I created a new variable which incremented and decremented a variable when the player gained or used a charge, preventing the sound from playing if it had already reached that charge level, but I do not think its necessarily a fix worth implementing, especially when this PR does the idea arguably better in 1 line.

In my testing however, even with high lag the second sound that plays due to a prediction error in this case happened like half a second later, although the test was done with an artificially terrible network environment, a prediction error in a better networking scenario might play the sound closer to the first one.
There likely are also many other times in the game where a sound plays multiple times due to a prediction error, so fixing it just here would not be a good solution