### PR TITLE
[HL2MP] Spectator observer fixes

### DIFF
--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -2287,7 +2287,7 @@ bool CBasePlayer::StartObserverMode(int mode)
 	
     AddSolidFlags( FSOLID_NOT_SOLID );
 
-	SetObserverMode( mode );
+	SetObserverMode( OBS_MODE_ROAMING );
 
 	if ( gpGlobals->eLoadType != MapLoad_Background )
 	{
@@ -4644,6 +4644,29 @@ void CBasePlayer::PostThink()
 		ClientSettingsChanged();
 	}
 
+	if ( IsObserver() && !IsHLTV() )
+	{
+		if ( m_iObserverMode == OBS_MODE_POI || m_iObserverMode == OBS_MODE_FIXED )
+		{
+			// Remove a pointless second third person view
+			m_iObserverMode = OBS_MODE_ROAMING;
+		}
+
+		if ( m_iObserverLastMode == OBS_MODE_ROAMING )
+		{
+			SetMoveType( MOVETYPE_OBSERVER );
+		}
+
+		if ( m_iObserverMode != OBS_MODE_IN_EYE )
+		{
+			m_Local.m_iHideHUD = HIDEHUD_CROSSHAIR;
+		}
+		else
+		{
+			m_Local.m_iHideHUD &= ~HIDEHUD_CROSSHAIR;
+		}
+	}
+
 	m_vecSmoothedVelocity = m_vecSmoothedVelocity * SMOOTHING_FACTOR + GetAbsVelocity() * ( 1 - SMOOTHING_FACTOR );
 
 	if ( !g_fGameOver && !m_iPlayerLocked )
@@ -6607,6 +6630,11 @@ bool CBasePlayer::ClientCommand( const CCommand &args )
 		else
 		{
 			// switch to next spec mode if no parameter given
+			CBaseEntity *target = FindNextObserverTarget( false );
+
+			if ( !target )
+				return true;
+
  			mode = GetObserverMode() + 1;
 			
 			if ( mode > LAST_PLAYER_OBSERVERMODE )
@@ -6648,6 +6676,10 @@ bool CBasePlayer::ClientCommand( const CCommand &args )
 			{
 				SetObserverTarget( target );
 			}
+			else
+			{
+				SetObserverMode( OBS_MODE_ROAMING );
+			}
 		}
 		else if ( GetObserverMode() == OBS_MODE_FREEZECAM )
 		{
@@ -6666,6 +6698,10 @@ bool CBasePlayer::ClientCommand( const CCommand &args )
 			{
 				SetObserverTarget( target );
 			}
+			else
+			{
+				SetObserverMode( OBS_MODE_ROAMING );
+			}
 		}
 		else if ( GetObserverMode() == OBS_MODE_FREEZECAM )
 		{
@@ -6683,6 +6719,10 @@ bool CBasePlayer::ClientCommand( const CCommand &args )
 			if ( IsValidObserverTarget( target ) )
 			{
 				SetObserverTarget( target );
+			}
+			else
+			{
+				SetObserverMode( OBS_MODE_ROAMING );
 			}
 		}
 

--- a/src/game/shared/hl2mp/hl2mp_gamerules.cpp
+++ b/src/game/shared/hl2mp/hl2mp_gamerules.cpp
@@ -294,6 +294,8 @@ void CHL2MPRules::Think( void )
 	
 	CGameRules::Think();
 
+	ObserverTargetFix();
+
 	if ( g_fGameOver )   // someone else quit the game already
 	{
 		// check to see if we should change levels now
@@ -372,6 +374,39 @@ void CHL2MPRules::Think( void )
 
 #endif
 }
+
+#ifdef GAME_DLL
+void CHL2MPRules::ObserverTargetFix()
+{
+	// Fixes a bug where a specator could spectate another spectator
+	for ( int i = 1; i <= gpGlobals->maxClients; ++i )
+	{
+		CBasePlayer *pPlayer = UTIL_PlayerByIndex( i );
+
+		if ( !pPlayer )
+			continue;
+
+		if ( pPlayer->GetObserverMode() == OBS_MODE_CHASE || pPlayer->GetObserverMode() == OBS_MODE_IN_EYE )
+		{
+			CBasePlayer *pTarget = ToBasePlayer( pPlayer->GetObserverTarget() );
+
+			if ( pTarget )
+			{
+				if ( pTarget->GetTeamNumber() == TEAM_SPECTATOR )
+				{
+					pPlayer->SetObserverMode( OBS_MODE_ROAMING );
+					pPlayer->SetObserverTarget( NULL );
+				}
+			}
+			else
+			{
+				pPlayer->SetObserverMode( OBS_MODE_ROAMING );
+				pPlayer->SetObserverTarget( NULL );
+			}
+		}
+	}
+}
+#endif
 
 void CHL2MPRules::GoToIntermission( void )
 {

--- a/src/game/shared/hl2mp/hl2mp_gamerules.h
+++ b/src/game/shared/hl2mp/hl2mp_gamerules.h
@@ -152,6 +152,7 @@ public:
 	void	CheckAllPlayersReady( void );
 
 	virtual bool IsConnectedUserInfoChangeAllowed( CBasePlayer *pPlayer );
+	void ObserverTargetFix();
 	
 private:
 	


### PR DESCRIPTION
This PR is to tackle a few observer issues when being a spectator:

- Fixed an issue where spectators could spectate a player who joined team Spectator. 
    -> If you spectate a player in IN_EYE mode mainly, then you end up spectating someone who is now a spectator. It is a funny and harmless bug, though. Now, any time a player switches to team Spectator and you are in IN_EYE mode, you will be switched back to free roam observer mode.
- Switch to free roaming when joining team spectator.
    -> For some reason, you are stuck in place when switching to spectators. It looks like you should be in free roam mode, but you are not or is not set properly.
- Switch to free roaming when player leaves the game.
    -> Another harmless bug. If you spectate a player in IN_EYE mode amd then leaves, you are still stuck in that last observer mode. Now, any time a player leaves, it switches you back to free roam mode.
- Removed a useless second third-person view.
    -> No idea why this needed to be a thing. I guess it is for SourceTV mainly, but one of the observer modes is identical to third-person mode, which means you have to press space bar twice to get back to free roam mode from first-person view. The fix is to simply remove that extra observer mode outside of SourceTV.