### PR TITLE
Tf2 afterburn time fix

### DIFF
--- a/src/game/shared/tf/tf_player_shared.cpp
+++ b/src/game/shared/tf/tf_player_shared.cpp
@@ -2884,11 +2884,11 @@ void CTFPlayerShared::ConditionGameRulesThink( void )
 #endif // DEBUG
 
 				// which degree are we burning?
-				if ( m_flAfterburnDuration >= tf_afterburn_duration_ratio_third_degree * tf_afterburn_max_duration )
+				if ( m_flAfterburnDuration >= tf_afterburn_duration_ratio_third_degree * m_flAfterburnMaxDuration )
 				{
 					flBurnDamage *= tf_afterburn_mult_third_degree;
 				}
-				else if ( m_flAfterburnDuration >= tf_afterburn_duration_ratio_second_degree * tf_afterburn_max_duration )
+				else if ( m_flAfterburnDuration >= tf_afterburn_duration_ratio_second_degree * m_flAfterburnMaxDuration )
 				{
 					flBurnDamage *= tf_afterburn_mult_second_degree;
 				}
@@ -6580,12 +6580,18 @@ void CTFPlayerShared::Burn( CTFPlayer *pAttacker, CTFWeaponBase *pWeapon, float 
 	static float s_flReachMaxAfterburnTime = 0.f;
 #endif // DEBUG
 
+	// Cache mult_wpn_burntime instead of calling hook every time
+	float flMultWpnBurntime = 1.0f;
+	CALL_ATTRIB_HOOK_FLOAT_ON_OTHER( pWeapon, flMultWpnBurntime, mult_wpn_burntime );
+
 	if ( !InCond( TF_COND_BURNING ) )
 	{
 		// Start burning
 		AddCond( TF_COND_BURNING, -1.f, pAttacker );
 		m_flFlameBurnTime = gpGlobals->curtime + TF_BURNING_FREQUENCY;
+		m_flAfterburnMaxDuration = tf_afterburn_max_duration * flMultWpnBurntime;	// Updated only when starting to burn
 		m_flAfterburnDuration = pWeapon ? pWeapon->GetInitialAfterburnDuration() : 0.f;
+		m_flAfterburnDuration *= flMultWpnBurntime;
 		
 		// Reduces direct healing effectiveness
 		AddCond( TF_COND_HEALING_DEBUFF, m_flAfterburnDuration, pAttacker );
@@ -6668,8 +6674,6 @@ void CTFPlayerShared::Burn( CTFPlayer *pAttacker, CTFWeaponBase *pWeapon, float 
 		flFlameLife = flBurningTime;
 	}
 	
-	CALL_ATTRIB_HOOK_FLOAT_ON_OTHER( pWeapon, flFlameLife, mult_wpn_burntime );
-
 	// flame immunity will always have a fixed duration
 	if ( bAfterburnImmunity )
 	{
@@ -6678,20 +6682,20 @@ void CTFPlayerShared::Burn( CTFPlayer *pAttacker, CTFWeaponBase *pWeapon, float 
 	// otherwise stack the duration
 	else
 	{
-		m_flAfterburnDuration += flFlameLife;
+		m_flAfterburnDuration += flFlameLife * flMultWpnBurntime;
 	}
 
-	m_flAfterburnDuration = Clamp( m_flAfterburnDuration, 0.f, tf_afterburn_max_duration );
+	m_flAfterburnDuration = Clamp( m_flAfterburnDuration, 0.f, m_flAfterburnMaxDuration );
 
 #ifdef DEBUG
 	if ( tf_afterburn_debug.GetBool() )
 	{
 		engine->Con_NPrintf( 1, "Added afterburn duration = %f", m_flAfterburnDuration );
 
-		if ( s_flReachMaxAfterburnTime == 0.f && m_flAfterburnDuration == tf_afterburn_max_duration )
+		if ( s_flReachMaxAfterburnTime == 0.f && m_flAfterburnDuration == flAfterburnMaxDuration )
 		{
 			s_flReachMaxAfterburnTime = gpGlobals->curtime;
-			DevMsg( "took %f seconds to reach max afterburn duration\n", s_flReachMaxAfterburnTime - s_flStartAfterburnTime );
+			DevMsg( "took %f seconds to reach max afterburn duration %f s\n", s_flReachMaxAfterburnTime - s_flStartAfterburnTime, flAfterburnMaxDuration );
 		}
 	}
 #endif // DEBUG

--- a/src/game/shared/tf/tf_player_shared.h
+++ b/src/game/shared/tf/tf_player_shared.h
@@ -1037,7 +1037,8 @@ private:
 	CHandle<CTFPlayer>		m_hOriginalBurnAttacker;		// Player who originally ignited this target
 	CHandle<CTFWeaponBase>	m_hBurnWeapon;
 	float					m_flFlameBurnTime;
-	float					m_flAfterburnDuration;
+	float					m_flAfterburnDuration;			// Active afterburn duration
+	float					m_flAfterburnMaxDuration;		// Maximum afterburn duration
 
 	// Bleeding
 	struct bleed_struct_t

--- a/src/game/shared/tf/tf_weaponbase.h
+++ b/src/game/shared/tf/tf_weaponbase.h
@@ -554,7 +554,7 @@ class CTFWeaponBase : public CBaseCombatWeapon, public IHasOwner, public IHasGen
 	void			SetClipScale ( float flScale ) { m_flClipScale = flScale; }
 
 	virtual float	GetInitialAfterburnDuration() const { return 0.f; }
-	virtual float	GetAfterburnRateOnHit() const { return 0.f; }
+	virtual float	GetAfterburnRateOnHit() const { return 10.f; }
 
 // Client specific.
 #else


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description

Ever since Jungle Inferno updated the afterburn logic, the duration increase/decrease attribute (`mult_wpn_burntime`) has been very underwhelming because it only changes how quickly afterburn accumulates, not how long it actually lasts. This PR changes the attribute to affect also the initial and the maximum afterburn time.

The attribute `set_dmgtype_ignite` has been broken too because the default `GetAfterburnRateOnHit()` was set to zero, meaning it does not work for weapons that do not override it. The exact value does not matter as long as it is non-zero but it allows content creators to customise the duration with `mult_wpn_burntime`. This does not change any weapon that by default ignites target.