### PR TITLE
[HL2MP] Solve a crash with trigger_weapon_dissolve and accelerate weapon dissolve

### DIFF
--- a/src/game/server/hl2/hl2_triggers.cpp
+++ b/src/game/server/hl2/hl2_triggers.cpp
@@ -228,6 +228,10 @@ void CTriggerWeaponDissolve::DissolveThink( void )
 	for ( int i = 0; i < numWeapons; i++ )
 	{
 		CBaseCombatWeapon *pWeapon = m_pWeapons[i];
+
+		if ( !pWeapon )
+			continue;
+
 		Vector vecConduit = GetConduitPoint( pWeapon );
 		
 		// The physcannon upgrades when this happens
@@ -271,7 +275,11 @@ void CTriggerWeaponDissolve::DissolveThink( void )
 		EmitSound( "WeaponDissolve.Beam" );
 
 		m_pWeapons.Remove( i );
+#if defined(HL2MP)
+		SetContextThink( &CTriggerWeaponDissolve::DissolveThink, gpGlobals->curtime + random->RandomFloat( 0.2f, 0.5f ), s_pDissolveThinkContext );
+#else
 		SetContextThink( &CTriggerWeaponDissolve::DissolveThink, gpGlobals->curtime + random->RandomFloat( 0.5f, 1.5f ), s_pDissolveThinkContext );
+#endif
 		return;
 	}
 


### PR DESCRIPTION
**Issue**:
 This bug exists in HL2 and can be even more unstable in HL2DM due to its multiplayer nature. The game may crash when` trigger_weapon_dissolve` attempts to dissolve weapons. In HL2DM, dropped weapons are set to disappear after some time if not picked up, which can contribute to the crash.

**Fix**: 
The issue was caused by `pWeapon` not being properly validated before being used, potentially leading to a crash. A validity check has been added to prevent this. Additionally, the dissolving process is accelerated, reducing the time window to 0.2-0.5 second, helping prevent weapon entities from stacking up in servers with a large number of players.