### PR TITLE
[HL2DM] Move .357 snap after firing to client-side

### DIFF
--- a/src/game/shared/hl2mp/weapon_357.cpp
+++ b/src/game/shared/hl2mp/weapon_357.cpp
@@ -11,6 +11,7 @@
 
 #ifdef CLIENT_DLL
 	#include "c_hl2mp_player.h"
+	#include <prediction.h>
 #else
 	#include "hl2mp_player.h"
 #endif
@@ -133,16 +134,18 @@ void CWeapon357::PrimaryAttack( void )
 	// Fire the bullets, and force the first shot to be perfectly accuracy
 	pPlayer->FireBullets( info );
 
+#ifdef CLIENT_DLL
 	//Disorient the player
-	QAngle angles = pPlayer->GetLocalAngles();
-
-	angles.x += random->RandomInt( -1, 1 );
-	angles.y += random->RandomInt( -1, 1 );
-	angles.z = 0;
-
-#ifndef CLIENT_DLL
-	pPlayer->SnapEyeAngles( angles );
-#endif
+	if ( prediction->IsFirstTimePredicted() )
+	{
+		QAngle angles;
+		engine->GetViewAngles( angles );
+		angles.x += random->RandomInt( -1, 1 );
+		angles.y += random->RandomInt( -1, 1 );
+		angles.z += 0.0f;
+		engine->SetViewAngles( angles );
+	}
+#endif // CLIENT_DLL
 
 	pPlayer->ViewPunch( QAngle( -8, random->RandomFloat( -2, 2 ), 0 ) );
 


### PR DESCRIPTION
This PR addresses an issue where firing the .357 causes the player’s view angles to "snap" back to the firing angles due to the server processing this. This becomes particularly problematic at higher pings, where firing the weapon while moving your view results in your view snapping back to the firing angles after this many milliseconds corresponding to the player's latency.

Some server ops resolve this by disabling the view angle snapping entirely on the server, which does prevent the issue. However, this also removes the intended randomization in where the crosshair ends up after the weapon’s disorienting recoil effect, reducing the intended gameplay feedback.

The fix here moves the view angle snapping logic to the client-side, preventing the annoying snapping caused by the server processing the shots.