### PR TITLE
[HL2MP] Spawn using "joingame" command

### DIFF
--- a/src/game/server/hl2mp/hl2mp_player.cpp
+++ b/src/game/server/hl2mp/hl2mp_player.cpp
@@ -1078,6 +1078,12 @@ bool CHL2MP_Player::ClientCommand( const CCommand &args )
 	}
 	else if ( FStrEq( args[0], "joingame" ) )
 	{
+		if ( GetTeamNumber() == TEAM_SPECTATOR )
+		{
+			ChangeTeam( random->RandomInt( 2, 3 ) );
+			Spawn();
+		}
+
 		return true;
 	}
 


### PR DESCRIPTION
**Issue**: 
The `joingame` command does absolutely nothing.

**Fix**: 
Simply allow the `joingame` console command to actually do something and put players into a team if they come from spectators. By default, it just returns true and does nothing.