### PR TITLE
[HL2MP] Fix silent object hold exploit

### DIFF
--- a/src/game/shared/hl2mp/weapon_physcannon.cpp
+++ b/src/game/shared/hl2mp/weapon_physcannon.cpp
@@ -2337,7 +2337,7 @@ void CWeaponPhysCannon::ItemPostFrame()
 		}
 	}
 	
-	if (( pOwner->m_nButtons & IN_ATTACK2 ) == 0 )
+	if ( ( pOwner->m_nButtons & IN_ATTACK2 ) == 0 && CanPerformSecondaryAttack() )
 	{
 		m_nAttack2Debounce = 0;
 	}


### PR DESCRIPTION
**Issue**: 
Players can silently hold objects with the physcannon, making it impossible for others to hear when an enemy is holding an object. Additionally, if a player releases the object between 0.4 and 0.5 seconds, the physcannon visually shuts down, but the object remains held.

**Fix**: 
Simply check if a secondary attack can be performed and prevent secondary attack operations if we are not allowed.