### PR TITLE
[TF2] Let player shoot on the same tick they canceled their reload

### DIFF
--- a/src/game/shared/baseplayer_shared.cpp
+++ b/src/game/shared/baseplayer_shared.cpp
@@ -272,7 +272,8 @@ void CBasePlayer::ItemPostFrame()
 			GetActiveWeapon()->ItemBusyFrame();
 		}
 	}
-	else
+
+	if ( gpGlobals->curtime >= m_flNextAttack )
 	{
 		if ( GetActiveWeapon() && (!IsInAVehicle() || UsingStandardWeaponsInVehicle()) )
 		{


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
When a player tries to shoot a weapon with a non-empty clip while reloading in TF2, it cancels the reload on the first tick and only fires the weapon on the tick after. This happens because `ItemBusyFrame` (idle logic) and `ItemPostFrame` (shooting logic) are separated with an if/else statement controlled by `gpGlobals->curtime < m_flNextAttack`. Canceling a reload is effectively done by setting `m_flNextAttack = gpGlobals->curtime` inside `ItemBusyFrame`, so `ItemPostFrame` is skipped over even though `m_flNextAttack` marks the weapon as ready to shoot.

Changing the if/else to an if/if solves this. I'm pretty sure it shouldn't cause any problems as it only applies when `m_flNextAttack` is intentionally set to `gpGlobals->curtime` by weapon logic. However this is mostly a change directed at TF2, so I could specifically target TF2's reload cancel if need be.