### PR TITLE
[HL2MP] Fix oil drums blowing up on surface contact after yoyoing them

### DIFF
--- a/src/game/server/props.cpp
+++ b/src/game/server/props.cpp
@@ -2742,6 +2742,12 @@ void CPhysicsProp::OnPhysGunPickup( CBasePlayer *pPhysGunUser, PhysGunPickup_t r
 		}
 	}
 
+	if ( pPhysicsObject && ( pPhysicsObject->GetGameFlags() & FVPHYSICS_WAS_THROWN ) )
+	{
+		PhysClearGameFlags( pPhysicsObject, FVPHYSICS_WAS_THROWN );
+	}
+	m_bFirstCollisionAfterLaunch = false;
+
 	m_OnPhysGunPickup.FireOutput( pPhysGunUser, this );
 
 	if( reason == PICKED_UP_BY_CANNON )


### PR DESCRIPTION
**Issue**: 
Whenever a player does a yo-yo with an explosive prop, like the explosive barrels on `dm_lockdown`, then their thrown flag is not cleared and causes the prop to blow no matter how gently you put it down.

**Fix**: 
Clear the `FVPHYSICS_WAS_THROWN` flag.