### PR TITLE
[HL2MP] Deactivate game_ui on player death

### DIFF
--- a/src/game/server/game_ui.cpp
+++ b/src/game/server/game_ui.cpp
@@ -264,6 +264,13 @@ void CGameUI::Think( void )
 		return;
 	}
 
+	if ( !pPlayer->IsAlive() )
+	{
+		pPlayer->RemoveFlag( FL_ONTRAIN );
+		Deactivate( pPlayer );
+		return;
+	}
+
 	// If we're forcing an update, state with a clean button state
 	if ( m_bForceUpdate )
 	{


### PR DESCRIPTION
**Issue**: 
When a player dies while controlling a `game_ui`, it is not deactivated.

**Fix**: 
Deactivate `game_ui` for the player who died.