### PR TITLE
[HL2MP] Enforce cl_autowepswitch

### DIFF
--- a/src/game/server/hl2/hl2_player.cpp
+++ b/src/game/server/hl2/hl2_player.cpp
@@ -2647,13 +2647,17 @@ int CHL2_Player::GiveAmmo( int nCount, int nAmmoIndex, bool bSuppressSound)
 	// If I was dry on ammo for my best weapon and justed picked up ammo for it,
 	// autoswitch to my best weapon now.
 	//
-	if (bCheckAutoSwitch)
+	const char *cl_autowepswitch = engine->GetClientConVarValue( engine->IndexOfEdict( this->edict() ), "cl_autowepswitch" ); // if cl_autowepswitch is 0, it will not switch weapon.
+	if ( cl_autowepswitch && atoi( cl_autowepswitch ) >= 1 )
 	{
-		CBaseCombatWeapon *pWeapon = g_pGameRules->GetNextBestWeapon(this, GetActiveWeapon());
-
-		if ( pWeapon && pWeapon->GetPrimaryAmmoType() == nAmmoIndex )
+		if ( bCheckAutoSwitch )
 		{
-			SwitchToNextBestWeapon(GetActiveWeapon());
+			CBaseCombatWeapon *pWeapon = g_pGameRules->GetNextBestWeapon( this, GetActiveWeapon() );
+
+			if ( pWeapon && pWeapon->GetPrimaryAmmoType() == nAmmoIndex )
+			{
+				SwitchToNextBestWeapon( GetActiveWeapon() );
+			}
 		}
 	}
 


### PR DESCRIPTION
**Issue**: 
Despite `cl_autowepswitch` being set to 0, in some cases, the game completely ignores it and still proceeds with the switch.

**Fix**: 
Refactor the switch bit to properly detect `cl_autowepswitch`.