### PR TITLE
[HL2MP] Fix rockets slowing down in water

### DIFF
--- a/src/game/shared/hl2mp/weapon_rpg.cpp
+++ b/src/game/shared/hl2mp/weapon_rpg.cpp
@@ -454,7 +454,7 @@ void CMissile::IgniteThink( void )
 	SetModel("models/weapons/w_missile.mdl");
 	UTIL_SetSize( this, vec3_origin, vec3_origin );
  	RemoveSolidFlags( FSOLID_NOT_SOLID );
-
+	AddEFlags( EFL_NO_WATER_VELOCITY_CHANGE );
 	//TODO: Play opening sound
 
 	Vector vecForward;


### PR DESCRIPTION
**Issue**: 
Rockets slow down when they collide with water.

**Fix**: 
Added a flag to prevent rockets slowing down in water.