### PR TITLE
[TF2] Make flame damage direction independent against tanks

### DIFF
--- a/src/game/shared/tf/tf_flame.h
+++ b/src/game/shared/tf/tf_flame.h
@@ -68,6 +68,7 @@ public:
 
 	static CTFFlameManager* Create( CBaseEntity *pOwner, bool bIsAdditionalManager = false );
 	virtual bool AddPoint( int iCurrentTick ) OVERRIDE;
+	virtual void Touch( CBaseEntity* pOther ) OVERRIDE;
 	void HookAttributes();
 	void UpdateDamage( int iDmgType, float flDamage, float flBurnFrequency, bool bCritFromBehind );
 	bool BCanBurnEntityThisFrame( CBaseEntity *pEnt ) const;


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description

Fixes https://github.com/ValveSoftware/Source-1-Games/issues/6062

In short, Pyro's flamethrower damage is calculated from the latest flame particle touching the target entity. This is problematic when the target is particularly big or standing against a wall. This PR fixes the damage just in MvM and against tanks as it would otherwise be non-insignificant game balance change.

Alternatively original issue https://github.com/ValveSoftware/Source-1-Games/issues/3720 would be fixed as a whole by changing FOR_EACH_VEC to FOR_EACH_VEC_BACK in CTFPointManager::Touch().