### PR TITLE
[HL2MP] Fix spectator exploits

### DIFF
--- a/src/game/server/hl2/func_tank.cpp
+++ b/src/game/server/hl2/func_tank.cpp
@@ -1450,6 +1450,9 @@ void CFuncTank::Use( CBaseEntity *pActivator, CBaseEntity *pCaller, USE_TYPE use
 	if ( !pPlayer )
 		return;
 
+	if ( pPlayer->IsPlayer() && pPlayer->GetTeamNumber() == TEAM_SPECTATOR )
+		return;
+
 	if ( value == 2 && useType == USE_SET )
 	{
 		ControllerPostFrame();

--- a/src/game/shared/teamplay_gamerules.cpp
+++ b/src/game/shared/teamplay_gamerules.cpp
@@ -354,6 +354,9 @@ bool CTeamplayRules::IsTeamplay( void )
 
 bool CTeamplayRules::FPlayerCanTakeDamage( CBasePlayer *pPlayer, CBaseEntity *pAttacker, const CTakeDamageInfo &info )
 {
+	if ( pAttacker->GetTeamNumber() == TEAM_SPECTATOR )
+		return false;
+
 	if ( pAttacker && PlayerRelationship( pPlayer, pAttacker ) == GR_TEAMMATE && !info.IsForceFriendlyFire() )
 	{
 		// my teammate hit me.


### PR DESCRIPTION
**Issue**: 
By default, it is possible to unfairly kill people when attacking them and switching to spectators quickly. 

**Example**: If TDM is enabled and you throw a grenade to a team mate and switch to spectators before that grenade blows, then that grenade will hurt or kill what used to be your team mate. This is because the game thinks you are no longer in the same team, and logically, you are not anymore. 

**Fix**: 
The fix is to treat all damage done by anyone in spectators as no damage. This fix also applies if TDM is disabled.