### PR TITLE
Fix players clipping through displacements by uncrouching

### DIFF
--- a/src/game/shared/gamemovement.cpp
+++ b/src/game/shared/gamemovement.cpp
@@ -4059,6 +4059,7 @@ void CGameMovement::FixPlayerCrouchStuck( bool upward )
 	mv->SetAbsOrigin( test ); // Failed
 }
 
+[[gnu::optimize("no-associative-math")]]
 bool CGameMovement::CanUnduck()
 {
 	int i;
@@ -4098,6 +4099,7 @@ bool CGameMovement::CanUnduck()
 //-----------------------------------------------------------------------------
 // Purpose: Stop ducking
 //-----------------------------------------------------------------------------
+[[gnu::optimize("no-associative-math")]]
 void CGameMovement::FinishUnDuck( void )
 {
 	int i;
@@ -4202,6 +4204,7 @@ void CGameMovement::FinishUnDuckJump( trace_t &trace )
 //-----------------------------------------------------------------------------
 // Purpose: Finish ducking
 //-----------------------------------------------------------------------------
+[[gnu::optimize("no-associative-math")]]
 void CGameMovement::FinishDuck( void )
 {
 	if ( player->GetFlags() & FL_DUCKING )


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
On servers hosted on Linux it is possible that the origin calculated in ducking-related functions gets slightly horizontally shifted because of floating point precision errors. This only happens around powers of 2 and is caused by the compiler being allowed to reorder the instructions to something mathematically equivalent (`-ffast-math`). The expressions as they are written in the code would not lead to this kind of error happening, so the fix is to simply tell the compiler not to reorder the instructions in the relevant functions (`CGameMovement::CanUnduck`, `CGameMovement::FinishUnDuck`, `CGameMovement::FinishDuck`).

This fixes an exploit that let players uncrouch into displacements because `CanUnduck` incorrectly reported that there was nothing above the player whereafter `FinishUnDuck` moved the player into the displacement. `FinishUnDuck` (after `CanUnduck` fix) and `FinishDuck` could also let players clip into geometry by themselves, but it was a lot harder to find and perform as the player needed to get really close to the surface before uncrouching or crouching for anything to happen (usually done by wiggling in the air).

Videos of `CanUnduck`+`FinishUnDuck` and `FinishDuck` causing the player to clip into the geometry. Notice the stuck messages in the top right. The player automatically gets teleported out if they don't move by the regularly occurring unstuck routine.

https://github.com/user-attachments/assets/436e9adc-4725-4945-ae0f-f5152feefdb6

https://github.com/user-attachments/assets/d4f95f1b-06c0-4c58-b747-b954aabca3f6

