### PR TITLE
[HL2MP] Trains: Exclude vphysics

### DIFF
--- a/src/game/server/trains.cpp
+++ b/src/game/server/trains.cpp
@@ -1694,11 +1694,14 @@ void CFuncTrackTrain::Blocked( CBaseEntity *pOther )
 	}
 	else
 	{
-		Vector vecNewVelocity;
-		vecNewVelocity = pOther->GetAbsOrigin() - GetAbsOrigin();
-		VectorNormalize(vecNewVelocity);
-		vecNewVelocity *= m_flBlockDamage;
-		pOther->SetAbsVelocity( vecNewVelocity );
+		if ( pOther->GetMoveType() != MOVETYPE_VPHYSICS )
+		{
+			Vector vecNewVelocity;
+			vecNewVelocity = pOther->GetAbsOrigin() - GetAbsOrigin();
+			VectorNormalize( vecNewVelocity );
+			vecNewVelocity *= m_flBlockDamage;
+			pOther->SetAbsVelocity( vecNewVelocity );
+		}
 	}
 	if ( HasSpawnFlags(SF_TRACKTRAIN_UNBLOCKABLE_BY_PLAYER) )
 	{


### PR DESCRIPTION
**Issue**: 
VPhysics objects were being unnaturally pushed when moving trains directly set their velocity.

**Fix**:
Instead of manually overriding the velocity of all entities, allow physics objects to move naturally through proper physics interactions.