### PR TITLE
[HL2MP] Fix held orb external influence

### DIFF
--- a/src/game/server/hl2/prop_combine_ball.cpp
+++ b/src/game/server/hl2/prop_combine_ball.cpp
@@ -769,6 +769,12 @@ void CPropCombineBall::SetBallAsLaunched( void )
 	WhizSoundThink();
 }
 
+bool CPropCombineBall::OnAttemptPhysGunPickup( CBasePlayer *pPhysGunUser, PhysGunPickup_t reason )
+{
+	return ( !m_bHeld || pPhysGunUser == GetOwnerEntity() ?
+		CDefaultPlayerPickupVPhysics::OnAttemptPhysGunPickup( pPhysGunUser, reason ) : false );
+}
+
 //-----------------------------------------------------------------------------
 // Lighten the mass so it's zippy toget to the gun
 //-----------------------------------------------------------------------------

--- a/src/game/server/hl2/prop_combine_ball.h
+++ b/src/game/server/hl2/prop_combine_ball.h
@@ -117,6 +117,7 @@ public:
 
 private:
 
+	bool OnAttemptPhysGunPickup( CBasePlayer *, PhysGunPickup_t ) OVERRIDE;
 	void SetPlayerLaunched( CBasePlayer *pOwner );
 
 	float GetBallHoldDissolveTime();


### PR DESCRIPTION
**Issue**:
When a player holds an orb in the physcannon, other players can punt the orb and influence its ownership, causing the previous owner i.e. the one who is holding the orb to be disintegrated in some situations.

**Fix**:
Prevent any external influence from modifying how the held orb behaves until it is let go.