### PR TITLE
[HL2MP] Clear actions when switching teams

### DIFF
--- a/src/game/client/hud_basechat.cpp
+++ b/src/game/client/hud_basechat.cpp
@@ -1391,7 +1391,7 @@ Color CBaseHudChat::GetClientColor( int clientIndex )
 	}
 	else if( g_PR )
 	{
-		return g_ColorGrey;
+		return g_ColorYellow;
 	}
 
 	return g_ColorYellow;

--- a/src/game/server/hl2mp/hl2mp_player.cpp
+++ b/src/game/server/hl2mp/hl2mp_player.cpp
@@ -984,6 +984,16 @@ void CHL2MP_Player::ChangeTeam( int iTeam )
 
 	BaseClass::ChangeTeam( iTeam );
 
+	ClearZoomOwner();
+	DetonateTripmines();
+	ClearUseEntity();
+
+	if ( FlashlightIsOn() )
+		FlashlightTurnOff();
+
+	if ( IsInAVehicle() )
+		LeaveVehicle();
+
 	m_flNextTeamChangeTime = gpGlobals->curtime + TEAM_CHANGE_INTERVAL;
 
 	if ( HL2MPRules()->IsTeamplay() == true )
@@ -1289,11 +1299,10 @@ void CHL2MP_Player::DetonateTripmines( void )
 		if (pSatchel->m_bIsLive && pSatchel->GetThrower() == this )
 		{
 			g_EventQueue.AddEvent( pSatchel, "Explode", 0.20, this, this );
+			// Play sound for pressing the detonator if a satchel is live
+			EmitSound( "Weapon_SLAM.SatchelDetonate" );
 		}
 	}
-
-	// Play sound for pressing the detonator
-	EmitSound( "Weapon_SLAM.SatchelDetonate" );
 }
 
 void CHL2MP_Player::Event_Killed( const CTakeDamageInfo &info )


### PR DESCRIPTION
**Issue**: 
When switching to spectators, some actions are not cleared.

**Fix**: 
Properly unzoom, detonate tripmines, turn off flashlight, and exit vehicle when applicable.