### PR TITLE
[TF2] Make the Playermodel in the HUD use the players custom model if applicable

### DIFF
--- a/src/game/client/tf/tf_hud_playerstatus.cpp
+++ b/src/game/client/tf/tf_hud_playerstatus.cpp
@@ -446,6 +446,7 @@ void CTFHudPlayerClass::UpdateModelPanel()
 		int nClass;
 		int nTeam;
 		int nItemSlot = m_nLoadoutPosition;
+		const char* pszcustommodels = "";
 		CEconItemView *pWeapon = NULL;
 
 		bool bDisguised = pPlayer->m_Shared.InCond( TF_COND_DISGUISED );
@@ -474,10 +475,21 @@ void CTFHudPlayerClass::UpdateModelPanel()
 			{
 				pWeapon = pEnt->GetAttributeContainer()->GetItem();
 			}
+			if (pPlayer->GetPlayerClass()->HasCustomModel())
+			{
+				pszcustommodels = pPlayer->GetPlayerClass()->GetModelName();
+			}
 		}
 
 		m_pPlayerModelPanel->ClearCarriedItems();
-		m_pPlayerModelPanel->SetToPlayerClass( nClass );
+		if (pszcustommodels)
+		{
+			m_pPlayerModelPanel->SetToPlayerClass(nClass,false,pszcustommodels);
+		}
+		else
+		{ 
+			m_pPlayerModelPanel->SetToPlayerClass( nClass);
+		}
 		m_pPlayerModelPanel->SetTeam( nTeam );
 
 		if ( pWeapon )

--- a/src/game/client/tf/tf_hud_playerstatus.cpp
+++ b/src/game/client/tf/tf_hud_playerstatus.cpp
@@ -475,20 +475,20 @@ void CTFHudPlayerClass::UpdateModelPanel()
 			{
 				pWeapon = pEnt->GetAttributeContainer()->GetItem();
 			}
-			if (pPlayer->GetPlayerClass()->HasCustomModel())
+			if ( pPlayer->GetPlayerClass()->HasCustomModel() )
 			{
 				pszcustommodels = pPlayer->GetPlayerClass()->GetModelName();
 			}
 		}
 
 		m_pPlayerModelPanel->ClearCarriedItems();
-		if (pszcustommodels)
+		if ( pszcustommodels )
 		{
-			m_pPlayerModelPanel->SetToPlayerClass(nClass,false,pszcustommodels);
+			m_pPlayerModelPanel->SetToPlayerClass( nClass, false, pszcustommodels );
 		}
 		else
 		{ 
-			m_pPlayerModelPanel->SetToPlayerClass( nClass);
+			m_pPlayerModelPanel->SetToPlayerClass( nClass );
 		}
 		m_pPlayerModelPanel->SetTeam( nTeam );
 

--- a/src/game/client/tf/vgui/tf_clientscoreboard.cpp
+++ b/src/game/client/tf/vgui/tf_clientscoreboard.cpp
@@ -266,7 +266,15 @@ void CTFClientScoreBoardDialog::UpdatePlayerModel()
 	}
 
 	m_pPlayerModelPanel->ClearCarriedItems();
-	m_pPlayerModelPanel->SetToPlayerClass( nClass );
+	if (pPlayer->GetPlayerClass()->HasCustomModel())
+	{
+		const char* pszcustommodels = pPlayer->GetPlayerClass()->GetModelName();
+		m_pPlayerModelPanel->SetToPlayerClass(nClass, false, pszcustommodels);
+	}
+	else
+	{
+		m_pPlayerModelPanel->SetToPlayerClass(nClass);
+	}
 	m_pPlayerModelPanel->SetTeam( nTeam );
 
 	if ( pWeapon )

--- a/src/game/client/tf/vgui/tf_clientscoreboard.cpp
+++ b/src/game/client/tf/vgui/tf_clientscoreboard.cpp
@@ -266,14 +266,14 @@ void CTFClientScoreBoardDialog::UpdatePlayerModel()
 	}
 
 	m_pPlayerModelPanel->ClearCarriedItems();
-	if (pPlayer->GetPlayerClass()->HasCustomModel())
+	if ( pPlayer->GetPlayerClass()->HasCustomModel() )
 	{
 		const char* pszcustommodels = pPlayer->GetPlayerClass()->GetModelName();
-		m_pPlayerModelPanel->SetToPlayerClass(nClass, false, pszcustommodels);
+		m_pPlayerModelPanel->SetToPlayerClass (nClass, false, pszcustommodels );
 	}
 	else
 	{
-		m_pPlayerModelPanel->SetToPlayerClass(nClass);
+		m_pPlayerModelPanel->SetToPlayerClass( nClass );
 	}
 	m_pPlayerModelPanel->SetTeam( nTeam );
 

--- a/src/game/client/tf/vgui/tf_playermodelpanel.cpp
+++ b/src/game/client/tf/vgui/tf_playermodelpanel.cpp
@@ -530,7 +530,7 @@ void CTFPlayerModelPanel::SwitchHeldItemTo( CEconItemView *pItem )
 		}
 		else
 		{
-			SetToPlayerClass( m_iCurrentClassIndex ,false, m_strPlayerModelOverride);
+			SetToPlayerClass( m_iCurrentClassIndex, false, m_strPlayerModelOverride );
 		}
 	}
 

--- a/src/game/client/tf/vgui/tf_playermodelpanel.cpp
+++ b/src/game/client/tf/vgui/tf_playermodelpanel.cpp
@@ -530,7 +530,7 @@ void CTFPlayerModelPanel::SwitchHeldItemTo( CEconItemView *pItem )
 		}
 		else
 		{
-			SetToPlayerClass( m_iCurrentClassIndex );
+			SetToPlayerClass( m_iCurrentClassIndex ,false, m_strPlayerModelOverride);
 		}
 	}
 


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
Currently the Playermodel Panel will always display the classes default model (or the Yeti model if the corresponding taunt is used), Which causes a discrepancy if the Map or Server changes the players model.

This PR changes the behavior for the Playerstatus Panel and the scoreboard to use the players custom model if they have one set.

Gamemodes like VSH and ZI which were added officially would benefit from this change as they use custom models for the players.

playerstatus before:
![grafik](https://github.com/user-attachments/assets/87c8cfcf-d158-45a7-9474-e277b0281a17)


playerstatus after:
![grafik](https://github.com/user-attachments/assets/ade3aeb1-071b-4b85-a201-5281763b8749)

scoreboard before:
![grafik](https://github.com/user-attachments/assets/d31c3edc-f1a9-459c-9286-69e2a8826b01)

scoreboard after:
![grafik](https://github.com/user-attachments/assets/df203e88-4a0c-4a83-9ec1-2e0b9afb36d3)
