### PR TITLE
[HL2MP] Fix client-side reload animation with the RPG

### DIFF
--- a/src/game/shared/hl2mp/weapon_rpg.h
+++ b/src/game/shared/hl2mp/weapon_rpg.h
@@ -233,6 +233,8 @@ public:
 	void			GetWeaponAttachment( int attachmentId, Vector &outVector, Vector *dir = NULL );
 	void			DrawEffects( void );
 //	void			DrawLaserDot( void );
+	bool			IsPredictingMissile() const { return m_bClientPredictingMissile; }
+	void			SetPredictingMissile( bool enabled ) { m_bClientPredictingMissile = enabled; }
 
 	CMaterialReference	m_hSpriteMaterial;	// Used for the laser glint
 	CMaterialReference	m_hBeamMaterial;	// Used for the laser beam
@@ -262,6 +264,10 @@ protected:
 private:
 	
 	CWeaponRPG( const CWeaponRPG & );
+
+#ifdef CLIENT_DLL
+	bool m_bClientPredictingMissile; // Tracks if the client should treat a missile as active
+#endif
 };
 
 #endif // WEAPON_RPG_H


### PR DESCRIPTION
**Issue**: 
On listen servers and sometimes dedicated servers, the RPG reload animation plays prematurely after firing a rocket, even though the rocket is still in the air. This happens because the client incorrectly assumes the rocket is NULL and starts the reload, only to sync up with the server once the actual rocket is destroyed.

**Fix**: 
Fake a predicted rocket on the client to prevent reloading early.