### PR TITLE
[HL2MP] Prevent deleting vital entities

### DIFF
--- a/src/game/server/baseentity.cpp
+++ b/src/game/server/baseentity.cpp
@@ -5705,6 +5705,20 @@ void CC_Ent_Remove( const CCommand& args )
 {
 	CBaseEntity *pEntity = NULL;
 
+	CBasePlayer *pPlayer = UTIL_GetCommandClient();
+	if ( pPlayer )
+	{
+		if ( !Q_stricmp( args[ 1 ], "player" ) || 
+			!Q_stricmp( args[ 1 ], "worldspawn" ) || 
+			!Q_stricmp( args[ 1 ], "info_player_deathmatch" ) || 
+			!Q_stricmp( args[ 1 ], "info_player_rebel" ) 
+			|| !Q_stricmp( args[ 1 ], "info_player_combine" ) )
+		{
+			ClientPrint( pPlayer, HUD_PRINTCONSOLE, "This entity cannot be removed\n" );
+			return;
+		}
+	}
+
 	// If no name was given set bits based on the picked
 	if ( FStrEq( args[1],"") ) 
 	{
@@ -5753,6 +5767,20 @@ void CC_Ent_RemoveAll( const CCommand& args )
 	}
 	else 
 	{
+		CBasePlayer *pPlayer = UTIL_GetCommandClient();
+		if ( pPlayer )
+		{
+			if ( !Q_stricmp( args[ 1 ], "player" ) ||
+				!Q_stricmp( args[ 1 ], "worldspawn" ) ||
+				!Q_stricmp( args[ 1 ], "info_player_deathmatch" ) ||
+				!Q_stricmp( args[ 1 ], "info_player_rebel" )
+				|| !Q_stricmp( args[ 1 ], "info_player_combine" ) )
+			{
+				ClientPrint( pPlayer, HUD_PRINTCONSOLE, "This entity cannot be removed\n" );
+				return;
+			}
+		}
+
 		// Otherwise remove based on name or classname
 		int iCount = 0;
 		CBaseEntity *ent = NULL;

--- a/src/game/server/hl2mp/hl2mp_player.cpp
+++ b/src/game/server/hl2mp/hl2mp_player.cpp
@@ -22,6 +22,7 @@
 #include "gamestats.h"
 #include "ammodef.h"
 #include "NextBot.h"
+#include "subs.h"
 
 #include "engine/IEngineSound.h"
 #include "SoundEmitterSystem/isoundemittersystembase.h"
@@ -43,8 +44,8 @@ void DropPrimedFragGrenade( CHL2MP_Player *pPlayer, CBaseCombatWeapon *pGrenade 
 
 LINK_ENTITY_TO_CLASS( player, CHL2MP_Player );
 
-LINK_ENTITY_TO_CLASS( info_player_combine, CPointEntity );
-LINK_ENTITY_TO_CLASS( info_player_rebel, CPointEntity );
+LINK_ENTITY_TO_CLASS( info_player_combine, CBaseTeamSpawn );
+LINK_ENTITY_TO_CLASS( info_player_rebel, CBaseTeamSpawn );
 
 // specific to the local player
 BEGIN_SEND_TABLE_NOBASE( CHL2MP_Player, DT_HL2MPLocalPlayerExclusive )

--- a/src/game/server/server_base.vpc
+++ b/src/game/server/server_base.vpc
@@ -621,6 +621,7 @@ $Project
 		$File	"$SRCDIR\public\stringregistry.h"
 		$File	"$SRCDIR\game\shared\studio_shared.cpp"
 		$File	"subs.cpp"
+		$File	"subs.h"
 		$File	"sun.cpp"
 		$File	"tactical_mission.cpp"
 		$File	"tactical_mission.h"

--- a/src/game/server/subs.cpp
+++ b/src/game/server/subs.cpp
@@ -10,6 +10,7 @@
 #include "doors.h"
 #include "entitylist.h"
 #include "globals.h"
+#include "subs.h"
 
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"
@@ -38,19 +39,6 @@ void CNullEntity::Spawn( void )
 }
 LINK_ENTITY_TO_CLASS(info_null,CNullEntity);
 
-class CBaseDMStart : public CPointEntity
-{
-public:
-	DECLARE_CLASS( CBaseDMStart, CPointEntity );
-
-	bool IsTriggered( CBaseEntity *pEntity );
-
-	DECLARE_DATADESC();
-
-	string_t m_Master;
-
-private:
-};
 
 BEGIN_DATADESC( CBaseDMStart )
 

--- a/src/game/server/subs.h
+++ b/src/game/server/subs.h
@@ -1,0 +1,24 @@
+#include "cbase.h"
+
+class CBaseDMStart : public CPointEntity
+{
+public:
+	DECLARE_CLASS( CBaseDMStart, CPointEntity );
+
+	bool IsTriggered( CBaseEntity *pEntity );
+
+	DECLARE_DATADESC();
+
+	string_t m_Master;
+
+private:
+};
+
+// Peter: I don't see a reason why this could not use CBaseDMStart, 
+// but as a precaution because team spawn points were set to use CPointEntity, 
+// I will create a class for this.
+class CBaseTeamSpawn : public CPointEntity
+{
+public:
+	DECLARE_CLASS( CBaseTeamSpawn, CPointEntity );
+};


### PR DESCRIPTION
**Issue**: 
Deleting certain entities crashes the game. Obviously, deleting `worldspawn` is a bad idea for example.

**Fix**: 
Prevent deleting vital entities responsible for running the game properly.