### PR TITLE
[HL2MP] Use bitflags for filters

### DIFF
--- a/src/game/server/filters.cpp
+++ b/src/game/server/filters.cpp
@@ -372,7 +372,7 @@ protected:
 
 	bool PassesDamageFilterImpl(const CTakeDamageInfo &info)
 	{
-	 	return info.GetDamageType() == m_iDamageType;
+		return ( ( info.GetDamageType() & m_iDamageType ) == m_iDamageType );
 	}
 
 	int m_iDamageType;


### PR DESCRIPTION
Original fix authored by Tony Sergi [here](https://github.com/ValveSoftware/source-sdk-2013/commit/2cea82d834a04207ac585cfd4864ae07292bfd30).

**Issue**: 
Bitflags weren't being managed properly because of missing or incorrect bitwise operations. This led to unexpected behavior when trying to set, check, or combine multiple flags. Improper flag management could result in unintended logic execution or failure to deliver the desired functionality.

**Fix**: 
Implemented the right bitwise operations to accurately set, check, and handle bitflags. This allows multiple flags to work together as they should, without causing any conflicts, resulting in more reliable and consistent behavior.