### PR TITLE
Fix client-side entities playing some sounds incorrectly

### DIFF
--- a/src/game/shared/SoundEmitterSystem.cpp
+++ b/src/game/shared/SoundEmitterSystem.cpp
@@ -1138,7 +1138,16 @@ void CBaseEntity::EmitSound( const char *soundname, float soundtime /*= 0.0f*/, 
 	params.m_pflSoundDuration = duration;
 	params.m_bWarnOnDirectWaveReference = true;
 
-	EmitSound( filter, entindex(), params );
+	int iEntIndex = entindex();
+#if defined( CLIENT_DLL )
+	if ( iEntIndex == -1 )
+	{
+		// If we're a clientside entity, we need to use the soundsourceindex instead of the entindex
+		iEntIndex = GetSoundSourceIndex();
+	}
+#endif
+
+	EmitSound( filter, iEntIndex, params );
 }
 
 #if !defined ( CLIENT_DLL )
@@ -1177,7 +1186,16 @@ void CBaseEntity::EmitSound( const char *soundname, HSOUNDSCRIPTHANDLE& handle, 
 	params.m_pflSoundDuration = duration;
 	params.m_bWarnOnDirectWaveReference = true;
 
-	EmitSound( filter, entindex(), params, handle );
+	int iEntIndex = entindex();
+#if defined( CLIENT_DLL )
+	if ( iEntIndex == -1 )
+	{
+		// If we're a clientside entity, we need to use the soundsourceindex instead of the entindex
+		iEntIndex = GetSoundSourceIndex();
+	}
+#endif
+
+	EmitSound( filter, iEntIndex, params, handle );
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description

This PR fixes an issue where entities only created on the client side would play certain sounds incorrectly.

The particular bug solved here is that the entity IDs of entities that only exist on the client side is not correctly calculated by the two non-static overloads of `C_BaseEntity::EmitSound`, causing entity-specific effects (such as positional volume) to not be applied to sounds played using these methods. This is because both methods calculate the ID using `entindex()`, which returns -1 for entities that don't exist on the server side. This PR fixes this by calculating the ID as `GetSoundSourceIndex()` when `entindex() == -1`, just as `C_BaseEntity::StopSound` does.

This resolves https://github.com/ValveSoftware/Source-1-Games/issues/4850.

(This is also my first time working with the Source Engine, so forgive me if anything seems incorrect.)