### PR TITLE
[HL2MP] Improve PointAngleSensor accuracy for player entities

### DIFF
--- a/src/game/server/pointanglesensor.cpp
+++ b/src/game/server/pointanglesensor.cpp
@@ -216,7 +216,14 @@ void CPointAngleSensor::Think(void)
 	if (m_hTargetEntity != NULL)
 	{
 		Vector forward;
-		m_hTargetEntity->GetVectors(&forward, NULL, NULL);
+		if ( dynamic_cast< CBasePlayer * >( m_hTargetEntity.Get() ) != NULL )
+		{
+			dynamic_cast< CBasePlayer * >( m_hTargetEntity.Get() )->EyeVectors( &forward, NULL, NULL );
+		}
+		else
+		{
+			m_hTargetEntity->GetVectors( &forward, NULL, NULL );
+		}
 		m_TargetDir.Set(forward, this, this);
 
 		if (m_hLookAtEntity != NULL)


### PR DESCRIPTION
**Issue**:  
The `CPointAngleSensor` used to depend on the target entity's general forward vector, which doesn't always match up with a player's true view direction. This could lead to misalignment in systems that require precise player viewing angles, like sensors, tracking systems, or targeting mechanisms, especially when the target is a player.

**Fix**:  
To better manage player entities, we add a check for `CBasePlayer`. Now, if the target is a player, it fetches the player's `EyeVectors()` instead of the usual `GetVectors()`. This ensures that the angle sensor aligns accurately with the player's actual line of sight. If the target isn't a player, it reverts to the original `GetVectors()` method.