### PR TITLE
[HL2MP] Make info_null and infodecal server-side

### DIFF
--- a/src/game/server/subs.cpp
+++ b/src/game/server/subs.cpp
@@ -22,10 +22,10 @@ void CPointEntity::Spawn( void )
 }
 
 
-class CNullEntity : public CBaseEntity
+class CNullEntity : public CServerOnlyEntity
 {
 public:
-	DECLARE_CLASS( CNullEntity, CBaseEntity );
+	DECLARE_CLASS( CNullEntity, CServerOnlyEntity );
 
 	void Spawn( void );
 };

--- a/src/game/server/world.cpp
+++ b/src/game/server/world.cpp
@@ -43,10 +43,9 @@ extern CUtlMemoryPool g_EntityListPool;
 
 #define SF_DECAL_NOTINDEATHMATCH		2048
 
-class CDecal : public CPointEntity
-{
+class CDecal : public CServerOnlyPointEntity {
 public:
-	DECLARE_CLASS( CDecal, CPointEntity );
+	DECLARE_CLASS( CDecal, CServerOnlyPointEntity );
 
 	void	Spawn( void );
 	bool	KeyValue( const char *szKeyName, const char *szValue );


### PR DESCRIPTION
**Issue**: 
`info_null` and `infodecal` are not server-sided.

**Fix**: 
Make them server-sided.