### PR TITLE
[HL2MP] Fix ear ringing being stuck

### DIFF
--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -1462,6 +1462,7 @@ void CBasePlayer::OnDamagedByExplosion( const CTakeDamageInfo &info )
 
 	CSingleUserRecipientFilter user( this );
 	enginesound->SetPlayerDSP( user, effect, false );
+	iDamageTime = gpGlobals->curtime;
 }
 
 //=========================================================

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -838,6 +838,7 @@ private:
 
 	int					DetermineSimulationTicks( void );
 	void				AdjustPlayerTimeBase( int simulation_ticks );
+	int					iDamageTime;
 
 public:
 	

--- a/src/game/server/player_command.cpp
+++ b/src/game/server/player_command.cpp
@@ -13,6 +13,7 @@
 #include "player_command.h"
 #include "movehelper_server.h"
 #include "iservervehicle.h"
+#include "engine/IEngineSound.h"
 #include "tier0/vprof.h"
 
 // memdbgon must be the last include file in a .cpp file!!!
@@ -299,6 +300,11 @@ void CPlayerMove::RunThink (CBasePlayer *player, double frametime )
 void CPlayerMove::RunPostThink( CBasePlayer *player )
 {
 	VPROF( "CPlayerMove::RunPostThink" );
+
+	CSingleUserRecipientFilter user( player );
+
+	if ( gpGlobals->curtime >= player->iDamageTime + 3 )
+		enginesound->SetPlayerDSP( user, 0, false );
 
 	// Run post-think
 	player->PostThink();


### PR DESCRIPTION
**Issue**: 
In some cases, whenever a player is damaged by explosion, it causes a ringing effect. The problem is that this ringing can become stuck and players must either reconnect or use `snd_restart`.

**Fix**: 
Try to force the DSP to end with a `Think` function if it is stuck.