### PR TITLE
[HL2MP] Move phys_swap client-side

### DIFF
--- a/src/game/client/weapon_selection.cpp
+++ b/src/game/client/weapon_selection.cpp
@@ -400,6 +400,38 @@ void CBaseHudWeaponSelection::UserCmd_Slot10(void)
 	SelectSlot( 10 );
 }
 
+void ClientInstantPhysSwap()
+{
+	C_BasePlayer *pPlayer = C_BasePlayer::GetLocalPlayer();
+	if ( !pPlayer )
+		return;
+
+	C_BaseCombatWeapon *pWeapon = pPlayer->GetActiveWeapon();
+	if ( !pWeapon )
+		return;
+
+	const char *strWeaponName = pWeapon->GetName();
+
+	if ( !Q_stricmp( strWeaponName, "weapon_physcannon" ) )
+	{
+		input->MakeWeaponSelection( pPlayer->GetLastWeapon() ); // back to previous weapon
+	}
+	else
+	{
+		for ( int i = 0; i < pPlayer->WeaponCount(); ++i )
+		{
+			C_BaseCombatWeapon *pWeapon = pPlayer->GetWeapon( i );
+			if ( pWeapon && !Q_stricmp( pWeapon->GetClassname(), "weapon_physcannon" ) ) // switch to physcannon
+			{
+				input->MakeWeaponSelection( pWeapon );
+				return;
+			}
+		}
+	}
+}
+
+static ConCommand cl_physswap( "phys_swap", ClientInstantPhysSwap, "Client-predicted physcannon swap for low-latency switching." );
+
 //-----------------------------------------------------------------------------
 // Purpose: returns true if the CHudMenu should take slot1, etc commands
 //-----------------------------------------------------------------------------

--- a/src/game/server/client.cpp
+++ b/src/game/server/client.cpp
@@ -1038,40 +1038,6 @@ void CC_Player_TestDispatchEffect( const CCommand &args )
 
 static ConCommand test_dispatcheffect("test_dispatcheffect", CC_Player_TestDispatchEffect, "Test a clientside dispatch effect.\n\tUsage: test_dispatcheffect <effect name> <distance away> <flags> <magnitude> <scale>\n\tDefaults are: <distance 1024> <flags 0> <magnitude 0> <scale 0>\n", FCVAR_CHEAT);
 
-#ifdef HL2_DLL
-//-----------------------------------------------------------------------------
-// Purpose: Quickly switch to the physics cannon, or back to previous item
-//-----------------------------------------------------------------------------
-void CC_Player_PhysSwap( void )
-{
-	CBasePlayer *pPlayer = ToBasePlayer( UTIL_GetCommandClient() );
-	
-	if ( pPlayer )
-	{
-		CBaseCombatWeapon *pWeapon = pPlayer->GetActiveWeapon();
-
-		if ( pWeapon )
-		{
-			// Tell the client to stop selecting weapons
-			engine->ClientCommand( UTIL_GetCommandClient()->edict(), "cancelselect" );
-
-			const char *strWeaponName = pWeapon->GetName();
-
-			if ( !Q_stricmp( strWeaponName, "weapon_physcannon" ) )
-			{
-				PhysCannonForceDrop( pWeapon, NULL );
-				pPlayer->SelectLastItem();
-			}
-			else
-			{
-				pPlayer->SelectItem( "weapon_physcannon" );
-			}
-		}
-	}
-}
-static ConCommand physswap("phys_swap", CC_Player_PhysSwap, "Automatically swaps the current weapon for the physcannon and back again." );
-#endif
-
 //-----------------------------------------------------------------------------
 // Purpose: Quickly switch to the bug bait, or back to previous item
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
**Issue**: 
`phys_swap` is server-sided for reasons I fail to grasp. This causes a number of issues, mainly the delay between the key press and the weapon being drawn since it is dependent on the player's latency i.e. it is not a predicted action. Additionally, it causes an issue where players can switch to another weapon despite holding an object with the physcannon. This causes client-side prop ghosting to happen. The latter can be fixed with `cl_fullupdate`, but it is cheat protected, which I don't think it should be for stuff like this.

![20250314120031_1](https://github.com/user-attachments/assets/747618d2-68f9-48c2-a2df-ab9a22cad56d)

**Fix**: Moved `phys_swap` client-side. This prevents switching weapons if there is a held object with the physcannon.