### PR TITLE
[HL2MP] Fix hot bolt issue

### DIFF
--- a/src/game/shared/hl2mp/weapon_crossbow.cpp
+++ b/src/game/shared/hl2mp/weapon_crossbow.cpp
@@ -303,7 +303,7 @@ void CCrossbowBolt::BoltTouch( CBaseEntity *pOther )
 			else
 			{
 				SetThink( &CCrossbowBolt::SUB_Remove );
-				SetNextThink( gpGlobals->curtime + 2.0f );
+				SetNextThink( gpGlobals->curtime );
 				
 				//FIXME: We actually want to stick (with hierarchy) to what we've hit
 				SetMoveType( MOVETYPE_NONE );
@@ -326,7 +326,7 @@ void CCrossbowBolt::BoltTouch( CBaseEntity *pOther )
 				AddEffects( EF_NODRAW );
 				SetTouch( NULL );
 				SetThink( &CCrossbowBolt::SUB_Remove );
-				SetNextThink( gpGlobals->curtime + 2.0f );
+				SetNextThink( gpGlobals->curtime );
 
 				if ( m_pGlowSprite != NULL )
 				{


### PR DESCRIPTION
**Issue**: 
When player 1 shoots a bolt that gets stuck in the world, player 2 can jump onto player 1's bolt in the 2-second window the bolt has ended its course and transfer its speed to the player, causing players to fly at insane speeds. You can't do it with your own bolts, though, but it is possible to make this happen.

**Fix**: 
Immediately prevent players from jumping onto recently landed bolts instead of waiting 2 seconds.