### PR TITLE
[HL2MP] Delay initial spawn

### DIFF
--- a/src/game/server/hl2mp/hl2mp_client.cpp
+++ b/src/game/server/hl2mp/hl2mp_client.cpp
@@ -38,11 +38,21 @@ ConVar sv_motd_unload_on_dismissal( "sv_motd_unload_on_dismissal", "0", 0, "If e
 extern CBaseEntity*	FindPickerEntityClass( CBasePlayer *pPlayer, char *classname );
 extern bool			g_fGameOver;
 
+void CBasePlayer::DelayedSpawn()
+{
+	Spawn();
+}
+
 void FinishClientPutInServer( CHL2MP_Player *pPlayer )
 {
 	pPlayer->InitialSpawn();
-	pPlayer->Spawn();
-
+	// Peter: I can't seem to find anything that would suggest 
+	// this would be broken after connecting to a server, but clearly, 
+	// delaying this fixes: 
+	// 
+	// 1) The spawning angles of 0, 0, 0 
+	// 2) Always spawning in showers on lockdown
+	pPlayer->SetContextThink( &CBasePlayer::DelayedSpawn, gpGlobals->curtime + 0.01f, "DelayedSnapEyeAngles" );
 
 	char sName[128];
 	Q_strncpy( sName, pPlayer->GetPlayerName(), sizeof( sName ) );

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -287,6 +287,7 @@ public:
 	// (like team members, entities out of our PVS, etc).
 	virtual bool			WantsLagCompensationOnEntity( const CBasePlayer	*pPlayer, const CUserCmd *pCmd, const CBitVec<MAX_EDICTS> *pEntityTransmitBits ) const;
 
+	void					DelayedSpawn();
 	virtual void			Spawn( void );
 	virtual void			Activate( void );
 	virtual void			SharedSpawn(); // Shared between client and server.


### PR DESCRIPTION
**Preamble**: 
I am not entirely sure whether the root cause lies within the Source SDK or deeper in the engine itself, particularly after the 64-bit update. If the issue does originate from the SDK, I apologize in advance. However, after digging through the SDK, I found no differences in behavior between the pre-64-bit update and the current version.

**Issue**: 
When a player joins a server --especially a dedicated one, as listen servers exhibit inconsistent behavior, their view angles are always set to `0 0 0` instead of inheriting the intended angles from the spawn point. Additionally, in maps like `dm_lockdown`, the first spawn seems to always occur in the showers or, at best, near the first ladder leading to the showers, rather than randomly selecting from all available spawn points.

**Fix**: 
The only reliable way I found to correct this issue was to introduce a slight delay (1/100th of a second) before the initial spawn. Not only do players now correctly inherit the intended view angles, but they are properly assigned to a random spawn point rather than being forced into the showers every time.