### PR TITLE
[HL2MP] Add missing physbox kill death notice icon

### DIFF
--- a/src/game/shared/hl2mp/hl2mp_gamerules.cpp
+++ b/src/game/shared/hl2mp/hl2mp_gamerules.cpp
@@ -723,7 +723,10 @@ void CHL2MPRules::DeathNotice( CBasePlayer *pVictim, const CTakeDamageInfo &info
 		{
 			killer_weapon_name = "physics";
 		}
-
+		if ( strstr( killer_weapon_name, "physbox" ) )
+		{
+			killer_weapon_name = "physics";
+		}
 		if ( strcmp( killer_weapon_name, "prop_combine_ball" ) == 0 )
 		{
 			killer_weapon_name = "combine_ball";


### PR DESCRIPTION
**Issue**: 
A physbox kill shows the suicide skull in the death notice.

**Fix**: 
Use the physics icon when a kill with physbox is made.