### PR TITLE
[HL2MP] Fix team change score counting

### DIFF
--- a/src/game/server/hl2mp/hl2mp_player.cpp
+++ b/src/game/server/hl2mp/hl2mp_player.cpp
@@ -1004,7 +1004,8 @@ void CHL2MP_Player::ChangeTeam( int iTeam )
 
 	if ( bKill == true )
 	{
-		CommitSuicide();
+		SETBITS( m_iSuicideCustomKillFlags, EPlayerSuicideFlag_LockScore );
+		CommitSuicide(false, true);
 	}
 }
 
@@ -1028,11 +1029,8 @@ bool CHL2MP_Player::HandleCommand_JoinTeam( int team )
 		if ( GetTeamNumber() != TEAM_UNASSIGNED && !IsDead() )
 		{
 			m_fNextSuicideTime = gpGlobals->curtime;	// allow the suicide to work
-
-			CommitSuicide();
-
-			// add 1 to frags to balance out the 1 subtracted for killing yourself
-			IncrementFragCount( 1 );
+			SETBITS( m_iSuicideCustomKillFlags, EPlayerSuicideFlag_LockScore );
+			CommitSuicide( false, true );
 		}
 
 		ChangeTeam( TEAM_SPECTATOR );
@@ -1322,7 +1320,7 @@ void CHL2MP_Player::Event_Killed( const CTakeDamageInfo &info )
 
 	CBaseEntity *pAttacker = info.GetAttacker();
 
-	if ( pAttacker )
+	if ( pAttacker && ( pAttacker != this || !FBitSet( m_iSuicideCustomKillFlags, EPlayerSuicideFlag_LockScore ) ) ) 
 	{
 		int iScoreToAdd = 1;
 

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -5437,23 +5437,20 @@ void CBasePlayer::CommitSuicide( bool bExplode /*= false*/, bool bForce /*= fals
 {
 	MDLCACHE_CRITICAL_SECTION();
 
-	if( !IsAlive() )
-		return;
-		
-	// prevent suiciding too often
-	if ( m_fNextSuicideTime > gpGlobals->curtime && !bForce )
-		return;
+	if ( IsAlive() && ( gpGlobals->curtime >= m_fNextSuicideTime || bForce ) )
+	{
+		// don't let them suicide for 5 seconds after suiciding
+		m_fNextSuicideTime = gpGlobals->curtime + 5;
 
-	// don't let them suicide for 5 seconds after suiciding
-	m_fNextSuicideTime = gpGlobals->curtime + 5;
+		int fDamage = DMG_PREVENT_PHYSICS_FORCE | ( bExplode ? ( DMG_BLAST | DMG_ALWAYSGIB ) : DMG_NEVERGIB );
 
-	int fDamage = DMG_PREVENT_PHYSICS_FORCE | ( bExplode ? ( DMG_BLAST | DMG_ALWAYSGIB ) : DMG_NEVERGIB );
+		// have the player kill themself
+		m_iHealth = 0;
+		CTakeDamageInfo info( this, this, 0, fDamage, m_iSuicideCustomKillFlags );
+		Event_Killed( info );
+		Event_Dying( info );
+	}
 
-	// have the player kill themself
-	m_iHealth = 0;
-	CTakeDamageInfo info( this, this, 0, fDamage, m_iSuicideCustomKillFlags );
-	Event_Killed( info );
-	Event_Dying( info );
 	m_iSuicideCustomKillFlags = 0;
 }
 

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -176,6 +176,11 @@ enum PlayerConnectedState
 	PlayerDisconnected,
 };
 
+enum
+{
+	EPlayerSuicideFlag_LockScore = 1 // Keep score during suicide
+};
+
 extern bool gInitHUD;
 extern ConVar *sv_cheats;
 
@@ -919,6 +924,8 @@ public:
 	int						GetNumWearables( void ) const { return m_hMyWearables.Count(); }
 #endif
 
+	int						m_iSuicideCustomKillFlags;
+
 private:
 
 	Activity				m_Activity;
@@ -998,7 +1005,6 @@ protected:
 	virtual int SpawnArmorValue( void ) const { return 0; }
 
 	float					m_fNextSuicideTime; // the time after which the player can next use the suicide command
-	int						m_iSuicideCustomKillFlags;
 
 	// Replay mode	
 	float					m_fDelay;			// replay delay in seconds

--- a/src/game/shared/multiplay_gamerules.cpp
+++ b/src/game/shared/multiplay_gamerules.cpp
@@ -769,7 +769,10 @@ ConVarRef suitcharger( "sk_suitcharger" );
 		CBaseEntity *pKiller = info.GetAttacker();
 		CBasePlayer *pScorer = GetDeathScorer( pKiller, pInflictor, pVictim );
 		
-		pVictim->IncrementDeathCount( 1 );
+		if ( pVictim != pScorer || !FBitSet( pVictim->m_iSuicideCustomKillFlags, EPlayerSuicideFlag_LockScore ) )
+		{
+			pVictim->IncrementDeathCount( 1 );
+		}
 
 		// dvsents2: uncomment when removing all FireTargets
 		// variant_t value;
@@ -779,7 +782,7 @@ ConVarRef suitcharger( "sk_suitcharger" );
 		// Did the player kill himself?
 		if ( pVictim == pScorer )  
 		{			
-			if ( UseSuicidePenalty() )
+			if ( !FBitSet( pVictim->m_iSuicideCustomKillFlags, EPlayerSuicideFlag_LockScore ) && UseSuicidePenalty() ) 
 			{
 				// Players lose a frag for killing themselves
 				pVictim->IncrementFragCount( -1 );


### PR DESCRIPTION
**Issue**:
It is possible to rapidly switch teams to increase player/team score. Additionally, the suicide cooldown can be bypassed by switching teams within 5 seconds of respawning. This allows players to avoid dying when they should.

**Fix**: 
The fix here is to keep the score from being updated when switching teams and enforce suicide to happen regardless of team changes.