### PR TITLE
[TF2] Prevent players with a lot of speed into a ramp from getting grounded

### DIFF
--- a/src/game/shared/gamemovement.h
+++ b/src/game/shared/gamemovement.h
@@ -180,15 +180,6 @@ protected:
 	// Does not change the entities velocity at all
 	void			PushEntity( Vector& push, trace_t *pTrace );
 
-	// Slide off of the impacting object
-	// returns the blocked flags:
-	// 0x01 == floor
-	// 0x02 == step / wall
-	//
-	// redirectCoeff - multiplier on the clipped velocity to apply along their new direction. 0 -> stomp into-normal
-	//                 velocity, 1 -> redirect it all along new vector.
-	int				ClipVelocity( Vector& in, Vector& normal, Vector& out, float overbounce, float redirectCoeff = 0.f );
-
 	// If pmove.origin is in a solid position,
 	// try nudging slightly on all axis to
 	// allow for the cut precision of the net coordinates
@@ -257,6 +248,14 @@ protected:
 
 
 protected:
+	// Slide off of the impacting object
+	// returns the blocked flags:
+	// 0x01 == floor
+	// 0x02 == step / wall
+	//
+	// redirectCoeff - multiplier on the clipped velocity to apply along their new direction. 0 -> stomp into-normal
+	//                 velocity, 1 -> redirect it all along new vector.
+	int				ClipVelocity( Vector& in, Vector& normal, Vector& out, float overbounce, float redirectCoeff = 0.f );
 
 	// Performs the collision resolution for fliers.
 	void			PerformFlyCollisionResolution( trace_t &pm, Vector &move );


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
Sometimes when a player flies into a ramp with a lot of speed they get grounded instead of sliding up it. This is caused by the 2 unit check for ground under the player that happens every movement update. If the player's final position ends up within 2 units of the ramp they are trying to slide up, without actually colliding with it, they will get grounded and get brought down to their walking speed.

This fix predicts how much vertical velocity the player would have gotten from colliding with the ramp on the next movement update had they not been grounded. In the case their vertical velocity would have exceeded the required 250u/s, which unconditionally makes players airborne, they will not get grounded. This allows the player to collide with the ramp on the next movement update and properly slide up it, or get grounded if they for some reason lost all their speed in the mean time from e.g. knockback.

https://github.com/user-attachments/assets/8294053a-9584-419a-bfb9-595fc8ed641d

The fix first applies one full movement update of gravity to the player's current velocity (`FinishGravity` + `StartGravity`), then it gets a slide coefficient from `AirMove` (used for airblast debuff according to TF2 wiki), whereafter the velocity is finally projected onto the ramp with `ClipVelocity` to get a prediction.

There are already SourceMod addons that use the same trick to fix this and they have been in use on jumping and competitive community servers for quite a while without issues. I decided to use a ConVar because in gamemodes like bhop and surf it is a good thing if you get grounded on a ramp because a speed-preserving bhop gives you a smoother entry onto the ramp when you collide with it right after. I enabled the fix by default though, since that's what makes sense in normal gameplay.

Feel free to chime in if you have a better name/description for the ConVar.
