### PR TITLE
[HL2DM] Disable client-side blood impacts and blood decals

### DIFF
--- a/src/game/client/hl2mp/c_hl2mp_player.cpp
+++ b/src/game/client/hl2mp/c_hl2mp_player.cpp
@@ -185,11 +185,13 @@ void C_HL2MP_Player::TraceAttack( const CTakeDamageInfo &info, const Vector &vec
 				return;
 		}
 
+		/*
 		if ( blood != DONT_BLEED )
 		{
 			SpawnBlood( vecOrigin, vecDir, blood, flDistance );// a little surface blood.
 			TraceBleed( flDistance, vecDir, ptr, info.GetDamageType() );
 		}
+		*/
 	}
 }
 

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -918,6 +918,8 @@ void CBasePlayer::DrawDebugGeometryOverlays(void)
 //=========================================================
 void CBasePlayer::TraceAttack( const CTakeDamageInfo &inputInfo, const Vector &vecDir, trace_t *ptr, CDmgAccumulator *pAccumulator )
 {
+	CDisablePredictionFiltering disabler;
+
 	if ( m_takedamage )
 	{
 		CTakeDamageInfo info = inputInfo;


### PR DESCRIPTION
This PR is really super simple. Discussed in #829, this moves all the client-side blood to the server's side to provide accurate hit information. The main problem with it being client-side in the first place is that a blood impacts may not guarantee a hit. By having be server-sided, if blood is shown, a hit is confirmed.