### PR TITLE
Adjusted `CTFPlayerDestructionLogic::EvaluatePlayerCount` to add a po…

### DIFF
--- a/src/game/shared/tf/tf_logic_player_destruction.cpp
+++ b/src/game/shared/tf/tf_logic_player_destruction.cpp
@@ -266,6 +266,11 @@ void CTFPlayerDestructionLogic::EvaluatePlayerCount()
 	CollectPlayers( &vecAllPlayers );
 
 	m_nMaxPoints = Max( m_nMinPoints, m_nPointsPerPlayer * vecAllPlayers.Count() );
+
+	if ( m_nRedScore.Get() >= m_nMaxPoints || m_nBlueScore.Get() >= m_nMaxPoints )
+	{
+		m_nMaxPoints = Max( m_nRedScore.Get(), m_nBlueScore.Get() ) + 1;
+	}
 }
 
 void CTFPlayerDestructionLogic::InputScoreRedPoints( inputdata_t& inputdata )


### PR DESCRIPTION
…int above the top scoring team in the event that players disconnecting adjust scores below what the new winning threshold would be.

<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
This is an alternative solution to the problem brought up by https://github.com/ValveSoftware/source-sdk-2013/pull/864 using a simpler approach suggested by FlaminSarge. 

It adjusts the `m_nMaxPoints` value to be 1 point higher than the winning / tied team in the event that an adjusted max point score is below or equal to the scores of the current round.