### PR TITLE
[TF2] Fix sentry busters dying without exploding

### DIFF
--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -8891,26 +8891,16 @@ int CTFPlayer::OnTakeDamage( const CTakeDamageInfo &inputInfo )
 
 		return 0;
 	}
-
+	
+	// Sentry Busters hurt teammates when they explode.
+	// Force damage value when the victim is a giant.
 	if ( IsBot() )
 	{
-		// Don't let Sentry Busters die until they've done their spin-up
 		if ( TFGameRules() && TFGameRules()->IsMannVsMachineMode() )
 		{
 			CTFBot *bot = ToTFBot( this );
 			if ( bot )
 			{
-				if ( bot->HasMission( CTFBot::MISSION_DESTROY_SENTRIES ) )
-				{
-					if ( ( m_iHealth - info.GetDamage() ) <= 0 )
-					{
-						m_iHealth = 1;
-						return 0;
-					}
-				}
-
-				// Sentry Busters hurt teammates when they explode.
-				// Force damage value when the victim is a giant.
 				if ( pTFAttacker && pTFAttacker->IsBot() )
 				{
 					CTFBot *pTFAttackerBot = ToTFBot( pTFAttacker );
@@ -9260,6 +9250,24 @@ int CTFPlayer::OnTakeDamage( const CTakeDamageInfo &inputInfo )
 	if ( !TFGameRules()->ApplyOnDamageModifyRules( info, this, bAllowDamage ) )
 	{
 		return 0;
+	}
+	
+	// Don't let Sentry Busters die until they've done their spin-up
+	if ( IsBot() )
+	{
+		if ( TFGameRules() && TFGameRules()->IsMannVsMachineMode() )
+		{
+			CTFBot* bot = ToTFBot( this );
+			if ( bot && bot->HasMission( CTFBot::MISSION_DESTROY_SENTRIES ) )
+			{
+				// Round to nearest like in OnTakeDamage_Alive
+				if ( ( m_iHealth - ( info.GetDamage() + 0.5f ) ) <= 0 )
+				{
+					m_iHealth = 1;
+					return 0;
+				}
+			}
+		}
 	}
 
 	// If player has Reflect Powerup, reflect damage to attacker. 


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description

Fixes https://github.com/ValveSoftware/Source-1-Games/issues/5193, busters sometimes dying without exploding.

### <ins>How to replicate</ins>
Create mission that spawns buster with 100 hp and kill it with crit boosted rocket launcher.

### <ins>Explanation of the bug</ins>

The root cause is that the damage check is done before applying damage modifiers in `CTFGameRules::ApplyOnDamageModifyRules()`. The bug happens when

1.  Base damage is under buster health (rocket 90)
2. Modified damage is over buster health (crit boost applied 3*90 = 270)

### <ins>Fix</ins>

Move buster death check to after damage modifications.