### PR TITLE
[HL2MP] Fix missing model check for phys_magnet

### DIFF
--- a/src/game/server/physobj.cpp
+++ b/src/game/server/physobj.cpp
@@ -1559,11 +1559,24 @@ CPhysMagnet::~CPhysMagnet( void )
 //-----------------------------------------------------------------------------
 void CPhysMagnet::Spawn( void )
 {
-	Precache();
-
 	SetMoveType( MOVETYPE_NONE );
 	SetSolid( SOLID_VPHYSICS );
-	SetModel( STRING( GetModelName() ) );
+
+	char *szModel = ( char * ) STRING( GetModelName() );
+
+	if ( !szModel || !*szModel )
+	{
+		Warning( "%s at %.0f, %.0f, %0.f missing modelname!\n",
+			GetClassname(),
+			GetAbsOrigin().x,
+			GetAbsOrigin().y,
+			GetAbsOrigin().z );
+		UTIL_Remove( this );
+		return;
+	}
+
+	PrecacheModel( szModel );
+	SetModel( szModel );
 
 	m_takedamage = DAMAGE_EVENTS_ONLY;
 


### PR DESCRIPTION
**Issue**: 
The `phys_magnet` entity was missing a proper model validation check, which could lead to issues such as spawning without a model, unexpected behavior, or crashes due to an invalid model reference.

**Fix**: 
Added a validation check to ensure that the entity has a valid model before proceeding with initialization. Additionally, models are now properly precached to ensure they are loaded before being used, preventing potential errors or missing assets in the game.