### PR TITLE
[TF2] Overhaul control point-related response rules

### DIFF
--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -19414,17 +19414,44 @@ void CTFPlayer::ModifyOrAppendCriteria( AI_CriteriaSet& criteriaSet )
 		CTeamControlPoint *pCP = pAreaTrigger->GetControlPoint();
 		if ( pCP )
 		{
-			if ( pCP->GetOwner() == GetTeamNumber() )
+			const int iPlayerTeam = GetTeamNumber();
+			const int iEnemyTeam = GetEnemyTeam( GetTeamNumber() );
+			const int iPointOwner = pCP->GetOwner();
+			const int iPointIndex = pCP->GetPointIndex();
+
+			if ( iPointOwner == iPlayerTeam )
 			{
 				criteriaSet.AppendCriteria( "OnFriendlyControlPoint", "1" );
 			}
-			else 
+			else
 			{
-				if ( TeamplayGameRules()->TeamMayCapturePoint( GetTeamNumber(), pCP->GetPointIndex() ) && 
-					 TeamplayGameRules()->PlayerMayCapturePoint( this, pCP->GetPointIndex() ) )
-				{
-					criteriaSet.AppendCriteria( "OnCappableControlPoint", "1" );
-				}
+				criteriaSet.AppendCriteria( "OnEnemyOrNeutralControlPoint", "1" );
+			}
+
+			// A point is only considered cappable if:
+			// a. Our team is ever allowed to capture it, we specifically are currently allowed to capture it,
+			//    and it is owned by either the other team or neither team.
+			// or
+			// b. The other team is ever allowed to capture it, and either we own it or neither team owns it.
+			bool bIsPointCappable = (
+				TeamplayGameRules()->TeamMayCapturePoint( iPlayerTeam, iPointIndex ) &&
+				TeamplayGameRules()->PlayerMayCapturePoint( this, iPointIndex ) &&
+				( iPointOwner == iEnemyTeam || iPointOwner == TEAM_UNASSIGNED )
+			) || (
+				TeamplayGameRules()->TeamMayCapturePoint( iEnemyTeam, iPointIndex ) &&
+				( iPointOwner == iPlayerTeam || iPointOwner == TEAM_UNASSIGNED )
+			);
+			
+			// If the current map is round-based, make sure the point is part of the current one.
+			CTeamControlPointMaster *pMaster = g_hControlPointMasters.Count() ? g_hControlPointMasters[ 0 ] : NULL;
+			if ( pMaster )
+			{
+				bIsPointCappable = bIsPointCappable && pMaster->IsInRound( pCP );
+			}
+
+			if ( bIsPointCappable )
+			{
+				criteriaSet.AppendCriteria( "OnCappableControlPoint", "1" );
 			}
 		}
 	}

--- a/src/game/shared/tf/tf_gamerules.cpp
+++ b/src/game/shared/tf/tf_gamerules.cpp
@@ -16720,19 +16720,24 @@ bool CTFGameRules::TeamMayCapturePoint( int iTeam, int iPointIndex )
 	if ( !tf_caplinear.GetBool() )
 		return true; 
 
+	// Are points currently able to be captured?
+	if ( !PointsMayBeCaptured() )
+		return false;
+
+	// Is the point locked?
+	if ( ObjectiveResource()->GetCPLocked( iPointIndex ) )
+		return false;
+
+	// Is the point set to allow our team to cap it?
+	if ( !ObjectiveResource()->TeamCanCapPoint( iPointIndex, iTeam ) )
+		return false;
+
 	// Any previous points necessary?
 	int iPointNeeded = ObjectiveResource()->GetPreviousPointForPoint( iPointIndex, iTeam, 0 );
 
 	// Points set to require themselves are always cappable 
 	if ( iPointNeeded == iPointIndex )
 		return true;
-
-	if ( IsInKothMode() && IsInWaitingForPlayers() )
-		return false;
-
-	// Is the point locked?
-	if ( ObjectiveResource()->GetCPLocked( iPointIndex ) )
-		return false;
 
 	// No required points specified? Require all previous points.
 	if ( iPointNeeded == -1 )


### PR DESCRIPTION
# Description
This PR is the "sequel" to https://github.com/ValveSoftware/source-sdk-2013/pull/938

Control point-related response rules are now dictated by the following three criteria:

## `OnFriendlyControlPoint`
This criterion is unchanged from it's existing logic, simply being set if the player is stood on a control point that their team owns.

## `OnEnemyOrNeutralControlPoint`
This new criterion is set if the player is stood on a control point that either the enemy team owns, or neither team owns.

## `OnCappableControlPoint`
The conditions under which this criterion is set have been changed drastically.

Rather than simply being set if the player is stood on a control point that their team is ever able to capture, and that they are currently able to capture, it is set only when one of the two following sets of conditions are met:
1. The control point is owned by either the player's team or neither team
2. The control point is ever cappable by the other team
3. If the map is round-based: the control point is associated with the current round
4. The match is not currently in the waiting for players or pre-round setup stages
5. Other miscellaneous conditions preventing capture of control points at this time are not met

**OR**

1. The control point is owned by either the other team or neither team
2. The control point is ever cappable by both the player's team, and the player themselves
3. If the map is round-based: the control point is associated with the current round
4. The match is not currently in the waiting for players or pre-round setup stages
5. Other miscellaneous conditions preventing capture of control points at this time are not met

This fixes an issue where inappropriate responses would be used for the "Help!" voice command,  such as:
* Calling for help defending a point that the other team cannot currently capture
* Calling for help capturing a point that their team cannot currently capture
* Calling for help capturing or defending a point that is not part of the current round

As mentioned above, this overhaul *does* require content changes in order to function.

In `tf/scripts/talker/response_rules.txt`, ideally near the other two criteria, `IsOnEnemyOrNeutralControlPoint` must be defined as:
`criterion "IsOnEnemyOrNeutralControlPoint" "OnEnemyOrNeutralControlPoint" "1" required`

All responses that require the `IsOnFriendlyControlPoint` criterion must be modified to also require the `IsOnCappableControlPoint` criterion.

All responses that already required the `IsOnCappableControlPoint` criterion must be modified to also require the `IsOnEnemyOrNeutralControlPoint` criterion.

Bear in mind that there is a sneaky usage of `IsOnCappableControlPoint` in `medic_auto.txt`.

I realize that `IsOnCappableControlPoint` being required for each response may seem like it is redundant, and should be merged with the other two -- however, my hope is that mod authors are able to get some kind of use out of these more robust criteria.

I have tested this change on AD maps, 5CP maps, KotH maps, Payload maps, and Payload Race maps.
The only issue found is that this does *not* fix players calling for help capturing the other teams payload in Payload Race maps.
Every map functioned as normal, otherwise.