### PR TITLE
Fix render box of tf_flame_manager refers wrong vectors

### DIFF
--- a/src/game/shared/tf/tf_point_manager.cpp
+++ b/src/game/shared/tf/tf_point_manager.cpp
@@ -319,19 +319,6 @@ bool CTFPointManager::UpdatePoint( tf_point_t *pPoint, int nIndex, float flDT, V
 	Vector vecNewVelocity = pPoint->m_vecVelocity + vecGravity + GetAdditionalVelocity( pPoint );
 	Vector vecNewPos = pPoint->m_vecPosition + flDT * vecNewVelocity;
 
-	if ( pVecMins )
-	{
-		*pVecMins = vecMins;
-	}
-	if ( pVecMaxs )
-	{
-		*pVecMaxs = vecMaxs;
-	}
-	if ( pVecNewPos )
-	{
-		*pVecNewPos = vecNewPos;
-	}
-
 	// Create a ray for point to trace
 	Ray_t rayWorld;
 	rayWorld.Init( pPoint->m_vecPosition, vecNewPos, vecMins, vecMaxs );
@@ -390,6 +377,19 @@ bool CTFPointManager::UpdatePoint( tf_point_t *pPoint, int nIndex, float flDT, V
 	pPoint->m_vecPrevPosition = pPoint->m_vecPosition;
 
 	pPoint->m_vecPosition = vecNewPos;
+
+	if ( pVecMins )
+	{
+		*pVecMins = vecMins;
+	}
+	if ( pVecMaxs )
+	{
+		*pVecMaxs = vecMaxs;
+	}
+	if ( pVecNewPos )
+	{
+		*pVecNewPos = vecNewPos;
+	}
 
 	return true;
 }


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
The tf_flame_manager decides size of render box by referring each points. But these points have wrong result because vector variables are called before tracing with walls. It causes recursion between functions make flames rendered/not rendered per a tick and creates lag. (Especially phlogistinator which has massive particles. See issue below) Even whether player makes bug on purpose or not.

This fix makes return variables after the tracing. Also, https://github.com/ValveSoftware/Source-1-Games/issues/4750 will be resolved.