### PR TITLE
[HL2DM] Fix sprint issues

### DIFF
--- a/src/game/client/hl2mp/c_hl2mp_player.cpp
+++ b/src/game/client/hl2mp/c_hl2mp_player.cpp
@@ -795,6 +795,21 @@ void C_HL2MP_Player::HandleSpeedChanges( CMoveData *mv )
 	const bool bWantsToChangeSprinting = ( m_HL2Local.m_bNewSprinting != bWantSprint ) && ( nChangedButtons & IN_SPEED ) != 0;
 
 	bool bSprinting = m_HL2Local.m_bNewSprinting;
+
+	// Fixes: 
+	// 1) Completely stop sprinting when going underwater 
+	// 2) Fix sprint not starting during unducking
+
+	if ( GetWaterLevel() == 3 )
+		bSprinting = false;
+
+	// Putting those here instead of within bWantsToChangeSprinting to ensure sprint properly starts when summoned! 
+	if ( m_Local.m_bDucked && !m_Local.m_bDucking && bSprinting )
+		bSprinting = false;
+
+	if ( m_Local.m_bDucked && m_Local.m_bDucking && !bSprinting && ( mv->m_nButtons & IN_SPEED ) )
+		bSprinting = true;
+
 	if ( bWantsToChangeSprinting )
 	{
 		if ( bWantSprint )

--- a/src/game/client/hl2mp/c_hl2mp_player.h
+++ b/src/game/client/hl2mp/c_hl2mp_player.h
@@ -99,6 +99,10 @@ public:
 	bool SuitPower_ShouldRecharge( void );
 	float SuitPower_GetCurrentPercentage( void ) { return m_HL2Local.m_flSuitPower; }
 	
+	bool IsNewSprinting() const
+	{
+		return m_HL2Local.m_bNewSprinting;
+	}
 	bool	CanSprint( void );
 	void	StartSprinting( void );
 	void	StopSprinting( void );

--- a/src/game/server/hl2/hl2_player.cpp
+++ b/src/game/server/hl2/hl2_player.cpp
@@ -505,6 +505,22 @@ void CHL2_Player::HandleSpeedChanges( CMoveData *mv )
 	const bool bWantsToChangeSprinting = ( m_HL2Local.m_bNewSprinting != bWantSprint ) && ( nChangedButtons & IN_SPEED ) != 0;
 
 	bool bSprinting = m_HL2Local.m_bNewSprinting;
+
+	// Fixes: 
+	// 1) Completely stop sprinting when going underwater 
+	// 2) Fix sprint not starting during unducking
+
+	if ( GetWaterLevel() == 3 )
+		bSprinting = false;
+
+	// Putting those here instead of within bWantsToChangeSprinting to ensure sprint properly starts when summoned!
+	// Restoring pre-OB (2010) working sprinting behavior.
+	if ( m_Local.m_bDucked && !m_Local.m_bDucking && bSprinting )
+		bSprinting = false;
+
+	if ( m_Local.m_bDucked && m_Local.m_bDucking && !bSprinting && ( mv->m_nButtons & IN_SPEED ) )
+		bSprinting = true;
+
 	if ( bWantsToChangeSprinting )
 	{
 		if ( bWantSprint )

--- a/src/game/server/hl2/hl2_player.h
+++ b/src/game/server/hl2/hl2_player.h
@@ -172,6 +172,11 @@ public:
 	bool CanSprint( void );
 	void EnableSprint( bool bEnable);
 
+	bool IsNewSprinting() const
+	{
+		return m_HL2Local.m_bNewSprinting;
+	}
+
 	bool CanZoom( CBaseEntity *pRequester );
 	void ToggleZoom(void);
 	void StartZooming( void );


### PR DESCRIPTION
This PR addresses some issues with HL2DM's sprinting mechanics.

- Fixed sprinting delay when unducking.
- Fixed sprinting not turning off when ducking.
- Fixed the Shrodinger's duck bug.
- Fixed sprinting underwater.

A video is worth a thousand words, so here is a before and after fix in regards to sprint delay and sprint while fully ducked.

https://youtu.be/xjIt0iWK_fk?si=hir2_YnXhLfUIgzi