### PR TITLE
Expose GetBotVisionInterface to VScript

### DIFF
--- a/src/game/server/NextBot/NextBotVisionInterface.cpp
+++ b/src/game/server/NextBot/NextBotVisionInterface.cpp
@@ -799,4 +799,33 @@ bool IVision::IsLookingAt( const CBaseCombatCharacter *actor, float cosTolerance
 	return IsLookingAt( actor->EyePosition(), cosTolerance );
 }
 
+BEGIN_ENT_SCRIPTDESC( IVision, INextBotComponent, "Next bot vision" )
 
+	// DEFINE_SCRIPTFUNC( CollectKnownEntities, "Collects all known entities into the given vector" ) // todo: figure out how to serialize Vectors into a vscript datatype
+	// DEFINE_SCRIPTFUNC( IsAwareOf, "Returns true if we are aware of the given entity" ) // private member function
+
+	DEFINE_SCRIPTFUNC_WRAPPED( GetPrimaryKnownThreat, "Returns the most dangerous threat from the set of known entities" )
+	DEFINE_SCRIPTFUNC( GetTimeSinceVisible, "Returns the time since the bot saw any member of a given team" )
+	DEFINE_SCRIPTFUNC_WRAPPED( GetClosestKnown, "Returns the closest recognized entity, optionally filtered by team" )
+	DEFINE_SCRIPTFUNC_WRAPPED( GetKnown, "Returns our known version of the given entity, or NULL if unknown" )
+	DEFINE_SCRIPTFUNC( GetKnownCount, "Returns the number of known entities on a given team closer than rangeLimit" )
+	DEFINE_SCRIPTFUNC_WRAPPED( AddKnownEntity, "Introduces a known entity into the system" )
+	DEFINE_SCRIPTFUNC_WRAPPED( ForgetEntity, "Removes the given entity from the bots list of known entities" )
+	DEFINE_SCRIPTFUNC( ForgetAllKnownEntities, "Removes all entities from the bots list of known entities" )
+	DEFINE_SCRIPTFUNC( GetMaxVisionRange, "Get the bots max vision range" )
+	DEFINE_SCRIPTFUNC( GetMinRecognizeTime, "Get the minimum time required to recognize an entity" )
+	//DEFINE_SCRIPTFUNC_WRAPPED( IsAbleToSeeEntity, "Checks if the bot can see the given Entity handle" )
+	DEFINE_SCRIPTFUNC_WRAPPED( IsAbleToSee, "Checks if the bot can see the given vector" )	
+	DEFINE_SCRIPTFUNC_WRAPPED( IsIgnored, "Returns true if we should ignore the given entity" )
+	DEFINE_SCRIPTFUNC_WRAPPED( IsVisibleEntityNoticed, "Returns true if the given visible entity has been noticed" )
+	DEFINE_SCRIPTFUNC_WRAPPED( IsInFieldOfView, "Checks if a given Vector is in the bots field of view" )
+	DEFINE_SCRIPTFUNC_WRAPPED( IsEntityInFieldOfView, "Checks if a given Entity handle is in the bots field of view" )
+	DEFINE_SCRIPTFUNC( GetDefaultFieldOfView, "Returns the default field of view in degrees" )
+	DEFINE_SCRIPTFUNC( GetFieldOfView, "Gets the bots field of view" )
+	DEFINE_SCRIPTFUNC( SetFieldOfView, "Sets the horizontal field of view angle in degrees" )
+	DEFINE_SCRIPTFUNC( IsLineOfSightClear, "Returns true if the ray to the given point is unobstructed" )
+	//DEFINE_SCRIPTFUNC_WRAPPED( IsLineOfSightClearToEntity, "Returns true if line of sight to the given entity is clear" )
+	DEFINE_SCRIPTFUNC_WRAPPED( IsLookingAt, "Checks if the bot is looking at the given position" )
+	//DEFINE_SCRIPTFUNC_WRAPPED( IsLookingAtPlayer, "Checks if the bot is looking at the given player handle" )
+
+END_SCRIPTDESC();

--- a/src/game/server/tf/bot/tf_bot.h
+++ b/src/game/server/tf/bot/tf_bot.h
@@ -295,7 +295,6 @@ public:
 	CTFNavArea *GetHomeArea( void ) const;
 	void ScriptSetHomeArea( HSCRIPT hScript ) { this->SetHomeArea( ToNavArea( hScript ) ); }
 	HSCRIPT ScriptGetHomeArea( void ) { return ToHScript( this->GetHomeArea() ); }
-
 	CObjectSentrygun *GetEnemySentry( void ) const;			// if we've been attacked/killed by an enemy sentry, this will return it, otherwise NULL
 	void RememberEnemySentry( CObjectSentrygun *sentry, const Vector &injurySpot );
 	const Vector &GetSpotWhereEnemySentryLastInjuredMe( void ) const;

--- a/src/game/shared/tf/tf_item_inventory.cpp
+++ b/src/game/shared/tf/tf_item_inventory.cpp
@@ -965,7 +965,10 @@ void CTFPlayerInventory::LoadLocalLoadout()
 
 					CEconItemView *pItem = GetInventoryItemByItemID(uItemId);
 					if (pItem) {
-						pItem->GetSOCData()->Equip(iClass, iSlot);
+						CEconItem *pEconItem = pItem->GetSOCData();
+						if (pEconItem) {
+							pEconItem->Equip(iClass, iSlot);
+						}
 					}
 				}
 			}

--- a/src/game/shared/tf/tf_item_inventory.cpp
+++ b/src/game/shared/tf/tf_item_inventory.cpp
@@ -965,10 +965,7 @@ void CTFPlayerInventory::LoadLocalLoadout()
 
 					CEconItemView *pItem = GetInventoryItemByItemID(uItemId);
 					if (pItem) {
-						CEconItem *pEconItem = pItem->GetSOCData();
-						if (pEconItem) {
-							pEconItem->Equip(iClass, iSlot);
-						}
+						pItem->GetSOCData()->Equip(iClass, iSlot);
 					}
 				}
 			}


### PR DESCRIPTION
The VScript API has a few functions for getting various bot interfaces, however only GetLocomotionInterface was actually correctly exposed, and ILocomotion is the only class that exists in the root table with any existing functions.

While it would be nice to have all of the other interfaces exposed, IVision is, in my opinion, the most valuable one to have.

The commented out script functions in NextBotVisionInterface.cpp were not done correctly and will not compile, and most of them are not too useful anyway (all of the ones targetting Entities can just be given ent.EyePosition() or ent.GetOrigin() to achieve the same thing).

I've also attached an example vscript file to test all of the vision interface functions:

- save file to tf/scripts/vscripts and change the extension from .txt to .nut
- load any mvm map (mvm_decoy has no delay before bots start spawning)
- uncomment a bot.GetScriptScope().ThreatThink function, change values as necessary to test
- script_execute `visiontest`
- start the wave (can skip the 10s timer by doing ```ent_fire "tf_gamerules" "runscriptcode" "NetProps.SetPropFloat(self, `m_flRestartRoundTime`, 1)"``` )
- tf_mvm_jump_to_wave 1 to reset, `ent_fire "player" "TerminateScriptScope"` to kill the think function on the bots
- comment out the confirmed working think function and uncomment another one
- repeat