### PR TITLE
add serverspawn.nut

### DIFF
--- a/src/game/client/vscript_client.cpp
+++ b/src/game/client/vscript_client.cpp
@@ -185,7 +185,9 @@ bool VScriptClientInit()
 				{
 					g_pScriptVM->Run( g_Script_vscript_client );
 				}
-
+				// ignore map-packed serverspawn files, allows server owners to run scripts before the map
+				VScriptRunScript( "serverspawn", false );
+				
 				VScriptRunScript( "mapspawn", false );
 
 				VMPROF_SHOW( pszScriptLanguage, "virtual machine startup" );

--- a/src/game/client/vscript_client.cpp
+++ b/src/game/client/vscript_client.cpp
@@ -185,9 +185,10 @@ bool VScriptClientInit()
 				{
 					g_pScriptVM->Run( g_Script_vscript_client );
 				}
+
 				// ignore map-packed serverspawn files, allows server owners to run scripts before the map
 				VScriptRunScript( "serverspawn", false );
-				
+
 				VScriptRunScript( "mapspawn", false );
 
 				VMPROF_SHOW( pszScriptLanguage, "virtual machine startup" );

--- a/src/game/server/vscript_server.cpp
+++ b/src/game/server/vscript_server.cpp
@@ -3503,6 +3503,9 @@ REGISTER_SCRIPT_CONST_TABLE( Server )
 				}
 				g_VScriptGameEventListener.Init();
 
+				// ignore map-packed serverspawn files, allows server owners to run scripts before the map
+				VScriptRunScript( "serverspawn", false );
+
 				VScriptRunScript( "mapspawn", false );
 
 				if ( script_connect_debugger_on_mapspawn.GetBool() )

--- a/src/game/shared/vscript_shared.cpp
+++ b/src/game/shared/vscript_shared.cpp
@@ -1,4 +1,4 @@
-//========== Copyright © 2008, Valve Corporation, All rights reserved. ========
+//========== Copyright ï¿½ 2008, Valve Corporation, All rights reserved. ========
 //
 // Purpose:
 //
@@ -102,7 +102,17 @@ HSCRIPT VScriptCompileScript( const char *pszScriptName, bool bWarnMissing )
 	}
 	else
 	{
-		bool bResult = filesystem->ReadFile( scriptPath, "GAME", bufferScript );
+		bool bResult = false;
+
+		// ignore map-packed serverspawn files, allows server owners to run scripts before the map
+		if ( V_strcmp( pszScriptName, "serverspawn" ) == 0 || V_strcmp( pszScriptName, CFmtStr("serverspawn%s", pszVMExtension) ) == 0 )
+		{
+			bResult = filesystem->ReadFile( scriptPath, "MOD", bufferScript );
+		}
+		else
+		{
+			bResult = filesystem->ReadFile( scriptPath, "GAME", bufferScript );
+		}
 
 		if( !bResult )
 		{


### PR DESCRIPTION
[Closes this issue](https://github.com/ValveSoftware/Source-1-Games/issues/6356)

TL;DR server owners do not have a good way to execute global, map-independent scripts.  `mapspawn` can be packed into the BSP and will be executed before ours, and `script_execute scriptname` in a server.cfg will run after mapspawn/any map executed scripts.

This PR adds a `serverspawn` file that executes before `mapspawn` that will not be read from the BSP, allowing server owners to replace sourcemod plugins with VScript where appropriate to do so.

Maps can still attempt to mess with our scripts, however if they are executed after ours we can more easily detect and block these attempts in VScript without the need for external plugins.