### PR TITLE
Change functionality of tf spells enabled

### DIFF
--- a/src/game/server/tf/halloween/spell/tf_spell_pickup.cpp
+++ b/src/game/server/tf/halloween/spell/tf_spell_pickup.cpp
@@ -31,6 +31,11 @@ void CSpellPickup::Spawn( void )
 {
 	BaseClass::Spawn();
 	m_nSkin = m_nTier;
+
+	if ( !TFGameRules()->IsUsingSpells() )
+	{
+		SetDisabled( true );
+	}
 }
 
 //-----------------------------------------------------------------------------

--- a/src/game/shared/tf/halloween/tf_weapon_spellbook.cpp
+++ b/src/game/shared/tf/halloween/tf_weapon_spellbook.cpp
@@ -1065,6 +1065,9 @@ void CTFSpellBook::CreateSpellJar( const Vector &position, const QAngle &angles,
 //-----------------------------------------------------------------------------
 void CTFSpellBook::RollNewSpell( int iTier, bool bForceReroll /*= false*/ )
 {
+	if ( !TFGameRules()->IsUsingSpells() )
+	return;
+	
 	// do not do anything if we already have a spell for low tier, always roll for high tier
 	if ( m_iSpellCharges > 0 && iTier == 0 && !bForceReroll )
 		return;

--- a/src/game/shared/tf/tf_gamerules.cpp
+++ b/src/game/shared/tf/tf_gamerules.cpp
@@ -741,7 +741,7 @@ ConVar tf_force_holidays_off( "tf_force_holidays_off", "0", FCVAR_NOTIFY | FCVAR
 #endif // GAME_DLL
 );
 ConVar tf_birthday( "tf_birthday", "0", FCVAR_NOTIFY | FCVAR_REPLICATED );
-ConVar tf_spells_enabled( "tf_spells_enabled", "0", FCVAR_NOTIFY | FCVAR_REPLICATED, "Enable to Allow Halloween Spells to be dropped and used by players" );
+ConVar tf_spells_enabled( "tf_spells_enabled", "-1", FCVAR_NOTIFY | FCVAR_REPLICATED, "-1 Default (Map-based)\n0 - Force off\n1 - Force on" );
 
 ConVar tf_caplinear( "tf_caplinear", "1", FCVAR_REPLICATED | FCVAR_DEVELOPMENTONLY, "If set to 1, teams must capture control points linearly." );
 ConVar tf_stalematechangeclasstime( "tf_stalematechangeclasstime", "20", FCVAR_REPLICATED | FCVAR_DEVELOPMENTONLY, "Amount of time that players are allowed to change class in stalemates." );
@@ -3661,9 +3661,15 @@ CTFGameRules::HalloweenScenarioType CTFGameRules::GetHalloweenScenario( void ) c
 //-----------------------------------------------------------------------------
 bool CTFGameRules::IsUsingSpells( void ) const
 {
-	if ( tf_spells_enabled.GetBool() )
+	if ( tf_spells_enabled.GetInt() == 0 )
+	{
+		return false;
+	}
+	else if ( tf_spells_enabled.GetInt() > 0 )
+	{
 		return true;
-
+	}
+	
 	if ( IsHalloweenScenario( CTFGameRules::HALLOWEEN_SCENARIO_HIGHTOWER ) )
 		return true;
 


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
This PR changes the functionality of "tf_spells_enabled" to actually manage the usage of spells and not just the HUD indicator.
Spells spawned in via tf_spell_pickup map entities / bosses still work regardless of the setting as is. https://developer.valvesoftware.com/wiki/Tf_logic_holiday#Inputs

## Changes
- `tf_spells_enabled` now has a default value of -1, which imitates normal behavior.
- `CTFGameRules::IsUsingSpells` now returns false if `tf_spells_enabled` is set to `0`.
- `tf_spell_pickup` entities are disabled on round start if `tf_spells_enabled` is set to `0`.
- `CTFSpellBook::RollNewSpell` now returns immediately if `CTFGameRules::IsUsingSpells` returns false.

