### PR TITLE
[TF2] Custom kill icon support

### DIFF
--- a/src/game/client/hud.cpp
+++ b/src/game/client/hud.cpp
@@ -533,6 +533,8 @@ void CHud::LevelInit( void )
 		group->bHidden = false;
 		group->m_pLockingElements.Purge();
 	}
+
+	RefreshHudTextures();
 }
 
 //-----------------------------------------------------------------------------
@@ -811,6 +813,14 @@ void CHud::RefreshHudTextures()
 
 	CUtlDict< CHudTexture *, int >	textureList;
 
+	// loading custom kill icons, presumably packed into the map
+	LoadHudTextures( textureList, "scripts/map_textures", NULL );
+	int co = textureList.Count();
+	for ( int index = 0; index < co; index++ )
+	{
+		CHudTexture* tex = textureList[ index ];
+		AddSearchableHudIconToList( *tex );
+	}
 	// check to see if we have sprites for this res; if not, step down
 	LoadHudTextures( textureList, "scripts/hud_textures", NULL );
 	LoadHudTextures( textureList, "scripts/mod_textures", NULL );

--- a/src/game/server/pointhurt.cpp
+++ b/src/game/server/pointhurt.cpp
@@ -22,6 +22,9 @@ BEGIN_DATADESC( CPointHurt )
 	DEFINE_KEYFIELD( m_flDelay, FIELD_FLOAT, "DamageDelay" ),
 	DEFINE_KEYFIELD( m_bitsDamageType, FIELD_INTEGER, "DamageType" ),
 	DEFINE_KEYFIELD( m_strTarget, FIELD_STRING, "DamageTarget" ),
+#ifdef TF_DLL
+	DEFINE_KEYFIELD( m_szKillIcon, FIELD_STRING, "KillIcon" ),
+#endif // TF_DLL
 	
 	// Function Pointers
 	DEFINE_FUNCTION( HurtThink ),

--- a/src/game/server/pointhurt.h
+++ b/src/game/server/pointhurt.h
@@ -27,4 +27,7 @@ public:
 	float		m_flDelay;
 	string_t	m_strTarget;
 	EHANDLE		m_pActivator;
+#ifdef TF_DLL
+	string_t m_szKillIcon;
+#endif // TF_DLL
 };

--- a/src/game/server/tf/func_croc.cpp
+++ b/src/game/server/tf/func_croc.cpp
@@ -18,6 +18,7 @@ LINK_ENTITY_TO_CLASS( func_croc, CFuncCroc );
 
 BEGIN_DATADESC( CFuncCroc )
 	DEFINE_KEYFIELD( m_iszModel, FIELD_STRING, "croc_model" ),
+	DEFINE_KEYFIELD( m_iszKillIcon, FIELD_STRING, "killicon" ),
 	// Outputs
 	DEFINE_OUTPUT( m_OnEat, "OnEat" ),
 	DEFINE_OUTPUT( m_OnEatRed, "OnEatRed" ),
@@ -103,6 +104,7 @@ void CEntityCroc::Think( void )
 CFuncCroc::CFuncCroc()
 {
 	m_iszModel = NULL_STRING;
+	m_iszKillIcon = NULL_STRING;
 }
 
 //-----------------------------------------------------------------------------
@@ -208,4 +210,14 @@ const char *CFuncCroc::GetCrocModel( void )
 	}
 
 	return CROC_MODEL;
+}
+
+//-----------------------------------------------------------------------------
+// Purpose:
+//-----------------------------------------------------------------------------
+const char *CFuncCroc::GetKillIcon( void )
+{
+	if ( m_iszKillIcon != NULL_STRING )
+		return ( STRING( m_iszKillIcon ) );
+	return "crocodile";
 }

--- a/src/game/server/tf/func_croc.h
+++ b/src/game/server/tf/func_croc.h
@@ -49,10 +49,12 @@ public:
 	void FireOutputs( CTFPlayer *pTFPlayer );
 
 	const char *GetCrocModel( void );
+	const char *GetKillIcon( void );
 
 private:
 
 	string_t m_iszModel;
+	string_t m_iszKillIcon;
 
 	COutputEvent m_OnEat;
 	COutputEvent m_OnEatRed;

--- a/src/game/server/triggers.cpp
+++ b/src/game/server/triggers.cpp
@@ -666,6 +666,9 @@ BEGIN_DATADESC( CTriggerHurt )
 	DEFINE_KEYFIELD( m_bitsDamageInflict, FIELD_INTEGER, "damagetype" ),
 	DEFINE_KEYFIELD( m_damageModel, FIELD_INTEGER, "damagemodel" ),
 	DEFINE_KEYFIELD( m_bNoDmgForce, FIELD_BOOLEAN, "nodmgforce" ),
+#ifdef TF_DLL
+	DEFINE_KEYFIELD( m_szKillIcon, FIELD_STRING, "killicon" ),
+#endif // TF_DLL
 
 	DEFINE_FIELD( m_flLastDmgTime, FIELD_TIME ),
 	DEFINE_FIELD( m_flDmgResetTime, FIELD_TIME ),

--- a/src/game/server/triggers.h
+++ b/src/game/server/triggers.h
@@ -210,6 +210,9 @@ public:
 	int		m_bitsDamageInflict;	// DMG_ damage type that the door or tigger does
 	int		m_damageModel;
 	bool	m_bNoDmgForce;		// Should damage from this trigger impart force on what it's hurting
+#ifdef TF_DLL
+	string_t m_szKillIcon;
+#endif // TF_DLL
 
 	enum
 	{

--- a/src/game/shared/tf/tf_gamerules.cpp
+++ b/src/game/shared/tf/tf_gamerules.cpp
@@ -127,6 +127,8 @@
 	#include "tf_party.h"
 	#include "tf_autobalance.h"
 	#include "player_voice_listener.h"
+	#include "pointhurt.h"
+	#include "func_croc.h"
 #endif
 
 #include "tf_mann_vs_machine_stats.h"
@@ -12227,7 +12229,11 @@ const char *CTFGameRules::GetKillingWeaponName( const CTakeDamageInfo &info, CTF
 		}
 		else
 		{
-			killer_weapon_name = "crocodile";
+			CFuncCroc *pFuncCroc = dynamic_cast<CFuncCroc*>( pInflictor );
+			if ( pFuncCroc )
+			{
+		        killer_weapon_name = pFuncCroc->GetKillIcon();
+            }
 		}
 	}
 	else if ( info.GetDamageCustom() == TF_DMG_CUSTOM_BOOTS_STOMP )
@@ -12389,6 +12395,28 @@ const char *CTFGameRules::GetKillingWeaponName( const CTakeDamageInfo &info, CTF
 		{
 			killer_weapon_name = "megaton";
 		}
+		else
+		{
+			CTriggerHurt *pTriggerHurt = dynamic_cast<CTriggerHurt*>( pInflictor );
+			if ( pTriggerHurt )
+			{
+				if ( pTriggerHurt->m_szKillIcon != NULL_STRING )
+				{
+		        	killer_weapon_name = STRING( pTriggerHurt->m_szKillIcon );
+				}
+            }
+			else
+			{
+				CPointHurt *pPointHurt = dynamic_cast<CPointHurt*>( pInflictor );
+				if ( pPointHurt )
+				{
+					if ( pPointHurt->m_szKillIcon != NULL_STRING )
+					{
+						killer_weapon_name = STRING( pPointHurt->m_szKillIcon );
+					}
+				}
+			}
+		}
 	}
 	else if ( pScorer && pInflictor && ( pInflictor == pScorer ) )
 	{
@@ -12474,6 +12502,18 @@ const char *CTFGameRules::GetKillingWeaponName( const CTakeDamageInfo &info, CTF
 						else if ( *iWeaponID == TF_WEAPON_CANNON )
 						{
 							killer_weapon_name = "loose_cannon_reflect";
+						}
+					}
+				}
+				else
+				{
+					// point_hurt won't set damageCustom to TF_DMG_CUSTOM_TRIGGER_HURT if it can't pass through uber
+					CPointHurt *pPointHurt = dynamic_cast<CPointHurt*>( pInflictor );
+					if ( pPointHurt )
+					{
+						if ( pPointHurt->m_szKillIcon != NULL_STRING )
+						{
+							killer_weapon_name = STRING( pPointHurt->m_szKillIcon );
 						}
 					}
 				}


### PR DESCRIPTION
### Description
This PR allows mappers to define custom kill icons by packing a new file called `scripts/map_textures.txt` that's structured identical to the game's `scripts/mod_textures.txt` where the stock kill icons are defined.
This PR also reloads kill icons on LevelInit.

Custom materials/textures are fully supported (unless different maps happened to store non-identical textures under the same name, which is a broader issue with asset caching anyway).

There's several ways for mappers to make use of this feature:
- This PR adds a keyvalue `killicon` to `trigger_hurt`, `func_croc` and `point_hurt`. When not empty, its value will be used as the kill icon name.
- By default, the game uses the inflictor's `classname` keyvalue for the kill icon name. Using VScript, you can use OnTakeDamage hook to assign a dummy entity as the inflictor:
```js
myCustomInflictor <- SpawnEntityFromTable("info_target", { classname = "my_custom_kill_icon" });
<...>
OnScriptHook_OnTakeDamage = function(params)
{
  if (/* insert condition */)
    params.inflictor = myCustomInflictor;
}
```
- It's possible to change `classname` of an existing entity with a map output `MyEntityName | AddOutput | classname my_custom_kill_icon` or with a VScript call `myEntity.KeyValueFromString("classname", "my_custom_kill_icon")`. However, the side-effects of this change are unclear and I recommend the other 2 methods.

### Considerations

- All changes to the kill icon loading procedure are contained within hud.cpp, in case if you want to merge only the icon loading functionality without adding the `killicon` keyvalue.
- While I've tested compatibility with `sv_pure` to the best of my ability, the sv_pure system works in mysterious ways.
- I've benchmarked the time it takes to reload the kill icons - it's negligible.
- An alternative path for the file could be `maps/%bspname%_map_textures.txt`, but keeping the file name in sync with the bsp name is very annoying to deal with during map development, and there is no need for this naming convention here, as the file appears to get reloaded between maps correctly.
- This PR unintentionally makes it possible to pack `scripts/mod_textures.txt` that will override the stock file until the map change. In fact, it's _already_ possible in Live TF2, but it requires the user to use `hud_reloadscheme` command for changes to take effect.
I see this as non-issue, as if a bad actor wants to mess with players with a poisoned map, there's many other opportunities to do so.
If you disagree, this can be fixed with the following change to hud.cpp that will force the game to load `hud_textures` and `mod_textures` from the _game's_ files.
```diff
-	LoadHudTextures( textureList, "scripts/hud_textures", NULL );
-	LoadHudTextures( textureList, "scripts/mod_textures", NULL );
+	const char* dudKey = "123";
+	LoadHudTextures( textureList, "scripts/hud_textures", (const unsigned char*) dudKey );
+	LoadHudTextures( textureList, "scripts/mod_textures", (const unsigned char*) dudKey );
```