### PR TITLE
[HL2MP] Fix searching "player" entity

### DIFF
--- a/src/game/server/entitylist.cpp
+++ b/src/game/server/entitylist.cpp
@@ -526,7 +526,14 @@ CBaseEntity *CGlobalEntityList::FindEntityProcedural( const char *szName, CBaseE
 		//
 		if ( FStrEq( pName, "player" ) )
 		{
-			return (CBaseEntity *)UTIL_PlayerByIndex( 1 );
+			if ( pSearchingEntity )
+			{
+				return FindEntityGenericNearest( "player", pSearchingEntity->GetAbsOrigin(), 0, pSearchingEntity, pActivator, pCaller );
+			}
+			else
+			{
+				return ( CBaseEntity * ) UTIL_PlayerByIndex( 1 );
+			}
 		}
 		else if ( FStrEq( pName, "pvsplayer" ) )
 		{


### PR DESCRIPTION
**Issue**: 
If we search for a "player" entity, we would always return with `UTIL_PlayerByIndex(1)`. This means this is a static search and not a dynamic one. Therefore, we lack the ability for more dynamic searches.

**Fix**: 
We introduce a different form of check:
If `bDirectEntity` is true, it uses `FindEntityGeneric()` to locate the player entity based on search criteria making the lookup more context-sensitive, else it falls back to the old method of returning the first player in the list.