### PR TITLE
[TF2] Make engineer bots care about teleporters

### DIFF
--- a/src/game/server/tf/bot/behavior/engineer/tf_bot_engineer_building.cpp
+++ b/src/game/server/tf/bot/behavior/engineer/tf_bot_engineer_building.cpp
@@ -231,6 +231,41 @@ bool CTFBotEngineerBuilding::IsInPositionToWork(
 }
 
 //---------------------------------------------------------------------------------------------
+// Proccesses navigation towards ideal working spot
+void CTFBotEngineerBuilding::NavigateToWorkingSpot( CTFBot* me, const Vector& spot )
+{
+	if ( m_repathTimer.IsElapsed() )
+	{
+		// Periodically recalculate the path in case if our building... teleports... I guess...
+		m_repathTimer.Start( RandomFloat( 1.0f, 2.0f ) );
+
+		CTFBotPathCost cost( me, FASTEST_ROUTE );
+		m_path.Compute( me, spot, cost );
+	}
+
+	// Go to building
+	m_path.Update( me );
+}
+
+//---------------------------------------------------------------------------------------------
+// Proccesses maintaining buildings
+void CTFBotEngineerBuilding::MaintainBuilding(CTFBot* me, CBaseObject* workTarget)
+{
+	// we are in position - work on our buildings
+	me->StopLookingAroundForEnemies();
+	me->GetBodyInterface()->AimHeadTowards( LookAtPointOnWorkTarget( me, workTarget ), IBody::CRITICAL, 1.0f, NULL, "Work on my buildings" );
+	me->PressFireButton();
+}
+
+//---------------------------------------------------------------------------------------------
+// Returns a point on the work target which engineers should be looking at 
+// when they maintain their buildings 
+const Vector& CTFBotEngineerBuilding::LookAtPointOnWorkTarget(CTFBot* me, CBaseObject* workTarget) const
+{
+	return workTarget->WorldSpaceCenter();
+}
+
+//---------------------------------------------------------------------------------------------
 // Everything is built, upgrade/maintain it
 // TODO: Upgrade/maintain nearby friendly buildings, too.
 void CTFBotEngineerBuilding::UpgradeAndMaintainBuildings( CTFBot *me )

--- a/src/game/server/tf/bot/behavior/engineer/tf_bot_engineer_building.cpp
+++ b/src/game/server/tf/bot/behavior/engineer/tf_bot_engineer_building.cpp
@@ -62,6 +62,24 @@ ActionResult< CTFBot >	CTFBotEngineerBuilding::OnStart( CTFBot *me, Action< CTFB
 	return Continue();
 }
 
+//---------------------------------------------------------------------------------------------
+// Return whichever teleporter is the closest if both are built. 
+// Otherwise returns whichever is built or NULL if none
+CObjectTeleporter* PickClosestTeleporter( CTFBot* me )
+{
+	CObjectTeleporter *myTeleporterEntrance =
+		static_cast< CObjectTeleporter* >( me->GetObjectOfType( OBJ_TELEPORTER, MODE_TELEPORTER_ENTRANCE ) );
+	CObjectTeleporter *myTeleporterExit =
+		static_cast< CObjectTeleporter* >( me->GetObjectOfType( OBJ_TELEPORTER, MODE_TELEPORTER_EXIT ) );
+
+	if ( !myTeleporterEntrance && !myTeleporterExit ) return NULL;
+	if ( myTeleporterEntrance && !myTeleporterExit ) return myTeleporterEntrance;
+	if ( !myTeleporterEntrance && !myTeleporterExit ) return myTeleporterExit;
+
+	return 
+		me->GetDistanceBetween( myTeleporterEntrance ) < me->GetDistanceBetween( myTeleporterExit )
+		? myTeleporterEntrance : myTeleporterExit;
+}
 
 //---------------------------------------------------------------------------------------------
 // Everything is built, upgrade/maintain it
@@ -75,6 +93,8 @@ void CTFBotEngineerBuilding::UpgradeAndMaintainBuildings( CTFBot *me )
 	{
 		return;
 	}
+
+	CObjectTeleporter *myClosestTeleporter = PickClosestTeleporter( me );
 
 	CBaseCombatWeapon *wrench = me->Weapon_GetSlot( TF_WPN_TYPE_MELEE );
 	if ( wrench )

--- a/src/game/server/tf/bot/behavior/engineer/tf_bot_engineer_building.cpp
+++ b/src/game/server/tf/bot/behavior/engineer/tf_bot_engineer_building.cpp
@@ -196,7 +196,7 @@ bool CTFBotEngineerBuilding::IsInPositionToWork(
 	// Should duck not only to cover but also to approach the target more precisely
 	shouldBeDucking = curDistanceToPosition < 1.2f * tooFarRange;
 
-	if ( curDistanceToPosition < tooFarRange ) return false;
+	if ( curDistanceToPosition > tooFarRange ) return false;
 	
 	if ( workTarget->GetType() == OBJ_SENTRYGUN || workTarget->GetType() == OBJ_DISPENSER )
 	{
@@ -217,7 +217,7 @@ bool CTFBotEngineerBuilding::IsInPositionToWork(
 		if (sentry && dispencer)
 		{
 			// ... and 'inbetween' means the difference between distances to 
-			// both engineer and both buildings should be about equal
+			// engineer and both his buildings should be about equal
 			const float equalityTolerance = 25.0f;
 
 			const float sentryDistance = me->GetDistanceBetween( sentry );

--- a/src/game/server/tf/bot/behavior/engineer/tf_bot_engineer_building.h
+++ b/src/game/server/tf/bot/behavior/engineer/tf_bot_engineer_building.h
@@ -60,6 +60,10 @@ private:
 	CBaseObject* PickCurrentWorkTarget( CTFBot *me ) const;
 	Vector PickIdealWorkSpot( CTFBot *me, CBaseObject *workTarget ) const;
 	bool IsInPositionToWork( CTFBot *me, CBaseObject *workTarget, bool& shouldBeDucking, const Vector* idealPosition = NULL ) const;
+	void NavigateToWorkingSpot( CTFBot *me, const Vector& spot );
+	void MaintainBuilding( CTFBot *me, CBaseObject *workTarget );
+	const Vector& LookAtPointOnWorkTarget( CTFBot *me, CBaseObject *workTarget ) const;
+
 	void UpgradeAndMaintainBuildings( CTFBot *me );
 	bool IsMetalSourceNearby( CTFBot *me ) const;
 };

--- a/src/game/server/tf/bot/behavior/engineer/tf_bot_engineer_building.h
+++ b/src/game/server/tf/bot/behavior/engineer/tf_bot_engineer_building.h
@@ -56,6 +56,14 @@ private:
 	bool m_isSentryOutOfPosition;
 	bool CheckIfSentryIsOutOfPosition( CTFBot *me ) const;
 
+	CObjectSentrygun *m_mySentry = NULL;
+	CObjectDispenser *m_myDispencer = NULL;
+	CObjectTeleporter *m_myClosestTeleporter = NULL;
+
+	CObjectTeleporter* PickClosestValidTeleporter( CTFBot *me ) const;
+	CBaseObject* PickCurrentWorkTarget( CTFBot *me ) const;
+	Vector PickIdealWorkSpot( CTFBot *me, CBaseObject *workTarget ) const;
+	bool IsTooFarFromWorkTarget( CTFBot *me, CBaseObject *workTarget ) const;
 	void UpgradeAndMaintainBuildings( CTFBot *me );
 	bool IsMetalSourceNearby( CTFBot *me ) const;
 };

--- a/src/game/server/tf/bot/behavior/engineer/tf_bot_engineer_building.h
+++ b/src/game/server/tf/bot/behavior/engineer/tf_bot_engineer_building.h
@@ -56,14 +56,10 @@ private:
 	bool m_isSentryOutOfPosition;
 	bool CheckIfSentryIsOutOfPosition( CTFBot *me ) const;
 
-	CObjectSentrygun *m_mySentry = NULL;
-	CObjectDispenser *m_myDispencer = NULL;
-	CObjectTeleporter *m_myClosestTeleporter = NULL;
-
 	CObjectTeleporter* PickClosestValidTeleporter( CTFBot *me ) const;
 	CBaseObject* PickCurrentWorkTarget( CTFBot *me ) const;
 	Vector PickIdealWorkSpot( CTFBot *me, CBaseObject *workTarget ) const;
-	bool IsTooFarFromWorkTarget( CTFBot *me, CBaseObject *workTarget ) const;
+	bool IsInPositionToWork( CTFBot *me, CBaseObject *workTarget, bool& shouldBeDucking, const Vector* idealPosition = NULL ) const;
 	void UpgradeAndMaintainBuildings( CTFBot *me );
 	bool IsMetalSourceNearby( CTFBot *me ) const;
 };


### PR DESCRIPTION
This is a slight rework that now makes engineer bots remove sappers/repair/upgrade their teleporters like any other buildings. In order to not have these changes deviate their behavior from the original too much, teleporters are prioritized the least (in particular, they only repair teleporters when every other building is already at full health, upgrade them when every other is already upgraded, and remove sappers when all other buildings don't have sappers on them). Also comes with reordering and splitting original building maintenance code into separate functions for ease of further modification

https://github.com/user-attachments/assets/c1cc5693-b57f-4ebf-81ab-c271da76eee0


https://github.com/user-attachments/assets/8fc45326-4ecd-41c4-8b65-021ec8eb2767

