### PR TITLE
[HL2MP] Adress physics object NULL pointers

### DIFF
--- a/src/game/server/physobj.cpp
+++ b/src/game/server/physobj.cpp
@@ -633,7 +633,8 @@ int CPhysBox::DrawDebugTextOverlays(void)
 //-----------------------------------------------------------------------------
 void CPhysBox::InputWake( inputdata_t &inputdata )
 {
-	VPhysicsGetObject()->Wake();
+	if ( VPhysicsGetObject() )
+		VPhysicsGetObject()->Wake();
 }
 
 //-----------------------------------------------------------------------------
@@ -642,7 +643,8 @@ void CPhysBox::InputWake( inputdata_t &inputdata )
 //-----------------------------------------------------------------------------
 void CPhysBox::InputSleep( inputdata_t &inputdata )
 {
-	VPhysicsGetObject()->Sleep();
+	if ( VPhysicsGetObject() )
+		VPhysicsGetObject()->Sleep();
 }
 
 //-----------------------------------------------------------------------------
@@ -705,7 +707,8 @@ void CPhysBox::InputForceDrop( inputdata_t &inputdata )
 //-----------------------------------------------------------------------------
 void CPhysBox::Move( const Vector &direction )
 {
-	VPhysicsGetObject()->ApplyForceCenter( direction );
+	if ( VPhysicsGetObject() )
+		VPhysicsGetObject()->ApplyForceCenter( direction );
 }
 
 // Update the visible representation of the physic system's representation of this object


### PR DESCRIPTION
**Issue**: 
Straightforward, some physics functions lack a null pointer check.

**Fix**: 
Check if `VPhysicsGetObject()` is valid.