### PR TITLE
[HL2MP] Fix missing SetThink on logic_timer

### DIFF
--- a/src/game/server/logicentities.cpp
+++ b/src/game/server/logicentities.cpp
@@ -336,6 +336,7 @@ END_DATADESC()
 //-----------------------------------------------------------------------------
 void CTimerEntity::Spawn( void )
 {
+	SetThink( &CTimerEntity::FireTimer );
 	if (!m_iUseRandomTime && (m_flRefireTime < LOGIC_TIMER_MIN_INTERVAL))
 	{
 		m_flRefireTime = LOGIC_TIMER_MIN_INTERVAL;


### PR DESCRIPTION
**Issue**: 
The `void CTimerEntity::Spawn( void )` was missing a `SetThink`.

**Fix**: 
Add `SetThink( &CTimerEntity::FireTimer );`