### PR TITLE
[HL2MP] Fix fast draining suit

### DIFF
--- a/src/game/server/hl2/hl2_player.cpp
+++ b/src/game/server/hl2/hl2_player.cpp
@@ -576,9 +576,10 @@ void CHL2_Player::HandleSpeedChanges( CMoveData *mv )
 
 void CHL2_Player::ReduceTimers( CMoveData *mv )
 {
+	bool bPlayerNotMoving = mv->m_vecVelocity.Length() < 0.1f;
 	bool bSprinting = mv->m_flClientMaxSpeed == HL2_SPRINT_SPEED;
 
-	if ( bSprinting )
+	if ( bSprinting && !bPlayerNotMoving )
 	{
 		SuitPower_AddDevice( SuitDeviceSprint );
 	}


### PR DESCRIPTION
**Issue**: 
When a player stops moving, their sprint/aux power can keep draining, which needlessly consumes precious aux power, especially in HL2DM, given that the sprint aux power is drained a lot faster compared to HL2.

**Fix**: 
Simply stop using sprint aux power whenever a player stops moving, allowing the aux power to recharge, provided no other element requires aux power like oxygen.