### PR TITLE
tf2: Fix crash with game_round_win in koth

### DIFF
--- a/src/game/server/team_control_point_master.cpp
+++ b/src/game/server/team_control_point_master.cpp
@@ -1156,6 +1156,8 @@ int CTeamControlPointMaster::GetNumPointsOwnedByTeam( int iTeam )
 //-----------------------------------------------------------------------------	
 int CTeamControlPointMaster::CalcNumRoundsRemaining( int iTeam )
 {
+	if (m_ControlPointRounds.Count() == 0) return 0;
+
 	// To determine how many rounds remain for a given team if it consistently wins mini-rounds, we have to 
 	// simulate forward each mini-round and track the control point ownership that would result
 


### PR DESCRIPTION
The `game_round_win`'s `RoundWin` input would make the server on King of the Hill maps enter an infinite loop forever.
This patch fixes this.

Fixes https://github.com/ValveSoftware/Source-1-Games/issues/4254

<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->
