### PR TITLE
Fix bots never using their Seek and Destroy (Deathmatch AI)

### DIFF
--- a/src/game/server/tf/bot/behavior/tf_bot_seek_and_destroy.cpp
+++ b/src/game/server/tf/bot/behavior/tf_bot_seek_and_destroy.cpp
@@ -87,6 +87,17 @@ ActionResult< CTFBot >	CTFBotSeekAndDestroy::Update( CTFBot *me, float interval 
 		{
 			return Done( "Time to push for the objective" );
 		}
+
+
+		// Added proper fix to the bot offense push time bug that causes seek and destroy to never happen
+		// Basically just check for these gamemodes and otherwise allow seek and destroy at all times
+		if (TFGameRules()->GetGameType() == TF_GAMETYPE_ESCORT || TFGameRules()->GetGameType() == TF_GAMETYPE_CP)
+		{
+			if (!TFGameRules()->RoundHasBeenWon() && me->GetTimeLeftToCapture() < tf_bot_offense_must_push_time.GetFloat())
+			{
+				return Done("Time to push for the objective");
+			}
+		}
 	}
 
 	const CKnownEntity *threat = me->GetVisionInterface()->GetPrimaryKnownThreat();


### PR DESCRIPTION
# Description

Bots are intended to deathmatch when they don't understand the current gamemode. This feature was eventually broken when the cvar tf_bot_offense_must_push_time was added to the game. This check is only relevant in specific gamemodes.

Since only specific gamemodes account for this logic, it causes them to not go into their "deathmatch" mode when they're supposed to. I added a check for said gamemodes so they will still use "seek and destroy" logic if there is no other supported gamemode logic to go by.