### PR TITLE
fix: Fix the sandman voice lines not playing.

### DIFF
--- a/src/game/shared/tf/tf_weapon_bat.cpp
+++ b/src/game/shared/tf/tf_weapon_bat.cpp
@@ -759,6 +759,10 @@ void CTFStunBall::ApplyBallImpactEffectOnVictim( CBaseEntity *pOther )
 		{
 			pPlayer->m_Shared.StunPlayer( flStunDuration, flStunAmount, iStunFlags, pOwner );
 
+#ifdef GAME_DLL
+            pOwner->SpeakConceptIfAllowed( MP_CONCEPT_STUNNED_TARGET );
+#endif
+
 			if ( pPlayer->GetUserID() == m_iOriginalOwnerID )
 			{
 				// We just stunned a scout with their own ball.

--- a/src/game/shared/tf/tf_weapon_bat.cpp
+++ b/src/game/shared/tf/tf_weapon_bat.cpp
@@ -760,7 +760,7 @@ void CTFStunBall::ApplyBallImpactEffectOnVictim( CBaseEntity *pOther )
 			pPlayer->m_Shared.StunPlayer( flStunDuration, flStunAmount, iStunFlags, pOwner );
 
 #ifdef GAME_DLL
-            pOwner->SpeakConceptIfAllowed( MP_CONCEPT_STUNNED_TARGET );
+			pOwner->SpeakConceptIfAllowed( MP_CONCEPT_STUNNED_TARGET );
 #endif
 
 			if ( pPlayer->GetUserID() == m_iOriginalOwnerID )


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
The Scout has voice lines related to stunning another player with the sandman ball.
These lines no longer trigger as Scout no longer stuns the enemy player's controls which it was specifically checked for. This was originally triggered by [tf_player_shared.cpp](https://github.com/ValveSoftware/source-sdk-2013/blob/master/src/game/shared/tf/tf_player_shared.cpp#L9805)'s StunPlayer function. The trigger for the voice lines has now been moved into the `ApplyBallImpactEffectOnVictim` function to not break any existing logic related to the original StunPlayer function.

| Before | After |
| -------- | ------- |
| <video src="https://github.com/user-attachments/assets/c6b19e6c-5941-4af5-8642-f3f14328aba9"> | <video src="https://github.com/user-attachments/assets/24d26692-46f8-4d3e-906b-781a3e339dd2"> |

This would fix issue:
https://github.com/ValveSoftware/Source-1-Games/issues/4467