### PR TITLE
Implement IsNextBot()

### DIFF
--- a/src/game/server/NextBot/NextBot.h
+++ b/src/game/server/NextBot/NextBot.h
@@ -40,6 +40,7 @@ public:
 	virtual Vector EyePosition( void );
 
 	virtual INextBot *MyNextBotPointer( void ) { return this; }
+    virtual bool IsNextBot(void) const { return true; }
 
 	// Event hooks into NextBot system ---------------------------------------
 	virtual int OnTakeDamage_Alive( const CTakeDamageInfo &info );

--- a/src/game/server/baseentity.h
+++ b/src/game/server/baseentity.h
@@ -996,6 +996,9 @@ public:
 	void					TraceBleed( float flDamage, const Vector &vecDir, trace_t *ptr, int bitsDamageType );
 	virtual bool			IsTriggered( CBaseEntity *pActivator ) {return true;}
 	virtual bool			IsNPC( void ) const { return false; }
+#ifdef NEXT_BOT
+	virtual bool			IsNextBot(void) const { return false; }
+#endif
 	CAI_BaseNPC				*MyNPCPointer( void ); 
 	virtual CBaseCombatCharacter *MyCombatCharacterPointer( void ) { return NULL; }
 	virtual INextBot		*MyNextBotPointer( void ) { return NULL; }


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
This implements a boolean in baseentity.h that functions similarly to IsNPC or IsPlayer. When referencing a NextBot NPC or Player, the IsNextBot() value will return true.

This was originally made for my HL2 NPC awareness of NextBot feature to my personal fork and my FIREFIGHT RELOADED mod (https://github.com/BitlDevelopmentStudios/source-sdk-2013-bds-base/commit/14091c39328fd5ee02ec8967881c026157727573), but I decided to send a PR of IsNextBot() and not the senses implementation as I felt that the feature would only suit specific mods that have working NPCs in multiplayer or incorporating NextBot NPCs into singleplayer. IsNextBot() is general enough that I see it getting implemented in an SDK branch.