### PR TITLE
[HL2MP] Fix orbs not flying when a player disconnects

### DIFF
--- a/src/game/server/gameinterface.cpp
+++ b/src/game/server/gameinterface.cpp
@@ -2766,6 +2766,7 @@ void CServerGameClients::ClientDisconnect( edict_t *pEdict )
 	CBasePlayer *player = ( CBasePlayer * )CBaseEntity::Instance( pEdict );
 	if ( player )
 	{
+		player->ForceDropOfCarriedPhysObjects( NULL );
 		if ( !g_fGameOver )
 		{
 			player->SetMaxSpeed( 0.0f );


### PR DESCRIPTION
**Issue**:
If a player disconnects while they were holding an orb in with their physcannon, the orb ends up levitating in the air. It eventually dissolves, though.

**Fix**:
Free the orb and let it bounce freely.