### PR TITLE
show the actual path of steam_api.dll instead of printf formatting

### DIFF
--- a/src/launcher_main/main.cpp
+++ b/src/launcher_main/main.cpp
@@ -157,7 +157,7 @@ static bool LoadSteam( const char *pRootDir )
 	s_SteamModule = Launcher_LoadModule(szPathBuffer);
 	if ( !s_SteamModule )
 	{
-		char szErrorBuffer[4096];
+		char szErrorBuffer[4140];
 		_snprintf(szErrorBuffer, sizeof(szErrorBuffer), "Not able to load Steam API. Is %s missing?", szPathBuffer);
 		szErrorBuffer[sizeof(szErrorBuffer) - 1] = '\0';
 	

--- a/src/launcher_main/main.cpp
+++ b/src/launcher_main/main.cpp
@@ -149,15 +149,19 @@ static bool LoadSteam( const char *pRootDir )
 	#define STEAM_API_DLL_PATH	"%s/" PLATFORM_BIN_DIR "/libsteam_api.so"
 #endif
 
-	char szBuffer[4096];
+	char szPathBuffer[4096];
 	// Assemble the full path to our "steam_api.dll"
-	_snprintf( szBuffer, sizeof( szBuffer ), STEAM_API_DLL_PATH, pRootDir );
-	szBuffer[sizeof( szBuffer ) - 1] = '\0';
-
-	s_SteamModule = Launcher_LoadModule( szBuffer );
+	_snprintf(szPathBuffer, sizeof(szPathBuffer), STEAM_API_DLL_PATH, pRootDir );
+	szPathBuffer[sizeof(szPathBuffer) - 1] = '\0';
+	
+	s_SteamModule = Launcher_LoadModule(szPathBuffer);
 	if ( !s_SteamModule )
 	{
-		MessageBox( 0, "Not able to load Steam API. Is " STEAM_API_DLL_PATH " missing?", "Launcher Error", MB_OK );
+		char szErrorBuffer[4096];
+		_snprintf(szErrorBuffer, sizeof(szErrorBuffer), "Not able to load Steam API. Is %s missing?", szPathBuffer);
+		szErrorBuffer[sizeof(szErrorBuffer) - 1] = '\0';
+	
+		MessageBox( 0, szErrorBuffer, "Launcher Error", MB_OK );
 		return false;
 	}
 


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

normally if launcher fails to find steam_api.dll, an error message with the printf formatting gets shown instead of the actual path to where the dll is supposed to be
