### PR TITLE
[HL2MP] Death fall black screen removal

### DIFF
--- a/src/game/server/movehelper_server.cpp
+++ b/src/game/server/movehelper_server.cpp
@@ -390,16 +390,6 @@ bool CMoveHelperServer::PlayerFallingDamage( void )
 
     }
 
-	if ( m_pHostPlayer->m_iHealth <= 0 )
-	{
-		if ( g_pGameRules->FlPlayerFallDeathDoesScreenFade( m_pHostPlayer ) )
-		{
-			color32 black = {0, 0, 0, 255};
-			UTIL_ScreenFade( m_pHostPlayer, black, 0, 9999, FFADE_OUT | FFADE_STAYOUT );
-		}
-		return(false);
-	}
-
 	return(true);
 }
 

--- a/src/game/shared/gamerules.h
+++ b/src/game/shared/gamerules.h
@@ -283,7 +283,7 @@ public:
 	virtual bool ShouldUseRobustRadiusDamage(CBaseEntity *pEntity) { return false; }
 	virtual void  RadiusDamage( const CTakeDamageInfo &info, const Vector &vecSrc, float flRadius, int iClassIgnore, CBaseEntity *pEntityIgnore );
 	// Let the game rules specify if fall death should fade screen to black
-	virtual bool  FlPlayerFallDeathDoesScreenFade( CBasePlayer *pl ) { return TRUE; }
+	virtual bool  FlPlayerFallDeathDoesScreenFade( CBasePlayer *pl ) { return FALSE; }
 
 	virtual bool AllowDamage( CBaseEntity *pVictim, const CTakeDamageInfo &info ) = 0;
 


### PR DESCRIPTION
**Issue**: 
When a player die by fall damage, the screen becomes black.

**Fix**: 
Remove the black fade, because it is unnecessary.