### PR TITLE
[HL2MP] Fix signed integer issue in BitForBitnum function

### DIFF
--- a/src/tier1/bitbuf.cpp
+++ b/src/tier1/bitbuf.cpp
@@ -63,7 +63,7 @@ inline unsigned int CountTrailingZeros(unsigned int elem)
 
 static BitBufErrorHandler g_BitBufErrorHandler = 0;
 
-inline int BitForBitnum(int bitnum)
+inline unsigned int BitForBitnum(int bitnum)
 {
 	return GetBitForBitnum(bitnum);
 }


### PR DESCRIPTION
**Issue**: 
If we use signed integers, we end up holding negative numbers and this leads to certain number of issues, like incorrect handling of large values, as the sign bit may be interpreted incorrectly, causing wrong results.

**Fix**: 
Therefore, we switch `BitForBitnum` to return an unsigned int instead of int to stop negative values from being returned and allow shifting above 31 bits.