### PR TITLE
[HL2MP] Fix incorrect scrape sound

### DIFF
--- a/src/game/shared/physics_shared.cpp
+++ b/src/game/shared/physics_shared.cpp
@@ -1003,7 +1003,7 @@ void PhysFrictionSound( CBaseEntity *pEntity, IPhysicsObject *pObject, float ene
 	if ( psurf->sounds.scrapeSmooth && phit->audio.roughnessFactor < psurf->audio.roughThreshold )
 	{
 		soundName = psurf->sounds.scrapeSmooth;
-		soundHandle = &psurf->soundhandles.scrapeRough;
+		soundHandle = &psurf->soundhandles.scrapeSmooth;
 	}
 
 	const char *pSoundName = physprops->GetString( soundName );


### PR DESCRIPTION
**Issue**:
There is an incorrect use of the scrape rough sound, which sometimes lead to the sound being looped until `snd_restart` is used.

**Fix**:
Switch the sound to `scrapeSmooth`.