### PR TITLE
[HL2MP] Crossbow load spark effect fix

### DIFF
--- a/src/game/server/hl2mp/hl2mp_player.cpp
+++ b/src/game/server/hl2mp/hl2mp_player.cpp
@@ -1012,7 +1012,7 @@ bool CHL2MP_Player::HandleCommand_JoinTeam( int team )
 {
 	if ( !GetGlobalTeam( team ) || team == 0 )
 	{
-		ClientPrint( this, HUD_PRINTCONSOLE, "Please enter a valid team index\n" );
+		Warning( "HandleCommand_JoinTeam( %d ) - invalid team index.\n", team );
 		return false;
 	}
 
@@ -1064,6 +1064,11 @@ bool CHL2MP_Player::ClientCommand( const CCommand &args )
 	}
 	else if ( FStrEq( args[0], "jointeam" ) ) 
 	{
+		if ( args.ArgC() < 2 )
+		{
+			Warning( "Player sent bad jointeam syntax\n" );
+		}
+
 		if ( ShouldRunRateLimitedCommand( args ) )
 		{
 			int iTeam = atoi( args[1] );

--- a/src/game/server/hl2mp/hl2mp_player.cpp
+++ b/src/game/server/hl2mp/hl2mp_player.cpp
@@ -1012,7 +1012,7 @@ bool CHL2MP_Player::HandleCommand_JoinTeam( int team )
 {
 	if ( !GetGlobalTeam( team ) || team == 0 )
 	{
-		Warning( "HandleCommand_JoinTeam( %d ) - invalid team index.\n", team );
+		ClientPrint( this, HUD_PRINTCONSOLE, "Please enter a valid team index\n" );
 		return false;
 	}
 
@@ -1064,11 +1064,6 @@ bool CHL2MP_Player::ClientCommand( const CCommand &args )
 	}
 	else if ( FStrEq( args[0], "jointeam" ) ) 
 	{
-		if ( args.ArgC() < 2 )
-		{
-			Warning( "Player sent bad jointeam syntax\n" );
-		}
-
 		if ( ShouldRunRateLimitedCommand( args ) )
 		{
 			int iTeam = atoi( args[1] );

--- a/src/game/shared/hl2mp/weapon_crossbow.cpp
+++ b/src/game/shared/hl2mp/weapon_crossbow.cpp
@@ -813,6 +813,7 @@ void CWeaponCrossbow::DoLoadEffect( void )
 #else
 	data.m_nEntIndex = pViewModel->entindex();
 #endif
+	data.m_vOrigin = GetAbsOrigin();
 	data.m_nAttachmentIndex = 1;
 
 	DispatchEffect( "CrossbowLoad", data );


### PR DESCRIPTION
**Issue**: 
When the crossbow is being reloaded, whenever the bolt is attached, it is missing its spark effect.

**Fix**: 
Add it back with `data.m_vOrigin = GetAbsOrigin();`.