### PR TITLE
[HL2DM] Fixed ladder bugs

### DIFF
--- a/src/game/server/hl2mp/hl2mp_player.h
+++ b/src/game/server/hl2mp/hl2mp_player.h
@@ -143,6 +143,8 @@ public:
 
 	bool IsThreatAimingTowardMe( CBaseEntity* threat, float cosTolerance = 0.8f ) const;
 	bool IsThreatFiringAtMe( CBaseEntity* threat ) const;
+
+	void LadderRespawnFix();
 private:
 
 	CNetworkQAngle( m_angEyeAngles );

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -823,6 +823,9 @@ public:
 		}
 	}
 
+	float GetLadderCooldownTime() const { return m_flLadderCooldownTime; }
+	void SetLadderCooldownTime( float cooldownTime ) { m_flLadderCooldownTime = cooldownTime; }
+
 private:
 	// How much of a movement time buffer can we process from this user?
 	int				m_nMovementTicksForUserCmdProcessingRemaining;
@@ -838,6 +841,7 @@ private:
 
 	int					DetermineSimulationTicks( void );
 	void				AdjustPlayerTimeBase( int simulation_ticks );
+	float				m_flLadderCooldownTime;
 
 public:
 	

--- a/src/game/shared/hl2/hl_gamemovement.cpp
+++ b/src/game/shared/hl2/hl_gamemovement.cpp
@@ -468,8 +468,27 @@ bool CHL2GameMovement::ExitLadderViaDismountNode( CFuncLadder *ladder, bool stri
 			continue;
 		}
 
+		// Now perform a trace to ensure there is a clear line of sight
+		// between the player and the dismount node
+		trace_t losTrace;
+		Vector playerPos = mv->GetAbsOrigin() + player->GetViewOffset(); // Player's view position
+
+		UTIL_TraceLine( playerPos, org, MASK_PLAYERSOLID, player, COLLISION_GROUP_PLAYER_MOVEMENT, &losTrace );
+
+		// Peter: If there's an obstruction (a wall or other object) 
+		// between the player and the dismount node, skip it.
+		// There is an option in Hammer to prevent this, but 
+		// level designer tend to forget to properly set this, so maps 
+		// like dm_assault that have two ladders on either side means 
+		// players can clip through walls and I fail to see 
+		// why this should be a gameplay feature.
+		if ( losTrace.fraction != 1.0f )
+		{
+			continue;
+		}
+
 		// Find the best dot product
-		Vector vecToSpot = org - ( mv->GetAbsOrigin() + player->GetViewOffset() );
+		Vector vecToSpot = org - playerPos;
 		vecToSpot.z = 0.0f;
 		float d = VectorNormalize( vecToSpot );
 
@@ -964,6 +983,14 @@ bool CHL2GameMovement::LadderMove( void )
 
 	if ( !ladder )
 	{
+#ifdef GAME_DLL
+		// Check if the player is still in the cooldown period after dismounting the ladder
+		if ( gpGlobals->curtime < GetHL2Player()->GetLadderCooldownTime() )
+		{
+			// Player is still in cooldown, prevent mounting
+			return false;
+		}
+#endif
 		Findladder( 64.0f, &bestLadder, bestOrigin, NULL );
 	}
 
@@ -1083,6 +1110,11 @@ bool CHL2GameMovement::LadderMove( void )
 		{
 			mv->m_vecVelocity.z = mv->m_vecVelocity.z + 50;
 		}
+
+#ifdef GAME_DLL
+		// Set cooldown time for remounting the ladder (0.5 seconds) - server-side only
+		GetHL2Player()->SetLadderCooldownTime( gpGlobals->curtime + 0.5f );
+#endif
 		return false;
 	}
 
@@ -1188,9 +1220,7 @@ bool CHL2GameMovement::CanAccelerate()
 	}
 #endif
 
-	BaseClass::CanAccelerate();
-
-	return true;
+	return BaseClass::CanAccelerate();
 }
 
 

--- a/src/game/shared/hl2mp/hl2mp_gamerules.cpp
+++ b/src/game/shared/hl2mp/hl2mp_gamerules.cpp
@@ -1026,6 +1026,7 @@ void CHL2MPRules::RestartGame()
 			pPlayer->GetActiveWeapon()->Holster();
 		}
 		pPlayer->RemoveAllItems( true );
+		pPlayer->LadderRespawnFix();
 		respawn( pPlayer, false );
 		pPlayer->Reset();
 	}


### PR DESCRIPTION
This PR is to fix ladder issues.

- Fixed a bug where players could respawn on ladders. 
    Players could spawn or respawn on ladders during mp_restartgame or suicide for example.

- Fixed an issue where players disconnecting while on a ladder would cause it to become inoperable. 
    Disconnecting when mounting a ladder would cause it to break.

- Movement fixes.
    Properly move in the direction you are looking.

- Fixed an exploit where some players could use climb ladders at insane speeds. 
    Notorious speedrun trick among speedrunners, you could, through manual inputs or scripts/macros, climb ladders at a very fast pace.

- Fixed an issue where players could dismount ladders and go through walls.
    Minor issue since most maps do not have this setup, but if two ladders are on two sides of the same wall, then players could clip through walls to the dismount node.


