### PR TITLE
[HL2MP] Fix an exploit with env_info

### DIFF
--- a/src/game/server/baseentity.cpp
+++ b/src/game/server/baseentity.cpp
@@ -6241,6 +6241,12 @@ void CC_Ent_Info( const CCommand& args )
 	{
 		return;
 	}
+
+	if ( !Q_stricmp( args[ 1 ], "worldspawn" ) )
+	{
+		ClientPrint( pPlayer, HUD_PRINTCONSOLE, "Can't use command on worldspawn\n" );
+		return;
+	}
 	
 	if ( args.ArgC() < 2 )
 	{


### PR DESCRIPTION
**Issue**: 
If a player attempts to use `ent_info worldspawn`, their game will crash.

**Fix**: 
Prevent the usage of `ent_info worldspawn`.