### PR TITLE
Fix up paths for mods in rare cases

### DIFF
--- a/src/game/client/replay/replayyoutubeapi.cpp
+++ b/src/game/client/replay/replayyoutubeapi.cpp
@@ -476,7 +476,16 @@ public:
 		}
 		else
 		{
-			AssertMsg( 0, "Unknown game" );
+#if defined(TF_CLIENT_DLL)
+			//assume tf2
+			*ppShortGameName = "TF2";
+			*ppFullGameName = "Team Fortress 2";
+#elif defined(CSTRIKE_DLL)
+			//assume cstrike
+			*ppShortGameName = "CSS";
+			*ppFullGameName = "Counter-Strike: Source";
+#else
+			AssertMsg(0, "Unknown game");
 			*ppShortGameName = "";
 			*ppFullGameName = "";
 		}

--- a/src/game/client/viewrender.cpp
+++ b/src/game/client/viewrender.cpp
@@ -2040,16 +2040,15 @@ void CViewRender::RenderView( const CViewSetup &viewRender, int nClearFlags, int
 	{
 		// We know they were running at least 8.0 when the game started...we check the 
 		// value in ClientDLL_Init()...so they must be messing with their DirectX settings.
-		if ( ( Q_stricmp( COM_GetModDirectory(), "tf" ) == 0 ) || ( Q_stricmp( COM_GetModDirectory(), "tf_beta" ) == 0 ) )
+#ifdef TF_CLIENT_DLL
+		static bool bFirstTime = true;
+		if (bFirstTime)
 		{
-			static bool bFirstTime = true;
-			if ( bFirstTime )
-			{
-				bFirstTime = false;
-				Msg( "This game has a minimum requirement of DirectX 8.0 to run properly.\n" );
-			}
-			return;
+			bFirstTime = false;
+			Msg("This game has a minimum requirement of DirectX 8.0 to run properly.\n");
 		}
+		return;
+#endif
 	}
 
 	CMatRenderContextPtr pRenderContext( materials );


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
This PR aims to patch some minor issues where it requires the mod folder to be "tf", "tf_beta", "cstrike", or "cstrike_beta" in some rare cases:

- Set Youtube Replay API information for TF2 mods to "Team Fortress 2" (and an additional ifdef for CStrike mods to Counter Strike: Source, assuming those will become a thing in the near future) if the mod folder is not "tf", "tf_beta", "cstrike", or "cstrike_beta"
- Made it so TF_CLIENT_DLL determines when the DirectX 8.0 warning displays, rather than the folder the mod DLLs are placed in.