### PR TITLE
[HL2MP] Fix weapon respawn angles

### DIFF
--- a/src/game/server/basecombatweapon.cpp
+++ b/src/game/server/basecombatweapon.cpp
@@ -236,7 +236,7 @@ CBaseEntity* CBaseCombatWeapon::Respawn( void )
 {
 	// make a copy of this weapon that is invisible and inaccessible to players (no touch function). The weapon spawn/respawn code
 	// will decide when to make the weapon visible and touchable.
-	CBaseEntity *pNewWeapon = CBaseEntity::Create( GetClassname(), g_pGameRules->VecWeaponRespawnSpot( this ), GetLocalAngles(), GetOwnerEntity() );
+	CBaseEntity *pNewWeapon = CBaseEntity::Create( GetClassname(), g_pGameRules->VecWeaponRespawnSpot( this ), g_pGameRules->DefaultWeaponRespawnAngle( this ) );
 
 	if ( pNewWeapon )
 	{

--- a/src/game/shared/gamerules.h
+++ b/src/game/shared/gamerules.h
@@ -319,6 +319,7 @@ public:
 	virtual float FlWeaponRespawnTime( CBaseCombatWeapon *pWeapon ) = 0;// when may this weapon respawn?
 	virtual float FlWeaponTryRespawn( CBaseCombatWeapon *pWeapon ) = 0; // can i respawn now,  and if not, when should i try again?
 	virtual Vector VecWeaponRespawnSpot( CBaseCombatWeapon *pWeapon ) = 0;// where in the world should this weapon respawn?
+	virtual QAngle DefaultWeaponRespawnAngle( CBaseCombatWeapon *pWeapon ) = 0;
 
 // Item retrieval
 	virtual bool CanHaveItem( CBasePlayer *pPlayer, CItem *pItem ) = 0;// is this player allowed to take this item?

--- a/src/game/shared/hl2mp/hl2mp_gamerules.cpp
+++ b/src/game/shared/hl2mp/hl2mp_gamerules.cpp
@@ -457,6 +457,19 @@ Vector CHL2MPRules::VecWeaponRespawnSpot( CBaseCombatWeapon *pWeapon )
 	return pWeapon->GetAbsOrigin();
 }
 
+QAngle CHL2MPRules::DefaultWeaponRespawnAngle( CBaseCombatWeapon *pWeapon )
+{
+#ifndef CLIENT_DLL
+	CWeaponHL2MPBase *pHL2Weapon = dynamic_cast< CWeaponHL2MPBase * >( pWeapon );
+
+	if ( pHL2Weapon )
+	{
+		return pHL2Weapon->GetOriginalSpawnAngles();
+	}
+#endif
+	return pWeapon->GetAbsAngles();
+}
+
 #ifndef CLIENT_DLL
 
 CItem* IsManagedObjectAnItem( CBaseEntity *pObject )

--- a/src/game/shared/hl2mp/hl2mp_gamerules.h
+++ b/src/game/shared/hl2mp/hl2mp_gamerules.h
@@ -103,6 +103,7 @@ public:
 	virtual float FlWeaponRespawnTime( CBaseCombatWeapon *pWeapon );
 	virtual float FlWeaponTryRespawn( CBaseCombatWeapon *pWeapon );
 	virtual Vector VecWeaponRespawnSpot( CBaseCombatWeapon *pWeapon );
+	virtual QAngle DefaultWeaponRespawnAngle( CBaseCombatWeapon *pWeapon );
 	virtual int WeaponShouldRespawn( CBaseCombatWeapon *pWeapon );
 	virtual void Think( void );
 	virtual void CreateStandardEntities( void );

--- a/src/game/shared/multiplay_gamerules.cpp
+++ b/src/game/shared/multiplay_gamerules.cpp
@@ -943,6 +943,11 @@ ConVarRef suitcharger( "sk_suitcharger" );
 		return pWeapon->GetAbsOrigin();
 	}
 
+	QAngle CMultiplayRules::DefaultWeaponRespawnAngle( CBaseCombatWeapon *pWeapon )
+	{
+		return pWeapon->GetAbsAngles();
+	}
+
 	//=========================================================
 	// WeaponShouldRespawn - any conditions inhibiting the
 	// respawning of this weapon?

--- a/src/game/shared/multiplay_gamerules.h
+++ b/src/game/shared/multiplay_gamerules.h
@@ -163,6 +163,7 @@ public:
 	virtual float FlWeaponRespawnTime( CBaseCombatWeapon *pWeapon );
 	virtual float FlWeaponTryRespawn( CBaseCombatWeapon *pWeapon );
 	virtual Vector VecWeaponRespawnSpot( CBaseCombatWeapon *pWeapon );
+	virtual QAngle DefaultWeaponRespawnAngle( CBaseCombatWeapon *pWeapon );
 
 // Item retrieval
 	virtual bool CanHaveItem( CBasePlayer *pPlayer, CItem *pItem );

--- a/src/game/shared/singleplay_gamerules.cpp
+++ b/src/game/shared/singleplay_gamerules.cpp
@@ -385,6 +385,11 @@ bool CSingleplayRules::Damage_ShouldNotBleed( int iDmgType )
 		return pWeapon->GetAbsOrigin();
 	}
 
+	QAngle CSingleplayRules::DefaultWeaponRespawnAngle( CBaseCombatWeapon *pWeapon )
+	{
+		return pWeapon->GetAbsAngles();
+	}
+
 	//=========================================================
 	// WeaponShouldRespawn - any conditions inhibiting the
 	// respawning of this weapon?

--- a/src/game/shared/singleplay_gamerules.h
+++ b/src/game/shared/singleplay_gamerules.h
@@ -95,6 +95,7 @@ public:
 	virtual float FlWeaponRespawnTime( CBaseCombatWeapon *pWeapon );
 	virtual float FlWeaponTryRespawn( CBaseCombatWeapon *pWeapon );
 	virtual Vector VecWeaponRespawnSpot( CBaseCombatWeapon *pWeapon );
+	virtual QAngle DefaultWeaponRespawnAngle( CBaseCombatWeapon *pWeapon );
 
 // Item retrieval
 	virtual bool CanHaveItem( CBasePlayer *pPlayer, CItem *pItem );


### PR DESCRIPTION
**Issue**: 
When weapons respawn, they sometimes have the wrong angles applied.

**Fix**: 
Apply the default respawn angles with `g_pGameRules->DefaultWeaponRespawnAngle( this )`.