### PR TITLE
[HL2MP] Fix erroneous use of death sounds

### DIFF
--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -1754,7 +1754,8 @@ void CBasePlayer::Event_Dying( const CTakeDamageInfo& info )
 {
 	// NOT GIBBED, RUN THIS CODE
 
-	DeathSound( info );
+	if ( !IsDisconnecting() )
+		DeathSound( info );
 
 	// The dead body rolls out of the vehicle.
 	if ( IsInAVehicle() )
@@ -9604,7 +9605,8 @@ void CBasePlayer::Event_KilledOther( CBaseEntity *pVictim, const CTakeDamageInfo
 	}
 	else
 	{
-		gamestats->Event_PlayerSuicide( this );
+		if ( !IsDisconnecting() )
+			gamestats->Event_PlayerSuicide( this );
 	}
 }
 


### PR DESCRIPTION
**Issue**: 
When a player disconnects, a death sound is played.

**Fix**: 
Check if a player is disconnecting and don't play any sound.