### PR TITLE
[TF2] Fix empty weapon slots causing entire weapon selection to shift off-center vertically

### DIFF
--- a/src/game/client/tf/tf_hud_weaponselection.cpp
+++ b/src/game/client/tf/tf_hud_weaponselection.cpp
@@ -394,18 +394,36 @@ void CHudWeaponSelection::LevelShutdown( void )
 //-------------------------------------------------------------------------
 int CHudWeaponSelection::GetNumVisibleSlots()
 {
-	int nCount = 0;
+	if ( m_iMaxSlots <= 0 )
+		return 0;
 
-	// iterate over all the weapon slots
-	for ( int i = 0; i < m_iMaxSlots; i++ )
+	int nLastSlot = -1;
+	// find last non-empty slot
+	for ( int i = m_iMaxSlots - 1; i >= 0; i-- )
 	{
 		if ( GetFirstPos( i ) )
 		{
-			nCount++;
+			nLastSlot = i;
+			break;
 		}
 	}
 
-	return nCount;
+	int nFirstSlot = nLastSlot;
+	// find first non-empty slot
+	for ( int i = 0; i < nLastSlot; i++ )
+	{
+		if ( GetFirstPos( i ) )
+		{
+			nFirstSlot = i;
+			break;
+		}
+	}
+
+	if ( nLastSlot < 0 )
+		return 0;
+
+	// calc how many slots to draw including empty slots between those
+	return MAX( nLastSlot - nFirstSlot + 1, 0 );
 }
 
 
@@ -429,10 +447,14 @@ void CHudWeaponSelection::ComputeSlotLayout( SlotLayout_t *rSlot, int nActiveSlo
 			int nTotalHeight = ( nNumSlots - 1 ) * ( m_flSmallBoxTall + m_flBoxGap ) + m_flLargeBoxTall;
 			int xStartPos = GetWide() - m_flBoxGap - m_flRightMargin;
 			int ypos = ( GetTall() - nTotalHeight ) / 2;
+			bool bFoundFirstVisibleSlot = false;
 
 			// iterate over all the weapon slots
 			for ( int i = 0; i < m_iMaxSlots; i++ )
 			{
+				if ( !bFoundFirstVisibleSlot && GetFirstPos( i ) == NULL )
+					continue;
+				bFoundFirstVisibleSlot = true;
 				if ( i == nActiveSlot )
 				{
 					rSlot[i].wide = m_flLargeBoxWide;


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
As in title, empty weapon slots mess with the slot layout by using the vertical starting position of the number of visible weapons, rather than the entire span of weapon slots that are visible. This fixes that issue.

<details>
<summary>Screenshots: Unfixed (click to expand)</summary>

Unfixed: first and last weapon slots do not center around vertical center if weapons between them are missing
![image](https://github.com/user-attachments/assets/9b48371b-cd53-44e1-9440-a23bf02252e5)
![image](https://github.com/user-attachments/assets/b74ef900-ccdf-4eba-a0ef-fb6bc89c32e1)
![image](https://github.com/user-attachments/assets/0c29c4b8-d7cb-4899-a2d6-018f9df7077f)
![image](https://github.com/user-attachments/assets/9bcf3c04-603b-4cb0-bc5d-997f4e6692d2)
![image](https://github.com/user-attachments/assets/051b3021-c15a-4d4f-a178-6d17f1562f82)
![image](https://github.com/user-attachments/assets/fb94738f-16e2-435f-b8c9-c51eb260efa8)

</details>
<details>
<summary>Screenshots: Fixed (click to expand)</summary>

Fixed: first and last weapon slot are always centered around vertical center of the HUD even with missing slots
![image](https://github.com/user-attachments/assets/b5d507b5-724a-42fc-b733-6f65f6d95332)3
![image](https://github.com/user-attachments/assets/9476e015-c0db-406b-a122-71ecbbc199ec)
![image](https://github.com/user-attachments/assets/dd20b2d2-eda5-4101-92e9-1b77fa29e44f)
![image](https://github.com/user-attachments/assets/b7a5cabd-7a30-430a-ac84-871d65624a85)
![image](https://github.com/user-attachments/assets/0c6d89ca-9d00-4fd2-b37f-3ac2deb90661)
![image](https://github.com/user-attachments/assets/502aae80-211d-43cc-8d89-5e094aa3cd60)

</details>