### PR TITLE
[HL2MP] Attempt to stop rendering AR2 bullet impacts in the sky

### DIFF
--- a/src/game/shared/hl2mp/weapon_ar2.cpp
+++ b/src/game/shared/hl2mp/weapon_ar2.cpp
@@ -166,6 +166,9 @@ void CWeaponAR2::DoImpactEffect( trace_t &tr, int nDamageType )
 	data.m_vOrigin = tr.endpos + ( tr.plane.normal * 1.0f );
 	data.m_vNormal = tr.plane.normal;
 
+	if ( tr.fraction != 1.0 && ( ( tr.surface.flags & SURF_SKY ) || ( tr.surface.flags & SURF_NODRAW ) ) )
+		return;
+
 	DispatchEffect( "AR2Impact", data );
 
 	BaseClass::DoImpactEffect( tr, nDamageType );


### PR DESCRIPTION
**Issue**:  
Even though it's a small issue, the AR2 bullets show visible impacts when they hit the sky or nodraw textured surfaces.

**Fix**:  
Just avoid rendering any bullet impacts on those textures.