### PR TITLE
[TF2] Fix thirdperson weapon shell ejection

### DIFF
--- a/src/game/shared/tf/tf_weaponbase.cpp
+++ b/src/game/shared/tf/tf_weaponbase.cpp
@@ -331,6 +331,7 @@ CTFWeaponBase::CTFWeaponBase()
 	
 #ifdef CLIENT_DLL
 	m_iCachedModelIndex = 0;
+	m_hEjectBrassWeapon = NULL;
 	m_iEjectBrassAttachpoint = -2;
 
 	m_bInitViewmodelOffset = false;
@@ -4836,6 +4837,10 @@ bool CTFWeaponBase::OnFireEvent( C_BaseViewModel *pViewModel, const Vector& orig
 {
 	if ( event == 6002 && ShouldEjectBrass() )
 	{
+		m_hEjectBrassWeapon = GetWeaponForEffect();
+		if ( !m_hEjectBrassWeapon )
+			return true;
+
 		if ( UsingViewModel() && !g_pClientMode->ShouldDrawViewModel() )
 		{
 			// Prevent effects when the ViewModel is hidden with r_drawviewmodel=0
@@ -4846,16 +4851,16 @@ bool CTFWeaponBase::OnFireEvent( C_BaseViewModel *pViewModel, const Vector& orig
 		// Look for 'eject_brass' attachment first instead of using options which is a seemingly magic number
 		if ( m_iEjectBrassAttachpoint == -2 )
 		{
-			m_iEjectBrassAttachpoint = pViewModel->LookupAttachment( "eject_brass" );
+			m_iEjectBrassAttachpoint = m_hEjectBrassWeapon->LookupAttachment( "eject_brass" );
 		}
 
 		if ( m_iEjectBrassAttachpoint > 0 )
 		{
-			pViewModel->GetAttachment( m_iEjectBrassAttachpoint, data.m_vOrigin, data.m_vAngles );
+			m_hEjectBrassWeapon->GetAttachment( m_iEjectBrassAttachpoint, data.m_vOrigin, data.m_vAngles );
 		}
 		else
 		{
-			pViewModel->GetAttachment( atoi(options), data.m_vOrigin, data.m_vAngles );
+			m_hEjectBrassWeapon->GetAttachment( atoi(options), data.m_vOrigin, data.m_vAngles );
 		}
 		data.m_nDamageType = GetAttributeContainer()->GetItem() ? GetAttributeContainer()->GetItem()->GetItemDefIndex() : 0;
 		data.m_nHitBox = GetWeaponID();

--- a/src/game/shared/tf/tf_weaponbase.h
+++ b/src/game/shared/tf/tf_weaponbase.h
@@ -718,6 +718,8 @@ protected:
 #ifdef CLIENT_DLL
 	bool m_bOldResetParity;
 	int m_iCachedModelIndex;
+
+	EHANDLE m_hEjectBrassWeapon;
 	int m_iEjectBrassAttachpoint;
 
 #endif


### PR DESCRIPTION
Fixes weapon shell ejection coming out of the wrong spot when in thirdperson, by using the fix already used by the minigun's brass particle.

Before:

https://github.com/user-attachments/assets/ffed78d4-3b4a-476f-8784-e3005bc26eb8

After:

https://github.com/user-attachments/assets/eac09fac-6e0d-49b7-aa8d-5c7e0699e38c

