### PR TITLE
Remove MFC dependency in the launcher exe

### DIFF
--- a/src/launcher_main/launcher_main_mod_hl2mp.rc
+++ b/src/launcher_main/launcher_main_mod_hl2mp.rc
@@ -7,7 +7,7 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "afxres.h"
+#include "winres.h"
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS
@@ -43,7 +43,7 @@ END
 
 2 TEXTINCLUDE DISCARDABLE 
 BEGIN
-    "#include ""afxres.h""\r\n"
+    "#include ""winres.h""\r\n"
     "\0"
 END
 

--- a/src/launcher_main/launcher_main_mod_tf.rc
+++ b/src/launcher_main/launcher_main_mod_tf.rc
@@ -7,7 +7,7 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "afxres.h"
+#include "winres.h"
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS
@@ -43,7 +43,7 @@ END
 
 2 TEXTINCLUDE DISCARDABLE 
 BEGIN
-    "#include ""afxres.h""\r\n"
+    "#include ""winres.h""\r\n"
     "\0"
 END
 


### PR DESCRIPTION
# Description
This changes the file included in the .rc files for the launcher exe from afxres.h to winres.h, in order to allow users without MFC installed to compile the game. This does not remove it from other util .rc files which do depend on MFC.
afxres is the MFC equivalent of winres, and old versions of Visual Studio would create rc files with that included by default instead of winres, even if the project did not use MFC.