### PR TITLE
[HL2MP] RPG third rocket fix

### DIFF
--- a/src/game/shared/hl2mp/weapon_rpg.cpp
+++ b/src/game/shared/hl2mp/weapon_rpg.cpp
@@ -1795,7 +1795,7 @@ void CWeaponRPG::CreateLaserPointer( void )
 	if ( pOwner == NULL )
 		return;
 
-	if ( pOwner->GetAmmoCount(m_iPrimaryAmmoType) <= 0 )
+	if ( pOwner->GetAmmoCount(m_iPrimaryAmmoType) == 0 )
 		return;
 
 	m_hLaserDot = CLaserDot::Create( GetAbsOrigin(), GetOwner() );

--- a/src/game/shared/hl2mp/weapon_rpg.cpp
+++ b/src/game/shared/hl2mp/weapon_rpg.cpp
@@ -1791,11 +1791,14 @@ void CWeaponRPG::CreateLaserPointer( void )
 		return;
 
 	CBaseCombatCharacter *pOwner = GetOwner();
-	
-	if ( pOwner == NULL )
+	if ( !pOwner )
 		return;
 
-	if ( pOwner->GetAmmoCount(m_iPrimaryAmmoType) == 0 )
+	// Third rocket guidance fix
+	CMissile *pMissile = dynamic_cast< CMissile * >( m_hMissile.Get() );
+
+	// Let me still be guided if I am the owner's child
+	if ( !pMissile && pOwner->GetAmmoCount( m_iPrimaryAmmoType ) <= 0 )
 		return;
 
 	m_hLaserDot = CLaserDot::Create( GetAbsOrigin(), GetOwner() );


### PR DESCRIPTION
**Issue**: 
Sometimes, the last rocket in your ammo fails to be guided, especially if you switch to the RPG from another weapon and fire too quickly.

**Fix**: 
Ensure that if a rocket is fired, it remains guidable regardless of how quickly the weapon was switched.