### PR TITLE
[HL2MP] Fix physcannon interaction with picked up items

### DIFF
--- a/src/game/server/basecombatweapon.cpp
+++ b/src/game/server/basecombatweapon.cpp
@@ -243,7 +243,7 @@ CBaseEntity* CBaseCombatWeapon::Respawn( void )
 		pNewWeapon->AddEffects( EF_NODRAW );// invisible for now
 		pNewWeapon->SetTouch( NULL );// no touch
 		pNewWeapon->SetThink( &CBaseCombatWeapon::AttemptToMaterialize );
-
+		pNewWeapon->AddEFlags( EFL_NO_PHYSCANNON_INTERACTION );
 		UTIL_DropToFloor( this, MASK_SOLID );
 
 		// not a typo! We want to know when the weapon the player just picked up should respawn! This new entity we created is the replacement,
@@ -641,6 +641,7 @@ void CBaseCombatWeapon::AttemptToMaterialize( void )
 	if ( time == 0 )
 	{
 		Materialize();
+		RemoveEFlags( EFL_NO_PHYSCANNON_INTERACTION );
 		return;
 	}
 

--- a/src/game/server/item_world.cpp
+++ b/src/game/server/item_world.cpp
@@ -500,6 +500,7 @@ CBaseEntity* CItem::Respawn( void )
 {
 	SetTouch( NULL );
 	AddEffects( EF_NODRAW );
+	AddEFlags( EFL_NO_PHYSCANNON_INTERACTION );
 
 	VPhysicsDestroyObject();
 


### PR DESCRIPTION
**Issue**: 
This is barely an issue, but can become one in very specific situations. Whenever an item or weapon is picked up, it is possible to punt that picked up object, despite being invisible, at the level designer's placed location.

**Fix**: 
Simply prevent physcannon interaction with picked up items until they respawn.