### PR TITLE
Fix players entering enemy spawnrooms with partner taunts

### DIFF
--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -21567,6 +21567,18 @@ CTFPlayer *CTFPlayer::FindPartnerTauntInitiator( void )
 			continue;
 		}
 
+		// Check if: 1. the initiator is inside a respawnroom and 2. the round has not ended, 
+		// to not execute when players can already enter the enemy respawnroom.
+		// This should be an easy way to fix players entering spawnrooms with partner taunts
+		if( PointInRespawnRoom( pPlayer, pPlayer->WorldSpaceCenter() ) && TFGameRules()->State_Get() != GR_STATE_TEAM_WIN)
+		{
+			if ( tf_highfive_debug.GetBool() )
+				Msg( " - but %s is inside their spawn room and the round hasn't ended.\n", pPlayer->GetPlayerName() );
+
+			//no trolling
+			continue;
+		}
+
 		// update to closer target player
 		if ( flDistSqrToPlayer < flDistSqrToTargetInitiator )
 		{


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
ValveSoftware/Source-1-Games#3881

This fix adds a check if the player that initiates the taunt is inside their respawnroom, and if the round hasn't ended yet, so that players can still taunt with enemies when they lose.

(Ignore the tc2 logo)

https://github.com/user-attachments/assets/9ec27dbc-bf1a-4e20-aee0-c595077e60fb

https://github.com/user-attachments/assets/9bb3ec44-50df-4bc9-85ae-693bcfc00945

Of course, the other way doesn't make sense, and thus is allowed

https://github.com/user-attachments/assets/8cd9b7a5-1665-4bfb-bf13-acefe825fa73

Also, i think this would make the current fix, prevent if there is a respawnroomvisualizare between, useless, but we better keep it just in case