### PR TITLE
[HL2MP] Fix "Start locked" on func_rot_button

### DIFF
--- a/src/game/server/buttons.cpp
+++ b/src/game/server/buttons.cpp
@@ -898,6 +898,11 @@ void CRotButton::Spawn( void )
 
 	SetUse(&CRotButton::ButtonUse);
 
+	if ( HasSpawnFlags( SF_BUTTON_LOCKED ) )
+	{
+		m_bLocked = true;
+	}
+
 	//
 	// If touching activates the button, set its touch function.
 	//


### PR DESCRIPTION
**Issue**: `
Start locked` on `func_rot_button` doesn't work because it is missing a flag check.

**Fix**: 
Make it work xD