### PR TITLE
[HL2MP] Pass CBasePlayer in PreferredCarryAngles

### DIFF
--- a/src/game/server/physobj.h
+++ b/src/game/server/physobj.h
@@ -67,7 +67,11 @@ public:
 	virtual void OnPhysGunDrop( CBasePlayer *pPhysGunUser, PhysGunDrop_t Reason );
 
 	bool		 HasPreferredCarryAnglesForPlayer( CBasePlayer *pPlayer );
+#ifdef HL2MP
+	virtual QAngle PreferredCarryAngles( CBasePlayer *pPlayer ) { return m_angPreferredCarryAngles; }
+#else
 	virtual QAngle PreferredCarryAngles( void ) { return m_angPreferredCarryAngles; }
+#endif
 
 	// inputs
 	void InputWake( inputdata_t &inputdata );


### PR DESCRIPTION
**Issue**:
The function `PreferredCarryAngles` doesn't pass any arguments. It's not really an issue when we think about it, but we can improve this.

**Fix**:
Pass `CBasePlayer *pPlayer` for `PreferredCarryAngles`. The reason for passing `CBasePlayer*` instead of void in `PreferredCarryAngles` is to allow different carry angles based on the player interacting with the object.