### PR TITLE
[HL2MP] Check for physics validation when using the physcannon

### DIFF
--- a/src/game/shared/hl2mp/weapon_physcannon.cpp
+++ b/src/game/shared/hl2mp/weapon_physcannon.cpp
@@ -792,6 +792,13 @@ void CPlayerPickupController::Use( CBaseEntity *pActivator, CBaseEntity *pCaller
 		
 		//Adrian: Oops, our object became motion disabled, let go!
 		IPhysicsObject *pPhys = pAttached->VPhysicsGetObject();
+
+		if ( !pPhys )
+		{
+			Shutdown();
+			return;
+		}
+
 		if ( pPhys && pPhys->IsMoveable() == false )
 		{
 			Shutdown();
@@ -808,7 +815,7 @@ void CPlayerPickupController::Use( CBaseEntity *pActivator, CBaseEntity *pCaller
 		}
 #endif
 		// +ATTACK will throw phys objects
-		if ( m_pPlayer->m_nButtons & IN_ATTACK )
+		if ( pPhys && m_pPlayer->m_nButtons & IN_ATTACK )
 		{
 			Shutdown( true );
 			Vector vecLaunch;


### PR DESCRIPTION
**Issue**:  
When you use the physcannon and the physics object you're holding gets motion-disabled, it might not let go of the object. Plus, there's no proper verification to see if a physics object is present before trying to perform actions like throwing it with the primary attack.

**Fix**:  
- Added a check to make sure that if a physics object becomes motion-disabled, the physcannon will release it right away.  
- Added a validation for `pPhys`. Once that's confirmed, we can proceed with the usual logic for the primary attack check.