### PR TITLE
[HL2MP] Try to stop orbs getting stuck on items

### DIFF
--- a/src/game/server/hl2/prop_combine_ball.cpp
+++ b/src/game/server/hl2/prop_combine_ball.cpp
@@ -1566,6 +1566,18 @@ void CPropCombineBall::VPhysicsCollision( int index, gamevcollisionevent_t *pEve
 {
 	Vector preVelocity = pEvent->preVelocity[index];
 	float flSpeed = VectorNormalize( preVelocity );
+	CBaseEntity *pHitEntity = pEvent->pEntities[ !index ];
+
+	if ( FClassnameIs( pHitEntity, "npc_satchel" ) || // don't slow down on satchel charges
+		FClassnameIs( pHitEntity, "npc_grenade_frag" ) || // not on frag grenades either
+		StringHasPrefix( pHitEntity->GetClassname(), "weapon_" ) || // much less on weapons
+		StringHasPrefix( pHitEntity->GetClassname(), "item_" ) ) // the same for items
+	{
+		Vector vecBounceVelocity = -preVelocity;
+		vecBounceVelocity *= GetSpeed();
+		PhysCallbackSetVelocity( pEvent->pObjects[ index ], vecBounceVelocity );
+		return;
+	}
 
 	if ( m_nMaxBounces == -1 )
 	{
@@ -1573,7 +1585,7 @@ void CPropCombineBall::VPhysicsCollision( int index, gamevcollisionevent_t *pEve
 
 		if( pHit->game.material != CHAR_TEX_FLESH || !hl2_episodic.GetBool() )
 		{
-			CBaseEntity *pHitEntity = pEvent->pEntities[!index];
+			
 			if ( pHitEntity && IsHittableEntity( pHitEntity ) )
 			{
 				OnHitEntity( pHitEntity, flSpeed, index, pEvent );
@@ -1610,7 +1622,6 @@ void CPropCombineBall::VPhysicsCollision( int index, gamevcollisionevent_t *pEve
 	vecFinalVelocity *= GetSpeed();
 	PhysCallbackSetVelocity( pEvent->pObjects[index], vecFinalVelocity ); 
 
-	CBaseEntity *pHitEntity = pEvent->pEntities[!index];
 	if ( pHitEntity && IsHittableEntity( pHitEntity ) )
 	{
 		OnHitEntity( pHitEntity, flSpeed, index, pEvent );


### PR DESCRIPTION
**Issue**:
When orbs collide with weapons and items, they sometimes get stuck and stop moving until they are freed, either by themselves or by being grabbed/punted.

**Fix**:
Try to detect when orbs collide with those entities and prevent them from being stuck by re-applying their previous speed.