### PR TITLE
[TF2] Remove temporary player jingle files if tf_delete_temp_files is enabled

### DIFF
--- a/src/game/client/tf/clientmode_tf.cpp
+++ b/src/game/client/tf/clientmode_tf.cpp
@@ -531,6 +531,7 @@ void ClientModeTFNormal::Shutdown()
 	{
 		RemoveFilesInPath( "materials/temp" );
 		RemoveFilesInPath( "download/user_custom" );
+		RemoveFilesInPath( "sound/temp" );
 	}
 
 	DestroyStatsSummaryPanel();


### PR DESCRIPTION
# Description
Currently, only sprays and files in the `download/user_custom` path are removed on shutdown if `tf_delete_temp_files` is enabled, leaving temporary sound files from the oft-forgotten "jingle" feature untouched. These files are also commonly referred to as "sound sprays".

This PR fixes this by also removing these files on shutdown if the said cvar is enabled.

Resolves https://github.com/ValveSoftware/Source-1-Games/issues/4014