### PR TITLE
[TF2] Fix MvM bots with Attributes IgnoreFlag getting stuck in a loop when no flag is on the map

### DIFF
--- a/src/game/server/tf/bot/behavior/scenario/capture_the_flag/tf_bot_attack_flag_defenders.cpp
+++ b/src/game/server/tf/bot/behavior/scenario/capture_the_flag/tf_bot_attack_flag_defenders.cpp
@@ -58,7 +58,7 @@ ActionResult< CTFBot > CTFBotAttackFlagDefenders::Update( CTFBot *me, float inte
 
 		if ( !flag )
 		{
-			return Done( "No flag" );
+			return Continue();
 		}
 
 		// can't reach flag if it is at home


### PR DESCRIPTION
TFBots in Mann vs. Machine get stuck in a behavior loop in a specific scenario:

- There is no bomb (flag) currently active on the map.
- The bot is set to ignore the flag.
In this scenario, the bot will end up "idling" on the deploy area / hatch.

When inspected in-game using `nb_debug BEHAVIOR`, it becomes clear that the bot is caught in an infinite loop: their `FetchFlag` behavior calls for a suspension on itself, for the `AttackFlagDefenders` behavior.
However, said behavior performs a check for the existence of a flag; in the absence of one, its Update function will return "Done (no flag)", sending the bot's behavior back to `FetchFlag`. This behavior then sends it back to `AttackFlagDefenders`; an infinite loop.

By changing the result for the absence of a flag in `AttackFlagDefenders::Update` from "Done" to "Continue", the bot will instead stick to attacking flag defenders, as would be expected.

Fixes [ValveSoftware/Source-1-Games#4847](https://github.com/ValveSoftware/Source-1-Games/issues/4847#issue-1625941069); more details can be found in that post.