### PR TITLE
[HL2MP] Fix explosive barrels on respawn

### DIFF
--- a/src/game/server/props.cpp
+++ b/src/game/server/props.cpp
@@ -2638,6 +2638,18 @@ bool CPhysicsProp::CanBePickedUpByPhyscannon( void )
 }
 
 //-----------------------------------------------------------------------------
+// Purpose: Clear all flags after respawn
+//-----------------------------------------------------------------------------
+void CPhysicsProp::Break( CBaseEntity *pBreaker, const CTakeDamageInfo &info )
+{
+	m_bFirstCollisionAfterLaunch = false;
+	// Setup the think function to remove the flags
+	RegisterThinkContext( "PROP_CLEARFLAGS" );
+	SetContextThink( &CPhysicsProp::ClearFlagsThink, gpGlobals->curtime, "PROP_CLEARFLAGS" );
+	CBreakableProp::Break( pBreaker, info );
+}
+
+//-----------------------------------------------------------------------------
 // Purpose: 
 //-----------------------------------------------------------------------------
 bool CPhysicsProp::OverridePropdata( void )

--- a/src/game/server/props.h
+++ b/src/game/server/props.h
@@ -62,7 +62,7 @@ public:
 
 	virtual int OnTakeDamage( const CTakeDamageInfo &info );
 	void Event_Killed( const CTakeDamageInfo &info );
-	void Break( CBaseEntity *pBreaker, const CTakeDamageInfo &info );
+	virtual void Break( CBaseEntity *pBreaker, const CTakeDamageInfo &info );
 	void BreakThink( void );
 	void AnimateThink( void );
 
@@ -345,6 +345,8 @@ public:
 
 	virtual void VPhysicsUpdate( IPhysicsObject *pPhysics );
 	virtual void VPhysicsCollision( int index, gamevcollisionevent_t *pEvent );
+
+	void Break( CBaseEntity *pBreaker, const CTakeDamageInfo &info )override;
 
 	void InputWake( inputdata_t &inputdata );
 	void InputSleep( inputdata_t &inputdata );


### PR DESCRIPTION
**Issue**: 
When an explosive barrel was destroyed, every time it respawns, it would blow on contact with the floor.

**Fix**: 
Clear all previous flags.