### PR TITLE
[HL2MP] Turn off flashlight on ConVar update

### DIFF
--- a/src/game/server/game.cpp
+++ b/src/game/server/game.cpp
@@ -24,6 +24,28 @@ void MapCycleFileChangedCallback( IConVar *var, const char *pOldString, float fl
 	}
 }
 
+void flashlight_changed( IConVar *pConVar, const char *pOldString, float flOldValue )
+{
+	ConVarRef var( pConVar );
+	if ( !var.IsValid() )
+	{
+		return;
+	}
+
+	if ( var.GetInt() < 1 )
+	{
+		for ( int i = 1; i <= gpGlobals->maxClients; ++i )
+		{
+			CBasePlayer *pPlayer = UTIL_PlayerByIndex( i );
+
+			if ( !pPlayer )
+				return;
+
+			pPlayer->FlashlightTurnOff();
+		}
+	}
+}
+
 ConVar	displaysoundlist( "displaysoundlist","0" );
 ConVar  mapcyclefile( "mapcyclefile", "mapcycle.txt", FCVAR_NONE, "Name of the .txt file used to cycle the maps on multiplayer servers ", MapCycleFileChangedCallback );
 ConVar  servercfgfile( "servercfgfile","server.cfg" );
@@ -38,7 +60,7 @@ ConVar	footsteps( "mp_footsteps","1", FCVAR_NOTIFY );
 #ifdef CSTRIKE
 ConVar	flashlight( "mp_flashlight","1", FCVAR_NOTIFY );
 #else
-ConVar	flashlight( "mp_flashlight","0", FCVAR_NOTIFY );
+ConVar	flashlight( "mp_flashlight", "0", FCVAR_NOTIFY, 0, flashlight_changed ); 
 #endif
 ConVar	aimcrosshair( "mp_autocrosshair","1", FCVAR_NOTIFY );
 ConVar	decalfrequency( "decalfrequency","10", FCVAR_NOTIFY );


### PR DESCRIPTION
**Issue**: 
When `mp_flashlight` is set to 0, players who already have their flashlights on can keep them on until they manually turn them off.

**Fix**: 
Automatically disable all active flashlights when `mp_flashlight` is set to 0.