### PR TITLE
Fix constant redefinition errors

### DIFF
--- a/src/game/shared/tf/tf_weapon_flamethrower.cpp
+++ b/src/game/shared/tf/tf_weapon_flamethrower.cpp
@@ -2110,7 +2110,7 @@ bool CTFFlameThrower::EffectMeterShouldFlash( void )
 //-----------------------------------------------------------------------------
 Vector CTFFlameThrower::GetMuzzlePosHelper( bool bVisualPos )
 {
-	Vector vecMuzzlePos;
+	Vector vecMuzzlePos = vec3_origin;
 	CTFPlayer *pOwner = GetTFPlayerOwner();
 	if ( pOwner ) 
 	{

--- a/src/gcsdk/steamextra/tier0/t0constants.h
+++ b/src/gcsdk/steamextra/tier0/t0constants.h
@@ -18,6 +18,7 @@ const int64 k_nMillion = 1000000;
 const int64 k_nThousand = 1000;
 const int64 k_nKiloByte = 1024;
 const int64 k_nMegabyte = k_nKiloByte * k_nKiloByte;
+const int64 k_nGigabyte = k_nMegabyte * k_nKiloByte;
 
 //-----------------------------------------------------------------------------
 // Timing constants

--- a/src/public/tier1/fileio.h
+++ b/src/public/tier1/fileio.h
@@ -22,11 +22,13 @@
 #include "tier1/utlstring.h"
 #include "tier1/utllinkedlist.h"
 
+#ifndef T0CONSTANTS_H
 const int64 k_nMillion = 1000000;
 const int64 k_nThousand = 1000;
 const int64 k_nKiloByte = 1024;
 const int64 k_nMegabyte = k_nKiloByte * k_nKiloByte;
 const int64 k_nGigabyte = k_nMegabyte * k_nKiloByte;
+#endif
 
 class CPathString
 {


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
When trying to compile a mod I ran into this error, I wasn't sure on the best approach to get rid of it as idk what does and doesn't include t0constants and fileio