### PR TITLE
[HL2MP] Fix holstering with a live rocket round

### DIFF
--- a/src/game/shared/hl2mp/weapon_rpg.cpp
+++ b/src/game/shared/hl2mp/weapon_rpg.cpp
@@ -1635,7 +1635,7 @@ bool CWeaponRPG::Deploy( void )
 	return BaseClass::Deploy();
 }
 
-bool CWeaponRPG::CanHolster( void )
+bool CWeaponRPG::CanHolster( void ) const
 {
 	//Can't have an active missile out
 	if ( m_hMissile != NULL )

--- a/src/game/shared/hl2mp/weapon_rpg.h
+++ b/src/game/shared/hl2mp/weapon_rpg.h
@@ -190,7 +190,7 @@ public:
 	bool	WeaponShouldBeLowered( void );
 	bool	Lower( void );
 
-	bool	CanHolster( void );
+	bool	CanHolster( void ) const;
 
 	virtual void Drop( const Vector &vecVelocity );
 


### PR DESCRIPTION
**Issue**: 
If a player fires a rocket, they can switch weapons while this rocket is live.

**Fix**: 
This is a straightforward fix. Added `const` to `bool CWeaponRPG::CanHolster( void )`.