### PR TITLE
[HL2MP] Fix a crash with game_ui

### DIFF
--- a/src/game/server/game_ui.cpp
+++ b/src/game/server/game_ui.cpp
@@ -168,10 +168,6 @@ void CGameUI::Deactivate( CBaseEntity *pActivator )
 		m_nLastButtonState = 0;
 		m_player = NULL;
 	}
-	else
-	{
-		Warning("%s Deactivate(): I have no player when called by %s!\n", GetEntityName().ToCStr(), pActivator ? pActivator->GetEntityName().ToCStr() : NULL);
-	}
 	
 	// Stop thinking
 	SetNextThink( TICK_NEVER_THINK );


### PR DESCRIPTION
**Issue**: 
When a player disconnects when controlling a `game_ui`, the server or game crashes.

**Fix**: 
Prevent the warning from showing up and causing crashes.