### PR TITLE
[HL2DM] Fix shotgun issues, and improve trace logic

### DIFF
--- a/src/game/server/hl2mp/hl2mp_player.cpp
+++ b/src/game/server/hl2mp/hl2mp_player.cpp
@@ -684,7 +684,7 @@ bool CHL2MP_Player::WantsLagCompensationOnEntity( const CBasePlayer *pPlayer, co
 {
 	// No need to lag compensate at all if we're not attacking in this command and
 	// we haven't attacked recently.
-	if ( !( pCmd->buttons & IN_ATTACK ) && (pCmd->command_number - m_iLastWeaponFireUsercmd > 5) )
+	if ( !( ( pCmd->buttons & IN_ATTACK ) || ( pCmd->buttons & IN_ATTACK2 ) ) && ( pCmd->command_number - m_iLastWeaponFireUsercmd > 5 ) )
 		return false;
 
 	// If this entity hasn't been transmitted to us and acked, then don't bother lag compensating it.


### PR DESCRIPTION
This PR aims at fixing long standing shotgun issues.

- Fixed shotgun trace logic, using all 3 trace methods for the most accurate detection. 
    The default trace logic uses half trace lines, half trace hulls. The problem with this is that you end up with a shotgun that is either way too OP or too weak. With the proposed changes here, all three traces are used for maximum precision.

- Fixed secondary shotgun prediction bug.
    Looks like secondary attack was missing for prediction.

- Fixed shotgun infinite reload loop bug.
    The reload variable did not seem networked, so you could end up with a shotgun being stuck in an infinite reload loop animation.

- Fixed shotgun locking up when holding reload and attack keys simultaneously. 
    If you held the attack and reload keys simultaneously, your weapon ends up in an in-between state trying to do both, but is stuck.

- Set reload animation for the player model.
    If the player reloaded, the player model would not show any reload animation, making it impossible for other players to see a player reloading a shotgun.
