### PR TITLE
[HL2MP] Weapon respawn ownership fix

### DIFF
--- a/src/game/server/basecombatweapon.cpp
+++ b/src/game/server/basecombatweapon.cpp
@@ -236,7 +236,7 @@ CBaseEntity* CBaseCombatWeapon::Respawn( void )
 {
 	// make a copy of this weapon that is invisible and inaccessible to players (no touch function). The weapon spawn/respawn code
 	// will decide when to make the weapon visible and touchable.
-	CBaseEntity *pNewWeapon = CBaseEntity::Create( GetClassname(), g_pGameRules->VecWeaponRespawnSpot( this ), GetLocalAngles(), GetOwnerEntity() );
+	CBaseEntity *pNewWeapon = CBaseEntity::Create( GetClassname(), g_pGameRules->VecWeaponRespawnSpot( this ), GetLocalAngles() );
 
 	if ( pNewWeapon )
 	{

--- a/src/game/shared/hl2mp/weapon_hl2mpbase.cpp
+++ b/src/game/shared/hl2mp/weapon_hl2mpbase.cpp
@@ -195,7 +195,7 @@ void CWeaponHL2MPBase::Materialize( void )
 	}
 
 	SetPickupTouch();
-
+	SetOwnerEntity( NULL );
 	SetThink (NULL);
 }
 


### PR DESCRIPTION
**Issue**: 
When weapons respawn, the previous owner is sometimes retained, which makes it impossible to punt weapons. The most notorious case is on `dm_lostarena_rpg` where many players found themselves unable to grab the RPG located behind a fence, requiring the weapon to be moved to be picked up.

**Fix**: 
Clear the previous owner on respawn.