### PR TITLE
[HL2MP] Fix angle issues with func_rotating

### DIFF
--- a/src/game/server/bmodels.cpp
+++ b/src/game/server/bmodels.cpp
@@ -1098,6 +1098,19 @@ void CFuncRotating::RotateMove( void )
 {
 	SetMoveDoneTime( 10 );
 
+	QAngle angNormalizedAngles = GetLocalAngles();
+
+	if ( m_vecMoveAng.x )
+		angNormalizedAngles.x = AngleNormalize( angNormalizedAngles.x );
+
+	if ( m_vecMoveAng.y )
+		angNormalizedAngles.y = AngleNormalize( angNormalizedAngles.y );
+
+	if ( m_vecMoveAng.z )
+		angNormalizedAngles.z = AngleNormalize( angNormalizedAngles.z );
+
+	SetLocalAngles( angNormalizedAngles );
+
 	if ( m_bStopAtStartPos )
 	{
 		SetMoveDoneTime( GetNextMoveInterval() );


### PR DESCRIPTION
**Issue**: 
Rotating entities can at one point exceed valid angle ranges.

**Fix**: 
Normalize the angles of a rotating entity to ensure it doesn't exceed valid angle ranges.