### PR TITLE
[HL2MP] Fix spectator suit issues

### DIFF
--- a/src/game/server/hl2mp/hl2mp_client.cpp
+++ b/src/game/server/hl2mp/hl2mp_client.cpp
@@ -63,6 +63,11 @@ void FinishClientPutInServer( CHL2MP_Player *pPlayer )
 		ClientPrint( pPlayer, HUD_PRINTTALK, "You are on team %s1\n", pPlayer->GetTeam()->GetName() );
 	}
 
+	if ( pPlayer->GetTeamNumber() == TEAM_SPECTATOR )
+	{
+		pPlayer->RemoveAllItems( true );
+	}
+
 	const ConVar *hostname = cvar->FindVar( "hostname" );
 	const char *title = (hostname) ? hostname->GetString() : "MESSAGE OF THE DAY";
 

--- a/src/game/server/hl2mp/hl2mp_player.cpp
+++ b/src/game/server/hl2mp/hl2mp_player.cpp
@@ -999,6 +999,9 @@ void CHL2MP_Player::ChangeTeam( int iTeam )
 	{
 		RemoveAllItems( true );
 
+		if ( FlashlightIsOn() )
+			FlashlightTurnOff();
+
 		State_Transition( STATE_OBSERVER_MODE );
 	}
 

--- a/src/game/shared/hl2mp/hl2mp_gamerules.cpp
+++ b/src/game/shared/hl2mp/hl2mp_gamerules.cpp
@@ -1026,7 +1026,8 @@ void CHL2MPRules::RestartGame()
 			pPlayer->GetActiveWeapon()->Holster();
 		}
 		pPlayer->RemoveAllItems( true );
-		respawn( pPlayer, false );
+		if ( pPlayer->GetTeamNumber() != TEAM_SPECTATOR )
+			respawn( pPlayer, false );
 		pPlayer->Reset();
 	}
 


### PR DESCRIPTION
**Issue**: 
Whenever a player joins spectators, their suit is removed/stripped. The problem is that certain game events can cause the suit to be equipped for spectators again after certain game events, mainly `mp_restartgame`. 

**Fix**: 
The fix is to ensure that the suit is never given again to anyone in spectators regardless of those game events.