### PR TITLE
[HL2MP] Fix Vphysics negative Z punting

### DIFF
--- a/src/game/shared/hl2mp/weapon_physcannon.cpp
+++ b/src/game/shared/hl2mp/weapon_physcannon.cpp
@@ -1298,8 +1298,14 @@ void CWeaponPhysCannon::PuntVPhysics( CBaseEntity *pEntity, const Vector &vecFor
 				
 			if( forward.z < 0 )
 			{
-				//reflect, but flatten the trajectory out a bit so it's easier to hit standing targets
-				forward.z *= -0.65f;
+				// Only apply upward Z punt for props to still let players prop boost
+				CBaseProp *pProp = dynamic_cast< CBaseProp * >( pEntity );
+
+				if (pProp)
+				{
+					//reflect, but flatten the trajectory out a bit so it's easier to hit standing targets
+					forward.z *= -0.65f;
+				}
 			}
 				
 			// NOTE: Do this first to enable motion (if disabled) - so forces will work


### PR DESCRIPTION
**Issue**: 
If you punt an object while looking below the 0.0 horizontal view angle, the object ends up trying to be flattened or even sometimes can completely go upwards in the the opposite direction. You can observe this behavior here: https://youtu.be/f5e7pQgS-lk?si=R-0qtLMYZp2WToQL

**Fix**: 
Restrict the flattening effect to props only, preserving prop boosting while allowing all other objects to be punted in their expected direction.