### PR TITLE
[HL2MP] Fix RPG Rocket Damage

### DIFF
--- a/src/game/shared/hl2mp/weapon_rpg.cpp
+++ b/src/game/shared/hl2mp/weapon_rpg.cpp
@@ -359,6 +359,10 @@ void CMissile::ShotDown( void )
 //-----------------------------------------------------------------------------
 void CMissile::DoExplosion( void )
 {
+	Vector origin = GetAbsOrigin();
+	origin.z -= 1;
+	SetAbsOrigin( origin );
+
 	// Explode
 	ExplosionCreate( GetAbsOrigin(), GetAbsAngles(), GetOwnerEntity(), GetDamage(), GetDamage() * 2, 
 		SF_ENVEXPLOSION_NOSPARKS | SF_ENVEXPLOSION_NODLIGHTS | SF_ENVEXPLOSION_NOSMOKE, 0.0f, this);
@@ -452,7 +456,6 @@ void CMissile::IgniteThink( void )
 {
 	SetMoveType( MOVETYPE_FLY );
 	SetModel("models/weapons/w_missile.mdl");
-	UTIL_SetSize( this, vec3_origin, vec3_origin );
  	RemoveSolidFlags( FSOLID_NOT_SOLID );
 
 	//TODO: Play opening sound

--- a/src/game/shared/hl2mp/weapon_rpg.cpp
+++ b/src/game/shared/hl2mp/weapon_rpg.cpp
@@ -359,9 +359,7 @@ void CMissile::ShotDown( void )
 //-----------------------------------------------------------------------------
 void CMissile::DoExplosion( void )
 {
-	Vector origin = GetAbsOrigin();
-	origin.z -= 1;
-	SetAbsOrigin( origin );
+	Vector explosionOrigin = WorldSpaceCenter();
 
 	// Explode
 	ExplosionCreate( GetAbsOrigin(), GetAbsAngles(), GetOwnerEntity(), GetDamage(), GetDamage() * 2, 

--- a/src/game/shared/hl2mp/weapon_rpg.cpp
+++ b/src/game/shared/hl2mp/weapon_rpg.cpp
@@ -362,7 +362,7 @@ void CMissile::DoExplosion( void )
 	Vector explosionOrigin = WorldSpaceCenter();
 
 	// Explode
-	ExplosionCreate( GetAbsOrigin(), GetAbsAngles(), GetOwnerEntity(), GetDamage(), GetDamage() * 2, 
+	ExplosionCreate( explosionOrigin, GetAbsAngles(), GetOwnerEntity(), GetDamage(), GetDamage() * 2,
 		SF_ENVEXPLOSION_NOSPARKS | SF_ENVEXPLOSION_NODLIGHTS | SF_ENVEXPLOSION_NOSMOKE, 0.0f, this);
 }
 


### PR DESCRIPTION
**Issue**: 
Rockets blast radius can affect other players located above a ceiling or on the other side of a wall when they should not be damaged.

**Fix**: 
Adjust the origin on the Z axis to prevent unfair damage caused by rockets.