### PR TITLE
[HL2MP] Don't heal dead players

### DIFF
--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -866,6 +866,9 @@ void CBasePlayer::DeathSound( const CTakeDamageInfo &info )
 
 int CBasePlayer::TakeHealth( float flHealth, int bitsDamageType )
 {
+	if ( !IsAlive() )
+		return 0;
+
 	// clear out any damage types we healed.
 	// UNDONE: generic health should not heal any
 	// UNDONE: time-based damage


### PR DESCRIPTION
**Issue**: 
It is possible for dead players to heal, even though they were not alive to benefit from it.

**Fix**: 
Added a check so that if the player is not alive, then don't let them heal.