### PR TITLE
Use `COLLISION_GROUP_INTERACTIVE` for the `passtime_ball`

### DIFF
--- a/src/game/server/tf/tf_passtime_ball.cpp
+++ b/src/game/server/tf/tf_passtime_ball.cpp
@@ -324,7 +324,8 @@ void CPasstimeBall::CreateSphereCollider()
 void CPasstimeBall::Spawn()
 {
 	// not sure why this has to come first, but iirc it does.
-	SetCollisionGroup( COLLISION_GROUP_NONE ); 
+	// Use COLLISION_GROUP_INTERACTIVE so we don't collide with nonsense like dropped weapons and ammo from players.
+	SetCollisionGroup( COLLISION_GROUP_INTERACTIVE );
 
 	// === CBaseProp::Spawn
 	const char *pszModelName = (char*) STRING( GetModelName() );


### PR DESCRIPTION
With `COLLISION_GROUP_NONE`, we will collide with everything, including dropped weapons and ammo from players -- which is a bit silly!