### PR TITLE
[TF2] Fix the Third Degree's inconsistent behavior with Amputator healing

### DIFF
--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -10048,19 +10048,11 @@ void CTFPlayer::AddConnectedPlayers( CUtlVector<CTFPlayer*> &vecPlayers, CTFPlay
 
 	for ( int i = 0 ; i < pPlayerToConsider->m_Shared.GetNumHealers() ; i++ )
 	{
+		// Make sure the Medic is healing us specifically - don't count AoE healing
 		CTFPlayer *pMedic = ToTFPlayer( pPlayerToConsider->m_Shared.GetHealerByIndex( i ) );
-		if ( pMedic )
+		if ( pMedic && pMedic->MedicGetHealTarget() == pPlayerToConsider )
 		{
-			// Make sure the healer is healing us with a Medigun - don't count AoE healing
-			CTFWeaponBase *pWpn = pMedic->GetActiveTFWeapon();
-			if ( pWpn && pWpn->GetWeaponID() == TF_WEAPON_MEDIGUN )
-			{
-				CWeaponMedigun *pMedigun = assert_cast< CWeaponMedigun* >( pWpn );
-				if ( pMedigun->GetHealTarget() == pPlayerToConsider )
-				{
-					AddConnectedPlayers( vecPlayers, pMedic );
-				}
-			}
+			AddConnectedPlayers( vecPlayers, pMedic );
 		}
 	}
 }


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description

The Third Degree's current behavior with regard to players being healed by the Amputator taunt is inconsistent. Currently, as the TF2 wiki notes, when a Medic performs the Amputator taunt around a group of players:

- Attacking the taunting Medic with the Third Degree will damage the Medic only.
- Attacking a healing player with the Third Degree will damage the player and the taunting Medic only.

This PR fixes this inconsistency by not damaging the Amputator-taunting Medic when attacking a healing player with the Third Degree. This is done by not marking a healer as 'connected' to another player the healer's healing target is not also the player, which is only the case when they are being AoE healed.