### PR TITLE
[HL2MP] Force drop all items held in the physcannon when switching to spectators

### DIFF
--- a/src/game/server/hl2mp/hl2mp_player.cpp
+++ b/src/game/server/hl2mp/hl2mp_player.cpp
@@ -18,6 +18,7 @@
 #include "team.h"
 #include "weapon_hl2mpbase.h"
 #include "grenade_satchel.h"
+#include "hl2mp/weapon_physcannon.h"
 #include "eventqueue.h"
 #include "gamestats.h"
 #include "ammodef.h"
@@ -997,6 +998,19 @@ void CHL2MP_Player::ChangeTeam( int iTeam )
 
 	if ( iTeam == TEAM_SPECTATOR )
 	{
+		CBaseCombatWeapon *pWeapon = GetActiveWeapon();
+
+		if ( pWeapon && !pWeapon->Holster() )
+		{
+			CWeaponPhysCannon *pPhysCannon = dynamic_cast< CWeaponPhysCannon * >( pWeapon );
+
+			if ( pPhysCannon )
+			{
+				pPhysCannon->KillUsage(); // Make sure to drop everything.
+				pPhysCannon->Delete(); // Get rid of the gun, cause for some reason, it can stay on the screen otherwise.
+			}
+		}
+
 		RemoveAllItems( true );
 
 		State_Transition( STATE_OBSERVER_MODE );

--- a/src/game/shared/hl2mp/weapon_physcannon.h
+++ b/src/game/shared/hl2mp/weapon_physcannon.h
@@ -308,6 +308,12 @@ public:
 	EHANDLE m_hOldAttachedObject;
 
 	bool	CanPickupObject( CBaseEntity *pTarget );
+	void KillUsage()
+	{
+		ForceDrop();
+		DestroyEffects();
+	}
+
 protected:
 	enum FindObjectResult_t
 	{


### PR DESCRIPTION
**Issue**: 
If a player holds an object, mainly a prop, with their physcannon and changes team to spectators, that prop completely loses server-side collisions for that one player until the map is changed. This also causes a visual mismatch between server and client, that can be quickly fixed with `cl_fullupdate`, but that command is cheat protected.

**Fix**: 
Force drop all physics objects held in the physcannon. Ideally, you would also send a `cl_fullupdate` command to the client when they switch to spectators.