### PR TITLE
Fix issue where flaming friendly Snipers causes flame sfx when they're not actively using a bow

### DIFF
--- a/src/game/shared/tf/tf_flame.cpp
+++ b/src/game/shared/tf/tf_flame.cpp
@@ -705,11 +705,11 @@ void CTFFlameManager::OnCollide( CBaseEntity *pEnt, int iPointIndex )
 
 		// Does he have the bow?
 		CTFWeaponBase *pWpn = pPlayer->GetActiveTFWeapon();
-		if ( pWpn && pWpn->GetWeaponID() == TF_WEAPON_COMPOUND_BOW )
-		{
-			CTFCompoundBow *pBow = static_cast<CTFCompoundBow*>( pWpn );
-			pBow->SetArrowAlight( true );
-		}
+		if ( !pWpn || pWpn->GetWeaponID() != TF_WEAPON_COMPOUND_BOW )
+			return;
+
+		CTFCompoundBow *pBow = static_cast<CTFCompoundBow*>( pWpn );
+		pBow->SetArrowAlight( true );
 	}
 	else
 	{

--- a/src/game/shared/tf/tf_weapon_flamethrower.cpp
+++ b/src/game/shared/tf/tf_weapon_flamethrower.cpp
@@ -3128,19 +3128,19 @@ void CTFFlameEntity::OnCollideWithTeammate( CTFPlayer *pPlayer )
 	if ( !pPlayer->IsPlayerClass(TF_CLASS_SNIPER) )
 		return;
 
+	// Does he have the bow?
+	CTFWeaponBase *pWpn = pPlayer->GetActiveTFWeapon();
+	if ( !pWpn || pWpn->GetWeaponID() != TF_WEAPON_COMPOUND_BOW )
+		return;
+
+	CTFCompoundBow *pBow = static_cast<CTFCompoundBow*>( pWpn );
+	pBow->SetArrowAlight( true );
+
 	int iIndex = m_hEntitiesBurnt.Find( pPlayer );
 	if ( iIndex != m_hEntitiesBurnt.InvalidIndex() )
 		return;
 
 	m_hEntitiesBurnt.AddToTail( pPlayer );
-
-	// Does he have the bow?
-	CTFWeaponBase *pWpn = pPlayer->GetActiveTFWeapon();
-	if ( pWpn && pWpn->GetWeaponID() == TF_WEAPON_COMPOUND_BOW )
-	{
-		CTFCompoundBow *pBow = static_cast<CTFCompoundBow*>( pWpn );
-		pBow->SetArrowAlight( true );
-	}
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
# Description
This happens because the `CTFFlameManager::OnCollide` and `CTFFlameEntity::OnCollideWithTeammate` functions only early-exit if the flame collides with a teammate that isn't a Sniper, and not when it collides with a teammate that *is* a Sniper but *isn't* actively using a bow weapon.

This causes friendly, non-bow-wielding Snipers to still be added to the `m_mapEntitiesBurnt` and `m_hEntitiesBurnt` vectors of each class, at least one of which which is used... somewhere -- admittedly I didn't dig terribly deep into where exactly this occurs -- to play sound effects that convey to the player that they are flaming a flame-able entity.

This PR fixes this by simply early-exiting in each of these functions if the flamed player *is* a Sniper but *isn't* actively using a bow weapon.

Before: https://github.com/user-attachments/assets/3a45ab34-ece1-4801-ba89-8a467ee9dff0
After: https://github.com/user-attachments/assets/5577cc55-9d53-404e-a4a4-017f705de18f