### PR TITLE
[HL2MP] Fix trigger_push not lifting players off the ground

### DIFF
--- a/src/game/server/triggers.cpp
+++ b/src/game/server/triggers.cpp
@@ -2321,7 +2321,7 @@ void CTriggerPush::Touch( CBaseEntity *pOther )
 			{
 				pOther->SetGroundEntity( NULL );
 				Vector origin = pOther->GetAbsOrigin();
-				origin.z += 1.0f;
+				origin.z += 16.0f;
 				pOther->SetAbsOrigin( origin );
 			}
 

--- a/src/game/server/triggers.cpp
+++ b/src/game/server/triggers.cpp
@@ -2190,11 +2190,13 @@ public:
 	
 	float m_flAlternateTicksFix; // Scale factor to apply to the push speed when running with alternate ticks
 	float m_flPushSpeed;
+	bool m_bFixLift;
 };
 
 BEGIN_DATADESC( CTriggerPush )
 	DEFINE_KEYFIELD( m_vecPushDir, FIELD_VECTOR, "pushdir" ),
 	DEFINE_KEYFIELD( m_flAlternateTicksFix, FIELD_FLOAT, "alternateticksfix" ),
+	DEFINE_KEYFIELD( m_bFixLift, FIELD_BOOLEAN, "liftfix" ),
 	//DEFINE_FIELD( m_flPushSpeed, FIELD_FLOAT ),
 END_DATADESC()
 
@@ -2321,7 +2323,8 @@ void CTriggerPush::Touch( CBaseEntity *pOther )
 			{
 				pOther->SetGroundEntity( NULL );
 				Vector origin = pOther->GetAbsOrigin();
-				origin.z += 16.0f;
+				if ( m_bFixLift )
+					origin.z += 16.0f;
 				pOther->SetAbsOrigin( origin );
 			}
 


### PR DESCRIPTION
**Issue**: 
When a `trigger_push` is set to push players upwards, they often remain stuck to the ground and are not properly lifted when in motion (moving about). The original 1-unit Z-axis push is insufficient to "unglue" moving players from the floor.

**Fix**: 
Change the 1-unit Z push to 16. It might be overkill, but it at least ensures that players get pushed upwards when inside an active volume.