### PR TITLE
[TF2] Fix MvM Medic uber not sticking when exiting spawn area

### DIFF
--- a/src/game/server/tf/bot/behavior/tf_bot_behavior.cpp
+++ b/src/game/server/tf/bot/behavior/tf_bot_behavior.cpp
@@ -190,9 +190,7 @@ ActionResult< CTFBot >	CTFBotMainAction::Update( CTFBot *me, float interval )
 		if ( myArea && myArea->HasAttributeTF( spawnRoomFlag ) )
 		{
 			// invading bots get uber while they leave their spawn so they don't drop their cash where players can't pick it up
-			me->m_Shared.AddCond( TF_COND_INVULNERABLE, 0.5f );
 			me->m_Shared.AddCond( TF_COND_INVULNERABLE_HIDE_UNLESS_DAMAGED, 0.5f );
-			me->m_Shared.AddCond( TF_COND_INVULNERABLE_WEARINGOFF, 0.5f );
 			me->m_Shared.AddCond( TF_COND_IMMUNE_TO_PUSHBACK, 1.0f );
 		}
 


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
Fixes bug described in https://github.com/mastercomfig/tf2-patches-old/issues/218 under title "Fix Medicbot’s Ubercharge not working properly when going out of the spawn":

> Robots are under the “TF_COND_INVULNERABLE_HIDE_UNLESS_DAMAGED” condition when in their func_respawnroom (only making them appear as Ubercharged when attacked). If an Uber Medic uses his Ubercharge when in the robot spawn (when his patient health is low), he will not stay Ubercharged (but his patient will). This is mostly problematic on Bigrock, where this can be done easily due to the robot not dropping down from their spawn.

Giving `TF_COND_INVULNERABLE` to robots in spawn area is not necessary and `TF_COND_INVULNERABLE_HIDE_UNLESS_DAMAGED` is enough. In testing I was not able to notice any difference in spawn protection behaviour.