### PR TITLE
[VRAD] Added support for setting the number of ambient light samples (cubes) per leaf.

### DIFF
--- a/src/utils/vbsp/vbsp.cpp
+++ b/src/utils/vbsp/vbsp.cpp
@@ -1196,7 +1196,7 @@ int RunVBSP( int argc, char **argv )
 			Warning(
 				"Other options  :\n"
 				"  -novconfig   : Don't bring up graphical UI on vproject errors.\n"
-				"  -threads     : Control the number of threads vbsp uses (defaults to the # of\n"
+				"  -threads #   : Control the number of threads vbsp uses (defaults to the # of\n"
 				"                 processors on your machine).\n"
 				"  -verboseentities: If -v is on, this disables verbose output for submodels.\n"
 				"  -noweld      : Don't join face vertices together.\n"

--- a/src/utils/vrad/leaf_ambient_lighting.cpp
+++ b/src/utils/vrad/leaf_ambient_lighting.cpp
@@ -313,7 +313,7 @@ struct ambientsample_t
 // be discarded.  This has the effect of converging on the best samples when enough are added.
 void AddSampleToList( CUtlVector<ambientsample_t> &list, const Vector &samplePosition, Vector *pCube )
 {
-	const int MAX_SAMPLES = 16;
+	const int MAX_SAMPLES = ambientcubes_perleaf;
 
 	int index = list.AddToTail();
 	list[index].pos = samplePosition;
@@ -698,7 +698,7 @@ void ComputePerLeafAmbientLighting()
 		{
 			if ( !(dleafs[i].contents & CONTENTS_SOLID) )
 			{
-				Msg("Bad leaf ambient for leaf %d\n", i );
+				Warning("Bad leaf ambient for leaf %d\n", i );
 			}
 
 			int refLeaf = NearestNeighborWithLight(i);

--- a/src/utils/vrad/vrad.cpp
+++ b/src/utils/vrad/vrad.cpp
@@ -102,6 +102,7 @@ bool		debug_extra = false;
 qboolean	do_fast = false;
 qboolean	do_centersamples = false;
 int			extrapasses = 4;
+int			ambientcubes_perleaf = 16;
 float		smoothing_threshold = 0.7071067; // cos(45.0*(M_PI/180)) 
 // Cosine of smoothing angle(in radians)
 float		coring = 1.0;	// Light threshold to force to blackness(minimizes lightmaps)
@@ -2436,6 +2437,26 @@ int ParseCommandLine( int argc, char **argv, bool *onlydetail )
 		{
 			g_bLargeDispSampleRadius = true;
 		}
+		else if (!Q_stricmp(argv[i], "-AmbientCubesPerLeaf"))
+		{
+			if (++i < argc && *argv[i])
+			{
+				if (atof(argv[i]) > 0)
+				{
+					ambientcubes_perleaf = atof(argv[i]);
+				}
+				else
+				{
+					Warning("Error: expected a positive number after '-AmbientCubesPerLeaf'\n");
+					return -1;
+				}
+			}
+			else
+			{
+				Warning("Error: expected a number after '-AmbientCubesPerLeaf'\n");
+				return -1;
+			}
+		}
 		else if (!Q_stricmp( argv[i], "-dumppropmaps"))
 		{
 			g_bDumpPropLightmaps = true;
@@ -2836,7 +2857,7 @@ void PrintUsage( int argc, char **argv )
 		"  -dump           : Write debugging .txt files.\n"
 		"  -dumpnormals    : Write normals to debug files.\n"
 		"  -dumptrace      : Write ray-tracing environment to debug files.\n"
-		"  -threads        : Control the number of threads vbsp uses (defaults to the #\n"
+		"  -threads #      : Control the number of threads vbsp uses (defaults to the #\n"
 		"                    or processors on your machine).\n"
 		"  -lights <file>  : Load a lights file in addition to lights.rad and the\n"
 		"                    level lights file.\n"
@@ -2869,6 +2890,7 @@ void PrintUsage( int argc, char **argv )
 		"  -LargeDispSampleRadius: This can be used if there are splotches of bounced light\n"
 		"                          on terrain. The compile will take longer, but it will gather\n"
 		"                          light across a wider area.\n"
+		"  -AmbientCubesPerLeaf #: Lets you scale how many ambient lights your leaf has (default 16).\n"
         "  -StaticPropLighting   : generate backed static prop vertex lighting\n"
         "  -StaticPropPolys   : Perform shadow tests of static props at polygon precision\n"
         "  -OnlyStaticProps   : Only perform direct static prop lighting (vrad debug option)\n"

--- a/src/utils/vrad/vrad.h
+++ b/src/utils/vrad/vrad.h
@@ -54,6 +54,7 @@
 
 extern float dispchop; // "-dispchop" tightest number of luxel widths for a patch, used on edges
 extern float g_MaxDispPatchRadius;
+extern int	 ambientcubes_perleaf;
 
 //-----------------------------------------------------------------------------
 // forward declarations

--- a/src/utils/vvis/vvis.cpp
+++ b/src/utils/vvis/vvis.cpp
@@ -1039,7 +1039,7 @@ void PrintUsage( int argc, char **argv )
 #ifdef MPI
 		"  -mpi_pw <pw>    : Use a password to choose a specific set of VMPI workers.\n"
 #endif
-		"  -threads        : Control the number of threads vbsp uses (defaults to the #\n"
+		"  -threads #      : Control the number of threads vvis uses (defaults to the #\n"
 		"                    or processors on your machine).\n"
 		"  -nosort         : Don't sort portals (sorting is an optimization).\n"
 		"  -tmpin          : Make portals come from \\tmp\\<mapname>.\n"


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->
# Description
In many cases where a big levels have a large portal leaf, ambient lighting become less accurate for bounced light. Allowing the user to increase the number of ambient cubes with the `-AmbientCubesPerLeaf N` command helps solve this issue.

For users: The `-AmbientCubesPerLeaf N` command sets the number of ambient light cubes used for lighting calculations. N represents the number of ambient cubes you want VRAD to generate. VRAD will optimize the number of ambient cubes based on their RGB values (if they are very similar and close to each other, some ambient cubes will be deleted).