### PR TITLE
[HL2DM] Fix a few chat issues

### DIFF
--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -96,9 +96,10 @@ ConVar	spec_freeze_traveltime( "spec_freeze_traveltime", "0.4", FCVAR_CHEAT | FC
 ConVar sv_bonus_challenge( "sv_bonus_challenge", "0", FCVAR_REPLICATED, "Set to values other than 0 to select a bonus map challenge type." );
 
 ConVar sv_chat_bucket_size_tier1( "sv_chat_bucket_size_tier1", "4", FCVAR_NONE, "The maxmimum size of the short term chat msg bucket." );
-ConVar sv_chat_seconds_per_msg_tier1( "sv_chat_seconds_per_msg_tier1", "3", FCVAR_NONE, "The number of seconds to accrue an additional short term chat msg." );
+ConVar sv_chat_bucket_size_tier1_penalty( "sv_chat_bucket_size_tier1_penalty", "0.25", FCVAR_NONE, "The penalty multiplier that gets added to the regeneration time of this bucket." );
+ConVar sv_chat_seconds_per_msg_tier1( "sv_chat_seconds_per_msg_tier1", "6", FCVAR_NONE, "The number of seconds to accrue an additional short term chat msg." );
 ConVar sv_chat_bucket_size_tier2( "sv_chat_bucket_size_tier2", "30", FCVAR_NONE, "The maxmimum size of the long term chat msg bucket." );
-ConVar sv_chat_seconds_per_msg_tier2( "sv_chat_seconds_per_msg_tier2", "10", FCVAR_NONE, "The number of seconds to accrue an additional long term chat msg." );
+ConVar sv_chat_seconds_per_msg_tier2( "sv_chat_seconds_per_msg_tier2", "20", FCVAR_NONE, "The number of seconds to accrue an additional long term chat msg." );
 
 static ConVar sv_maxusrcmdprocessticks( "sv_maxusrcmdprocessticks", "24", FCVAR_NOTIFY, "Maximum number of client-issued usrcmd ticks that can be replayed in packet loss conditions, 0 to allow no restrictions" );
 
@@ -614,6 +615,8 @@ CBasePlayer::CBasePlayer( )
 	m_fLastPlayerTalkAttemptTime = 0.0f;
 	m_flPlayerTalkAvailableMessagesTier1 = 1.0f;
 	m_flPlayerTalkAvailableMessagesTier2 = 10.0f;
+	m_flChatPenaltyMultiplier = 1.0f;
+	m_flLastPenaltyDecayTime = gpGlobals->curtime;
 	m_PlayerInfo.SetParent( this );
 
 	ResetObserverMode();
@@ -8775,37 +8778,78 @@ void CBasePlayer::DeactivateMovementConstraint( )
 //-----------------------------------------------------------------------------
 // Purpose: Fight chat spam with a two tiered token bucket
 //-----------------------------------------------------------------------------
-bool CBasePlayer::ArePlayerTalkMessagesAvailable( void )
+void CBasePlayer::DecrementPlayerChatBuckets()
 {
-	// How long since we last tried to chat?
+	m_flPlayerTalkAvailableMessagesTier1 -= 1.0f;
+
+	// If the bucket in tier 1 is above 0, decrement by 1 
+	// this avoids really sinking into a deep hole and having 
+	// to wait for an undetermined amout of time
+	if ( m_flPlayerTalkAvailableMessagesTier1 > 0 )
+	{
+		m_flPlayerTalkAvailableMessagesTier2 -= 1.0f;
+	}
+
+	m_flPlayerTalkAvailableMessagesTier1 = MAX( -2.5f, m_flPlayerTalkAvailableMessagesTier1 );
+}
+
+bool CBasePlayer::ArePlayerTalkMessagesAvailable()
+{
 	float flTimeElapsedSinceLastMsg = gpGlobals->curtime - m_fLastPlayerTalkAttemptTime;
 	m_fLastPlayerTalkAttemptTime = gpGlobals->curtime;
 
-	// The max messages we can have available
-	// Tier 1 is for short-term spam
-	float flTotalBucketSizeTier1 = sv_chat_bucket_size_tier1.GetFloat();	
-	// rate at which we gain new messages, this slows if we continue to try to spam messages
-	float flSecondsPerMessageTier1 = sv_chat_seconds_per_msg_tier1.GetFloat() - MIN( 0.0f, m_flPlayerTalkAvailableMessagesTier1 );
+	// Apply decay to the penalty if enough time has passed since last chat message
+	const float flPenaltyDecayInterval = 30.0f;  // Every 30 seconds, the penalty decays slightly
+	if ( gpGlobals->curtime - m_flLastPenaltyDecayTime >= flPenaltyDecayInterval )
+	{
+		m_flChatPenaltyMultiplier = MAX( 1.0f, m_flChatPenaltyMultiplier - 0.1f );  // Slowly recover
+		m_flLastPenaltyDecayTime = gpGlobals->curtime;
+	}
 
-	// We'll count partial counts of accruing message throughout, as it'll be more consistent
+	// Short-term bucket
+	float flTotalBucketSizeTier1 = sv_chat_bucket_size_tier1.GetFloat();
+	float flChatPenaltyMulitplier = sv_chat_bucket_size_tier1_penalty.GetFloat();
+
+	// Increase regen time by the penalty multiplier
+	float flBaseSecondsPerMessageTier1 = sv_chat_seconds_per_msg_tier1.GetFloat();
+	float flSecondsPerMessageTier1 = flBaseSecondsPerMessageTier1 * m_flChatPenaltyMultiplier;
+
 	float flMessagesGainedTier1 = MAX( 0, flTimeElapsedSinceLastMsg / flSecondsPerMessageTier1 );
+	m_flPlayerTalkAvailableMessagesTier1 = MIN( flTotalBucketSizeTier1, m_flPlayerTalkAvailableMessagesTier1 + flMessagesGainedTier1 );
 
-	// But we will allow the counter to go negative, so if you keep trying to spam you have to work your way out of a hole.
-	m_flPlayerTalkAvailableMessagesTier1 = MAX( -2.5f, MIN( flTotalBucketSizeTier1, m_flPlayerTalkAvailableMessagesTier1 + flMessagesGainedTier1 ) - 1.0f ); 
+	// We are going to use a penalty system designed to limit spammers by slowing down the recovery rate of their buckets. 
+	// Basically, if the short term bucket value is insufficient, the message does not get sent and a multiplier penalty is added, 
+	// slowing down their regeneration of the bucket. Their buckets will keep refilling no matter what, but at a slower rate, 
+	// and at each failed message, the bucket fills more slowly. This penalty multiplier will eventually go back down if the player 
+	// stops spamming or does not use the chat for a while.
+	if ( m_flPlayerTalkAvailableMessagesTier1 <= 0.9f )
+	{
+		m_flChatPenaltyMultiplier += flChatPenaltyMulitplier;  // Increase penalty
 
-	// Tier2 is for curbing longer-term consistent spamming
-	// We'll only allow the long term bucket to accrue if we're not currently in a spammy state
+		if ( m_flPlayerTalkAvailableMessagesTier1 <= 0.0f )
+			m_flPlayerTalkAvailableMessagesTier1 = 0.0f;  // Never go negative
+	}
+
+	// Long-term bucket
+	float flMessagesGainedTier2 = 0.0f;
 	if ( m_flPlayerTalkAvailableMessagesTier1 > 0 )
 	{
 		float flTotalBucketSizeTier2 = sv_chat_bucket_size_tier2.GetFloat();
 		float flSecondsPerMessageTier2 = sv_chat_seconds_per_msg_tier2.GetFloat();
 
-		float flMessagesGainedTier2 = MAX( 0, flTimeElapsedSinceLastMsg / flSecondsPerMessageTier2 );
-		m_flPlayerTalkAvailableMessagesTier2 = MAX( 0, MIN( flTotalBucketSizeTier2, m_flPlayerTalkAvailableMessagesTier2 + flMessagesGainedTier2 ) - 1.0f );
-		//Msg( "Elapsed : %f2  Gained : %f2 / %f2 \n", flTimeElapsedSinceLastMsg, flMessagesGainedTier1, flMessagesGainedTier2 );
+		flMessagesGainedTier2 = MAX( 0, flTimeElapsedSinceLastMsg / flSecondsPerMessageTier2 );
+		m_flPlayerTalkAvailableMessagesTier2 = MIN( flTotalBucketSizeTier2, m_flPlayerTalkAvailableMessagesTier2 + flMessagesGainedTier2 );
 	}
+	m_flPlayerTalkAvailableMessagesTier2 = MAX( 0, m_flPlayerTalkAvailableMessagesTier2 );
 
-	//Msg( "Remaining Msgs : %f2 / %f2\n", m_flPlayerTalkAvailableMessagesTier1, m_flPlayerTalkAvailableMessagesTier2 );
+	// Debug messages
+	Msg( "Elapsed: %.2f sec | Gained Tier1: %.2f | Gained Tier2: %.2f\n",
+		flTimeElapsedSinceLastMsg, flMessagesGainedTier1, flMessagesGainedTier2 );
+
+	Msg( "Remaining Msgs - Tier1: %.2f / %.2f | Tier2: %.2f / %.2f | Penalty Multiplier: %.2f\n",
+		m_flPlayerTalkAvailableMessagesTier1, flTotalBucketSizeTier1,
+		m_flPlayerTalkAvailableMessagesTier2, sv_chat_bucket_size_tier2.GetFloat(),
+		m_flChatPenaltyMultiplier );
 
 	return m_flPlayerTalkAvailableMessagesTier1 > 1.0f && m_flPlayerTalkAvailableMessagesTier2 > 1.0f;
 }
@@ -8815,7 +8859,9 @@ bool CBasePlayer::ArePlayerTalkMessagesAvailable( void )
 //-----------------------------------------------------------------------------
 bool CBasePlayer::CanPlayerTalk()
 {
-	const float talk_interval = 0.66; // min time between say commands from a client
+	// min time between say commands from a client,
+	// has no effect when the game is paused because time is frozen
+	const float talk_interval = 0.66;
 
 	bool bRateLimitAllowed = LastTimePlayerTalked() + talk_interval < gpGlobals->curtime;
 

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -777,6 +777,7 @@ public:
 	void	NotePlayerTalked() { m_fLastPlayerTalkTime = gpGlobals->curtime; }
 	float	LastTimePlayerTalked() const { return m_fLastPlayerTalkTime; }
 	bool	ArePlayerTalkMessagesAvailable();
+	void	DecrementPlayerChatBuckets();
 
 	void	DisableButtons( int nButtons );
 	void	EnableButtons( int nButtons );
@@ -838,6 +839,10 @@ private:
 
 	int					DetermineSimulationTicks( void );
 	void				AdjustPlayerTimeBase( int simulation_ticks );
+
+	// Player spamming way too much, add a penalty
+	float m_flChatPenaltyMultiplier;
+	float m_flLastPenaltyDecayTime;
 
 public:
 	

--- a/src/game/shared/hl2mp/hl2mp_gamerules.cpp
+++ b/src/game/shared/hl2mp/hl2mp_gamerules.cpp
@@ -1249,9 +1249,10 @@ const char *CHL2MPRules::GetChatFormat( bool bTeamOnly, CBasePlayer *pPlayer )
 	}
 
 	const char *pszFormat = NULL;
+	bool bIsDead = ( pPlayer->m_lifeState != LIFE_ALIVE );
 
 	// team only
-	if ( bTeamOnly == TRUE )
+	if ( bTeamOnly )
 	{
 		if ( pPlayer->GetTeamNumber() == TEAM_SPECTATOR )
 		{
@@ -1266,7 +1267,14 @@ const char *CHL2MPRules::GetChatFormat( bool bTeamOnly, CBasePlayer *pPlayer )
 			}
 			else
 			{
-				pszFormat = "HL2MP_Chat_Team";
+				if ( bIsDead )
+				{
+					pszFormat = "HL2MP_Chat_Team_Dead";
+				}
+				else
+				{
+					pszFormat = "HL2MP_Chat_Team";
+				}
 			}
 		}
 	}
@@ -1275,7 +1283,14 @@ const char *CHL2MPRules::GetChatFormat( bool bTeamOnly, CBasePlayer *pPlayer )
 	{
 		if ( pPlayer->GetTeamNumber() != TEAM_SPECTATOR )
 		{
-			pszFormat = "HL2MP_Chat_All";	
+			if ( bIsDead )
+			{
+				pszFormat = "HL2MP_Chat_AllDead";
+			}
+			else
+			{
+				pszFormat = "HL2MP_Chat_All";
+			}
 		}
 		else
 		{
@@ -1285,5 +1300,6 @@ const char *CHL2MPRules::GetChatFormat( bool bTeamOnly, CBasePlayer *pPlayer )
 
 	return pszFormat;
 }
+
 
 #endif


### PR DESCRIPTION
This PR is to fix a couple of chat issues and re-work the chat anti spam system.

In short:
- Fixed team chat not working in non-TDM mode.
- Fixed certain prefixes not being used like in CSS such as *DEAD* or *DEAD*(TEAM). 
- Fixed not being able to send more than one message when the game is paused.
- Reworked the anti chat spam, added `sv_chat_bucket_size_tier1_penalty`, defaulted to `0.25`.

By default, team chat messages in DM mode (teamplay disabled) are never seen by anyone because the logic used to check if a message is seen is this:
https://github.com/ValveSoftware/source-sdk-2013/blob/aea94b32cbefeba5d16ef6fc70eff9508cf11673/src/game/server/client.cpp#L305-L306
Because there is no notion of teammates in DM mode, the message never reaches anyone else and you, the sender, are the only one to see it. The fix is to simply check if teamplay is enabled. If it is not, then we check the teams of the sender and receivers and filter through that.

---

This one is pretty straightforward as well. For some reason, for the past 20+ years, HL2DM never used the `*DEAD*` prefix, despite its existence in `resource/hl2mp_english.txt` --and it is localized.

---

This one is also a straightforward fix. If the game is paused, the time is frozen. There are some functions that are immune to frozen time, though, but we are not touching those. Instead, we are simply checking if the game is paused and never apply any delay between messages. This indeed lets spam occur, but I would find it more frustrating to have a game paused for a while than spam.

---

Unsure if I was the only one experiencing this, but the default chat anti-spam logic is bizarre at best. When I was updating my SDK and initially testing the team chat fix, I found that some of my messages were being suppressed (not sent at all). At first, I thought I had introduced a bug, but after reviewing the code, I could not find anything wrong.

After asking around, I discovered that other players had experienced similar frustrations; they too had no idea why their messages were not going through. Eventually, someone mentioned that they believed this was caused by some kind of anti-spam system. Upon further investigation, I found the new chat anti-spam logic introduced in the SDK.

## Problems with the existing system

The biggest issue is that there is no feedback when your message is blocked. The message just does not send, leaving players confused. I initially thought this was a bug.

The second issue is with the logic itself. If you spam too many messages, your tier 1 chat bucket can go into negative values, meaning you do not just run out of messages — you go into debt. Every failed attempt to chat further brings you into debt, meaning the more you try, the deeper the hole you dig. This design results in players being locked out of chat for an extremely long time, even for relatively normal conversations where messages would be sent at a moderate pace, which feels far too harsh.

## Proposed Solution

This PR refactors the system into a more player-friendly and understandable approach:

**The Tier 1 bucket no longer goes below 0**. This avoids the "chat debt spiral."
### - A progressive penalty multiplier is introduced
If a player attempts to chat when their Tier 1 bucket is empty, the message is blocked without further reducing the bucket itself.
Instead, a penalty multiplier is applied, which slows down the rate at which Tier 1 regenerates. The more you spam, the worse the penalty gets.
### - Penalty decay over time
The penalty multiplier gradually decreases if the player stops spamming for a while, giving players a way to recover if they back off.

This system still prevents spam, but in a way that is more transparent, more forgiving for normal conversation, and scales appropriately to repeated chat spammers.
