### PR TITLE
[HL2MP] Fix non-looping sounds not stopping

### DIFF
--- a/src/game/server/sound.cpp
+++ b/src/game/server/sound.cpp
@@ -950,11 +950,13 @@ void CAmbientGeneric::SendSound( SoundFlags_t flags)
 		{
 			UTIL_EmitAmbientSound( pSoundSource->GetSoundSourceIndex(), pSoundSource->GetAbsOrigin(), m_szSoundFile,
 						0, SNDLVL_NONE, flags, 0);
+			m_fActive = false;
 		}
 		else
 		{
 			UTIL_EmitAmbientSound( pSoundSource->GetSoundSourceIndex(), pSoundSource->GetAbsOrigin(), m_szSoundFile,
 				(m_dpv.vol * 0.01), m_iSoundLevel, flags, m_dpv.pitch);
+			m_fActive = true;
 		}
 	}	
 	else
@@ -964,6 +966,7 @@ void CAmbientGeneric::SendSound( SoundFlags_t flags)
 		{
 			UTIL_EmitAmbientSound( m_nSoundSourceEntIndex, GetAbsOrigin(), m_szSoundFile,
 					0, SNDLVL_NONE, flags, 0);
+			m_fActive = false;
 		}
 	}
 }


### PR DESCRIPTION
**Issue**: 
Non-looping are immune to the `StopSound` input in Hammer for some reason.

**Fix**: 
When the `StopSound` input is sent to an `ambient_generic`, ensure that the sound is stopped by setting `m_fActive` to the correct value.