### PR TITLE
Fix Sentry Buster game freeze if victim is invalid

### DIFF
--- a/src/game/server/tf/bot/behavior/missions/tf_bot_mission_suicide_bomber.cpp
+++ b/src/game/server/tf/bot/behavior/missions/tf_bot_mission_suicide_bomber.cpp
@@ -48,7 +48,7 @@ ActionResult< CTFBot >	CTFBotMissionSuicideBomber::OnStart( CTFBot *me, Action< 
 //---------------------------------------------------------------------------------------------
 ActionResult< CTFBot >	CTFBotMissionSuicideBomber::Update( CTFBot *me, float interval )
 {
-	// one we start detonating, there's no turning back
+	// once we start detonating, there's no turning back
 	if ( m_detonateTimer.HasStarted() )
 	{
 		if ( m_detonateTimer.IsElapsed() )
@@ -111,6 +111,13 @@ ActionResult< CTFBot >	CTFBotMissionSuicideBomber::Update( CTFBot *me, float int
 				m_lastKnownVictimPosition = sentry->GetOwner()->GetAbsOrigin();
 			}
 		}
+	}
+	else
+	{
+		// If there's no victim - detonate
+		StartDetonate( me );
+
+		return Continue();
 	}
 
 	// Get to a third of the damage range before detonating


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
Technically supersedes #963, although arguably serves a different purpose. 

If the Sentry Buster doesn't have a valid victim, `m_lastKnownVictimPosition` is never initialized, which leads to the game freezing in a while loop in `CNavMesh::GetGroundHeight()` (called by `m_path.Compute()` in the buster code)

This fixes that by starting the detonation sequence if m_victim is NULL

This doesn't happen under normal circumstances since Sentry Busters are only spawned by the Populator system, and when it does that it makes sure to set a victim, however with vscript functions such as `SetMission()` (if it gets fixed), and people potentially doing wacky things with Sentry Busters in their mods of TF2, this becomes an issue.

## Some Notes
In most of the other AI actions/missions, is something happens akin to not having a victim, it will simply return `Done()` and essentially signal the NextBot to move on to a different thing, or simply find a new target. The sentry buster is a bit different since it only has the one mission, needs to stay in that mission to explode, and its behavior kind of relies on not being able to recalculate its victim (even when the engineer picks up his sentry, it doesn't technically update the victim to him, it just updates the position value to his position, so if he places it back down it will target the sentry again and not him)

While I considered adding in code to find a new victim if it is invalid, I decided against it partially due to the above constraints, and also because I think that some people might want to be able to just force a sentry buster to explode on command by just changing the mission without setting a target. Also I think that for people attempting to work with sentry buster missions, a bot instantly deciding to explode is a clearer indicator that something might be wrong than simply randomly picking a new target.