### PR TITLE
[HL2MP] Allow god mode

### DIFF
--- a/src/game/server/client.cpp
+++ b/src/game/server/client.cpp
@@ -1237,9 +1237,6 @@ void CC_God_f (void)
 	   if ( gpGlobals->deathmatch )
 		   return;
    }
-#else
-	if ( gpGlobals->deathmatch )
-		return;
 #endif
 
 	pPlayer->ToggleFlag( FL_GODMODE );


### PR DESCRIPTION
**Issue**: 
Why is the `god` command not available in MP?

**Fix**: 
Allow Jesus to take over the game.