### PR TITLE
[HL2MP] Do not run debug commands on dedicated servers

### DIFF
--- a/src/game/server/util.cpp
+++ b/src/game/server/util.cpp
@@ -3003,6 +3003,9 @@ static ConCommand kdtree_test( "kdtree_test", CC_KDTreeTest, "Tests spatial part
 
 void CC_VoxelTreeView( void )
 {
+	if ( g_pGameRules->IsDeathmatch() )
+		return;
+
 	Msg( "VoxelTreeView\n" );
 	::partition->RenderAllObjectsInTree( 10.0f );
 }
@@ -3012,8 +3015,17 @@ static ConCommand voxeltree_view( "voxeltree_view", CC_VoxelTreeView, "View enti
 void CC_VoxelTreePlayerView( void )
 {
 	Msg( "VoxelTreePlayerView\n" );
+	CBasePlayer *pPlayer = NULL;
 
-	CBasePlayer *pPlayer = static_cast<CBasePlayer*>( UTIL_GetLocalPlayer() );
+#ifdef HL2MP
+	pPlayer = UTIL_GetListenServerHost();
+#else
+	pPlayer = static_cast<CBasePlayer*>( UTIL_GetLocalPlayer() );
+#endif
+
+	if ( !pPlayer || engine->IsDedicatedServer() )
+		return;
+
 	Vector vecStart = pPlayer->GetAbsOrigin();
 	::partition->RenderObjectsInPlayerLeafs( vecStart - VEC_HULL_MIN_SCALED( pPlayer ), vecStart + VEC_HULL_MAX_SCALED( pPlayer ), 3.0f  );
 }


### PR DESCRIPTION
**Issue**: 
Some debug commands that work in singleplayer will just crash the game in multiplayer.

**Fix**: 
Prevent most debug commands that are known to crash the game from being used in MP or refactor them if they can be used on a listen server.