### PR TITLE
Fix potential game freeze from infinite while-loop in GetGroundHeight

### DIFF
--- a/src/game/server/nav_mesh.cpp
+++ b/src/game/server/nav_mesh.cpp
@@ -1331,6 +1331,14 @@ public:
 bool CNavMesh::GetGroundHeight( const Vector &pos, float *height, Vector *normal ) const
 {
 	VPROF( "CNavMesh::GetGroundHeight" );
+	// IS_NAN complains when trying to read from &pos, so it needs a throwaway variable.
+	Vector temp = pos;
+	for ( int i = 0; i < 3; i++ ) {
+		if ( IS_NAN(temp[i])) {
+			DevMsg("GetGroundHeight got NaN as position input!\n");
+			return false;
+		}
+	}
 
 	const float flMaxOffset = 100.0f;
 


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
This PR fixes a potential infinite loop in `CNavMesh::GetGroundHeight()` by adding an early out if the position input is NaN.

The place that I noticed this being an issue is the TF2 Sentry Buster's mission behavior, which will input a vector of all NaNs if it doesn't have a mission target set.
I don't believe this can happen under normal circumstances currently, but if the `SetMission()` vscript function gets fixed then users who forget or simply don't know that they need to set a mission target first will find that their game will freeze, not crash, due to it getting stuck attempting to trace a line to the ground from NaN to NaN over and over again.

This probably could be fixed within the Sentry Buster's behavior too (`CTFBotMissionSuicideBomber::Update()`, specifically the line `if ( m_path.Compute( me, m_lastKnownVictimPosition, cost ) == false )`), especially since if a the path compute check fails 3 times the Sentry Buster starts its detonation, but I decided to go for the change in the NavMesh code in case other parts of the code may cause the same issue when used via vscript or sourcemods in ways not originally intended by the developers over a decade ago.

