### PR TITLE
Add ConVar to disable MvM-specific diguise on backstab nerfs.

### DIFF
--- a/src/game/shared/tf/tf_gamerules.cpp
+++ b/src/game/shared/tf/tf_gamerules.cpp
@@ -881,9 +881,10 @@ ConVar tf_mvm_min_players_to_start( "tf_mvm_min_players_to_start", "3", FCVAR_RE
 ConVar tf_mvm_respec_enabled( "tf_mvm_respec_enabled", "1", FCVAR_CHEAT | FCVAR_REPLICATED, "Allow players to refund credits spent on player and item upgrades." );
 ConVar tf_mvm_respec_limit( "tf_mvm_respec_limit", "0", FCVAR_CHEAT | FCVAR_REPLICATED, "The total number of respecs a player can earn.  Default: 0 (no limit).", true, 0.f, true, 100.f );
 ConVar tf_mvm_respec_credit_goal( "tf_mvm_respec_credit_goal", "2000", FCVAR_CHEAT | FCVAR_REPLICATED, "When tf_mvm_respec_limit is non-zero, the total amount of money the team must collect to earn a respec credit." );
-ConVar tf_mvm_buybacks_method( "tf_mvm_buybacks_method", "0", FCVAR_REPLICATED | FCVAR_HIDDEN, "When set to 0, use the traditional, currency-based system.  When set to 1, use finite, charge-based system.", true, 0.0, true, 1.0 );
-ConVar tf_mvm_buybacks_per_wave( "tf_mvm_buybacks_per_wave", "3", FCVAR_REPLICATED | FCVAR_HIDDEN, "The fixed number of buybacks players can use per-wave." );
+ConVar tf_mvm_buybacks_method( "tf_mvm_buybacks_method", "0", FCVAR_REPLICATED, "When set to 0, use the traditional, currency-based system.  When set to 1, use finite, charge-based system.", true, 0.0, true, 1.0 );
+ConVar tf_mvm_buybacks_per_wave( "tf_mvm_buybacks_per_wave", "3", FCVAR_REPLICATED, "The fixed number of buybacks players can use per-wave." );
 
+ConVar tf_mvm_disguise_on_backstab_mode ("tf_mvm_disguise_on_backstab_mode", "0", FCVAR_REPLICATED, "When set to 1, disables MvM-specific nerfs for disguise on backstab weapons.");
 
 #ifdef GAME_DLL
 enum { kMVM_CurrencyPackMinSize = 1, };

--- a/src/game/shared/tf/tf_gamerules.cpp
+++ b/src/game/shared/tf/tf_gamerules.cpp
@@ -884,7 +884,7 @@ ConVar tf_mvm_respec_credit_goal( "tf_mvm_respec_credit_goal", "2000", FCVAR_CHE
 ConVar tf_mvm_buybacks_method( "tf_mvm_buybacks_method", "0", FCVAR_REPLICATED, "When set to 0, use the traditional, currency-based system.  When set to 1, use finite, charge-based system.", true, 0.0, true, 1.0 );
 ConVar tf_mvm_buybacks_per_wave( "tf_mvm_buybacks_per_wave", "3", FCVAR_REPLICATED, "The fixed number of buybacks players can use per-wave." );
 
-ConVar tf_mvm_disguise_on_backstab_mode ("tf_mvm_disguise_on_backstab_mode", "0", FCVAR_REPLICATED, "When set to 1, disables MvM-specific nerfs for disguise on backstab weapons.");
+ConVar tf_mvm_disguise_on_backstab_mode ( "tf_mvm_disguise_on_backstab_mode", "0", FCVAR_REPLICATED, "When set to 1, disables MvM-specific nerfs for disguise on backstab weapons." );
 
 #ifdef GAME_DLL
 enum { kMVM_CurrencyPackMinSize = 1, };

--- a/src/game/shared/tf/tf_weapon_knife.cpp
+++ b/src/game/shared/tf/tf_weapon_knife.cpp
@@ -50,6 +50,7 @@ END_PREDICTION_DATA()
 LINK_ENTITY_TO_CLASS( tf_weapon_knife, CTFKnife );
 PRECACHE_WEAPON_REGISTER( tf_weapon_knife );
 
+extern ConVar tf_mvm_disguise_on_backstab_mode;
 
 //=============================================================================
 //
@@ -246,8 +247,7 @@ void CTFKnife::PrimaryAttack( void )
 	if ( ShouldDisguiseOnBackstab() && bSuccessfulBackstab && !pPlayer->HasTheFlag( ignoreTypes, ARRAYSIZE( ignoreTypes ) ) )
 	{
 		// Different rules in MvM when stabbing bots
-		bool bDropDisguise = m_hBackstabVictim->IsBot() && ( ( TFGameRules() && TFGameRules()->IsMannVsMachineMode() ) 
-			);
+		bool bDropDisguise = m_hBackstabVictim->IsBot() && ( ( TFGameRules() && TFGameRules()->IsMannVsMachineMode() && !tf_mvm_disguise_on_backstab_mode.GetBool() ) );
 		if ( bDropDisguise )
 		{
 			// Remove the disguise first, otherwise this attribute is overpowered


### PR DESCRIPTION
Also removes FVCAR_HIDDEN from the old buyback behavior cvars.

The disguise on backstab mechanic found on the Your Eternal Reward/Wanga Prick was severely kneecapped into being effectively useless very early into MvM's development, developers were concerned that it would be overpowered based on the provided comment.

Discussion of weapon/item balance is generally very thorny, however I will say: 

- This behavior has been removed with an external plugin for several years for Potato.TF's events and archive servers.
- Most people who have used it seem to agree that it is not overpowered, while also enabling a more unique playstyle where spy focuses on clearing up common bots/uber medics rather than taking down giants.  
- The downside of not being able to freely disguise (especially after the dead ringer nerf) is seemingly significant enough to keep it out of "overpowered" territory.  Especially when compared to other weapons the MvM community believes are genuinely overpowered.
- There is also the more subtle downside that bumping bots while stabbing them will still occasionally cause them to be alerted by your presence anyway, meaning it requires fairly careful positioning to pull off long chain-stabs.

Adding a cvar to disable this nerf would allow community servers to experiment with this weapon more, without relying on external plugins/extensions.