### PR TITLE
[HL2MP] Prevent AR2 alt-fire mishaps

### DIFF
--- a/src/game/shared/hl2mp/weapon_ar2.cpp
+++ b/src/game/shared/hl2mp/weapon_ar2.cpp
@@ -268,7 +268,7 @@ void CWeaponAR2::SecondaryAttack( void )
 // Purpose: Override if we're waiting to release a shot
 // Output : Returns true on success, false on failure.
 //-----------------------------------------------------------------------------
-bool CWeaponAR2::CanHolster( void )
+bool CWeaponAR2::CanHolster( void ) const
 {
 	if ( m_bShotDelayed )
 		return false;

--- a/src/game/shared/hl2mp/weapon_ar2.h
+++ b/src/game/shared/hl2mp/weapon_ar2.h
@@ -45,7 +45,7 @@ public:
 	int		GetMaxBurst( void ) { return 5; }
 	float	GetFireRate( void ) { return 0.1f; }
 
-	bool	CanHolster( void );
+	bool	CanHolster( void ) const;
 	bool	Reload( void );
 
 	Activity	GetPrimaryAttackActivity( void );


### PR DESCRIPTION
**Issue**:  
While charging an orb using a secondary attack, players may unintentionally or deliberately cancel the charge by changing weapons.

**Fix**:  
Restrict weapon switching while an orb is being charged.