### PR TITLE
[HL2MP] Fix trigger_hurt & prop_physics_respawnable crash

### DIFF
--- a/src/game/server/triggers.cpp
+++ b/src/game/server/triggers.cpp
@@ -841,17 +841,20 @@ int CTriggerHurt::HurtAllTouchers( float dt )
 
 	m_hurtEntities.RemoveAll();
 
-	touchlink_t *root = ( touchlink_t * )GetDataObject( TOUCHLINK );
+	touchlink_t *root = ( touchlink_t * ) GetDataObject( TOUCHLINK );
 	if ( root )
 	{
-		for ( touchlink_t *link = root->nextLink; link != root; link = link->nextLink )
+		for ( touchlink_t *link = root->nextLink; link != root && link != nullptr; link = link->nextLink )
 		{
-			CBaseEntity *pTouch = link->entityTouched;
-			if ( pTouch )
+			if ( link )
 			{
-				if ( HurtEntity( pTouch, fldmg ) )
+				CBaseEntity *pTouch = link->entityTouched;
+				if ( pTouch )
 				{
-					hurtCount++;
+					if ( HurtEntity( pTouch, fldmg ) )
+					{
+						hurtCount++;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
**Issue**:
 Not a really common issue players would encounter, but still worth a fix. If a `prop_physics_respawnable` is put inside a `trigger_hurt` volume, then the server or game crashes.

**Fix**: 
Check if `link` is not `NULL`.