### PR TITLE
[HL2MP] Fix weapon respawn

### DIFF
--- a/src/game/shared/hl2mp/weapon_hl2mpbase.cpp
+++ b/src/game/shared/hl2mp/weapon_hl2mpbase.cpp
@@ -206,6 +206,31 @@ int CWeaponHL2MPBase::ObjectCaps()
 
 #endif
 
+#ifdef GAME_DLL
+void CWeaponHL2MPBase::FallThink( void )
+{
+	// Prevent the common HL2DM weapon respawn bug from happening
+	// When a weapon is spawned, the following chain of events occurs:
+	// - Spawn() is called, which then calls FallInit()
+	// - FallInit() is called, and prepares the weapon's 'Think' function (CBaseCombatWeapon::FallThink())
+	// - FallThink() is called, and performs several checks before deciding whether the weapon should Materialize()
+	// - Materialize() is called (the HL2DM version above), which sets the weapon's respawn location.
+	// The problem occurs when a weapon isn't placed properly by a level designer.
+	// If the weapon is unable to move from its location (e.g. if its bounding box is halfway inside a wall), Materialize() never gets called.
+	// Since Materialize() never gets called, the weapon's respawn location is never set, so if a person picks it up, it respawns forever at
+	// 0 0 0 on the map (infinite loop of fall, wait, respawn, not nice at all for performance and bandwidth!)
+	if ( HasSpawnFlags( SF_NORESPAWN ) == false )
+	{
+		if ( GetOriginalSpawnOrigin() == vec3_origin )
+		{
+			m_vOriginalSpawnOrigin = GetAbsOrigin();
+			m_vOriginalSpawnAngles = GetAbsAngles();
+		}
+	}
+	return BaseClass::FallThink();
+}
+#endif // GAME_DLL
+
 void CWeaponHL2MPBase::FallInit( void )
 {
 #ifndef CLIENT_DLL
@@ -262,7 +287,7 @@ void CWeaponHL2MPBase::FallInit( void )
 
 	SetPickupTouch();
 	
-	SetThink( &CBaseCombatWeapon::FallThink );
+	SetThink( &CWeaponHL2MPBase::FallThink );
 
 	SetNextThink( gpGlobals->curtime + 0.1f );
 

--- a/src/game/shared/hl2mp/weapon_hl2mpbase.h
+++ b/src/game/shared/hl2mp/weapon_hl2mpbase.h
@@ -45,6 +45,7 @@ public:
 
 		void Materialize( void );
 		virtual	int	ObjectCaps( void );
+		virtual void FallThink( void );
 	#endif
 
 	// All predicted weapons need to implement and return true


### PR DESCRIPTION
Applying the following [fix](https://developer.valvesoftware.com/wiki/Weapon_Respawn_Fix).

**Issue**: 
When weapons are not placed correctly by level designers (i.e. when their bounding boxes intersect other entities or world geometry), they will respawn at an incorrect place on the map after being picked up by players. In most cases, the weapon will instead respawn at `0 0 0` on the map, and will continue on in a perpetual loop of falling, waiting, respawning and falling again.

**Fix**: 
This was resolved by ensuring that when a weapon respawns, it checks for a valid spawn location that is not obstructed by world geometry or other entities. If the original spawn point is invalid, the weapon will attempt to find a nearby suitable location instead of defaulting to the map's origin `(0 0 0)`. This prevents the infinite falling and respawning loop.