### PR TITLE
Add forced floating health icon for giant MvM robots + RD robots, and better "see enemy health" attribute for non-Medics

### DIFF
--- a/src/game/client/tf/tf_hud_target_id.cpp
+++ b/src/game/client/tf/tf_hud_target_id.cpp
@@ -80,15 +80,17 @@ bool ShouldHealthBarBeVisible( CBaseEntity *pTarget, CTFPlayer *pLocalPlayer )
 	if ( !pTarget || !pLocalPlayer )
 		return false;
 
-	if ( tf_hud_target_id_disable_floating_health.GetBool() )
-		return false;
-
+	// now second in priority to force floating health bars on for giant robots in MvM, robot destruction NPCs, and any custom game logic that forces the mini boss flag on players
+	// regardless of setting due to entities that return this check as true typically not having a visible target ID to fall back to when tf_hud_target_id_disable_floating_health is 1.
 	if ( pTarget->IsHealthBarVisible() )
 		return true;
 
+	if ( tf_hud_target_id_disable_floating_health.GetBool() )
+		return false;
+	
 	if ( !pTarget->IsPlayer() )
 		return false;
-
+	
 	int iHideEnemyHealth = 0;
 	CALL_ATTRIB_HOOK_FLOAT_ON_OTHER( pLocalPlayer, iHideEnemyHealth, hide_enemy_health );
 	if ( ( iHideEnemyHealth > 0 ) && !pLocalPlayer->InSameTeam( pTarget ) )
@@ -475,7 +477,8 @@ bool CTargetID::IsValidIDTarget( int nEntIndex, float flOldTargetRetainFOV, floa
 
 				//Recreate the floating health icon if there isn't one, we're not a spectator, and 
 				// we're not a spy or this was a robot from Robot Destruction-Mode
-				if ( !m_pFloatingHealthIcon && !bSpectator && ( !bSpy || bHealthBarVisible ) && !DrawHealthIcon() )
+				// force render floating health icon if it's a player miniboss or RD robot.
+				if ( !m_pFloatingHealthIcon && !bSpectator && ( !bSpy || bHealthBarVisible ) && ( !DrawHealthIcon() || pEnt->IsHealthBarVisible() ) )
 				{
 					m_pFloatingHealthIcon = CFloatingHealthIcon::AddFloatingHealthIcon( pEnt );
 				}
@@ -794,21 +797,25 @@ void CTargetID::UpdateID( void )
 				}
 			}
 
+			// Remove redundant class checks in favor for the attribute itself, 
+			// and remove second enemy disguised spy check
+			// This allows for better support ith the see_enemy_health attribute on
+			// all classes.
 			bool bInSameTeam = pLocalTFPlayer->InSameDisguisedTeam( pEnt );
 			bool bSpy = pLocalTFPlayer->IsPlayerClass( TF_CLASS_SPY );
-			bool bMedic = pLocalTFPlayer->IsPlayerClass( TF_CLASS_MEDIC );
-			bool bHeavy = pLocalTFPlayer->IsPlayerClass( TF_CLASS_HEAVYWEAPONS );
+			int iSeeEnemyHealth = 0;
+			CALL_ATTRIB_HOOK_FLOAT_ON_OTHER( pLocalTFPlayer, iSeeEnemyHealth, see_enemy_health )
 
 			// See if the player wants to fill in the data string
 			bool bIsAmmoData = false;
 			bool bIsKillStreakData = false;
 			pPlayer->GetTargetIDDataString( bDisguisedTarget, sDataString, sizeof(sDataString), bIsAmmoData, bIsKillStreakData );
-			if ( pLocalTFPlayer->GetTeamNumber() == TEAM_SPECTATOR || bInSameTeam || bSpy || bDisguisedEnemy || bMedic || bHeavy )
+			if ( pLocalTFPlayer->GetTeamNumber() == TEAM_SPECTATOR || bInSameTeam )
 			{
 				printFormatString = "#TF_playerid_sameteam";
 				bShowHealth = true;
 			}
-			else if ( pLocalTFPlayer->m_Shared.GetState() == TF_STATE_DYING )
+			else if ( bSpy || iSeeEnemyHealth || pLocalTFPlayer->m_Shared.GetState() == TF_STATE_DYING )
 			{
 				// We're looking at an enemy who killed us.
 				printFormatString = "#TF_playerid_diffteam";


### PR DESCRIPTION
This introduces a QoL fix where if tf_hud_target_id_disable_floating_health is 1, it will now still display the health bars for entities that do not have a visible target ID to fall back to, such as enemy mini bosses (aka giant robots in MvM) and robot destruction bots. Before this fix, having floating health bars disabled would result in you being unable to view the health of giant robots whereas you normally should be able to.

This also adds a feature to allow the Solemn Vow's "allows you to see enemy health" attribute to work when classes other than the Medic (and Heavy?) have the attribute applied to them. Enemies are also now differentiated with the underused #TF_playerid_diffteam localization string.
This also removes 3 redundant checks involving checking if the local player is Medic or Heavy, and removes the second check if the target is a enemy disguised Spy.

Remade from #914 due to using an incorrect branch to open the original PR with.

All screenshots below are taken with tf_hud_target_id_disable_floating_health set to 1 to demonstrate.
### Looking at a teammate:
![image](https://github.com/user-attachments/assets/74256b88-2486-41fb-bcc9-eefa62883ec5)
### Looking at an undisguised enemy:
![image](https://github.com/user-attachments/assets/ac737786-7101-431f-a46a-251e83669547)
### Looking at a disguised enemy:
![image](https://github.com/user-attachments/assets/08d58e0b-0021-4cd9-a85b-55e09e859fcd)
### Looking at a giant robot in Mann vs. Machine:
![image](https://github.com/user-attachments/assets/f1ee42cc-04e7-446f-9a1b-5ace1b0c0bdf)
### Looking at a robot in Robot Destruction
![image](https://github.com/user-attachments/assets/3ad6c8b2-bbf1-43fa-ae93-dd47a9a74fbd)
