### PR TITLE
[HL2MP] Fix logic branch typo

### DIFF
--- a/src/game/server/logicentities.cpp
+++ b/src/game/server/logicentities.cpp
@@ -2244,7 +2244,7 @@ void CLogicBranch::UpdateOnRemove()
 		CBaseEntity *pEntity = m_Listeners.Element( i ).Get();
 		if ( pEntity )
 		{
-			g_EventQueue.AddEvent( this, "_OnLogicBranchRemoved", 0, this, this );
+			g_EventQueue.AddEvent( pEntity, "_OnLogicBranchRemoved", 0, this, this );
 		}
 	}
 	


### PR DESCRIPTION
**Issue**: 
There is a typo in `CLogicBranch::UpdateOnRemove()` that caused the `_OnLogicBranchRemoved` event to be sent to itself instead of its listeners.

**Fix**: 
Fixed the typo. Instead, when a logic branch is removed, all its listeners are properly notified, as originally intended.