### PR TITLE
VScript: VectorAngles and VectorAnglesReference

### DIFF
--- a/src/game/server/vscript_server.cpp
+++ b/src/game/server/vscript_server.cpp
@@ -1208,6 +1208,20 @@ QAngle RotateOrientation( QAngle posAngles, QAngle entAngles )
 	return outAngles;
 }
 
+QAngle ScriptVectorAngles( const Vector forward )
+{
+	QAngle outAngles;
+	VectorAngles( forward, outAngles );
+	return outAngles;
+}
+
+QAngle ScriptVectorAnglesReference( const Vector forward, const Vector pseudoup )
+{
+	QAngle outAngles;
+	VectorAngles( forward, pseudoup, outAngles );
+	return outAngles;
+}
+
 //-----------------------------------------------------------------------------
 static void ParseTable( CBaseEntity *pEntity, HSCRIPT spawn_table, const char *pKeyNameOverride = NULL )
 {
@@ -2522,6 +2536,9 @@ bool VScriptServerInit()
 
 				ScriptRegisterFunction( g_pScriptVM, RotatePosition, "Rotate a Vector around a point." );
 				ScriptRegisterFunction( g_pScriptVM, RotateOrientation, "Rotate a QAngle by another QAngle." );
+				ScriptRegisterFunctionNamed( g_pScriptVM, ScriptVectorAngles, "VectorAngles", "Create a QAngle from a direction vector, relative to the world." );
+				ScriptRegisterFunctionNamed( g_pScriptVM, ScriptVectorAnglesReference, "VectorAnglesReference", "Create a QAngle from a direction vector, relative to a provided vector." );
+
 				ScriptRegisterFunctionNamed( g_pScriptVM, Script_EmitSoundOn, "EmitSoundOn", "Play named sound on Entity. Legacy only, use EmitSoundEx." );
 				ScriptRegisterFunctionNamed( g_pScriptVM, Script_EmitSoundOnClient, "EmitSoundOnClient", "Play named sound only on the client for the passed in player. NOTE: This only supports soundscripts. Legacy only, use EmitSoundEx." );
 				ScriptRegisterFunctionNamed( g_pScriptVM, Script_EmitSoundEx, "EmitSoundEx", "Play a sound. Takes in a script table of params." );


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
Exposes the commonly-used VectorAngles function to VScript.

This allows for a QAngle to be created from a direction vector. This can either be relative to the global up direction, or to a reference up (exposed by VectorAnglesReference through the C++ `VectorAngles( Vector&, Vector&, QAngle& )` overload.)