### PR TITLE
[HL2MP] Add view kick for melee weapons

### DIFF
--- a/src/game/shared/hl2mp/weapon_hl2mpbasebasebludgeon.cpp
+++ b/src/game/shared/hl2mp/weapon_hl2mpbasebasebludgeon.cpp
@@ -135,7 +135,7 @@ void CBaseHL2MPBludgeonWeapon::Hit( trace_t &traceHit, Activity nHitActivity )
 	CBasePlayer *pPlayer = ToBasePlayer( GetOwner() );
 	
 	//Do view kick
-//	AddViewKick();
+	AddViewKick();
 
 	CBaseEntity	*pHitEntity = traceHit.m_pEnt;
 

--- a/src/game/shared/hl2mp/weapon_stunstick.cpp
+++ b/src/game/shared/hl2mp/weapon_stunstick.cpp
@@ -77,7 +77,7 @@ public:
 
 	float		GetRange( void )		{ return STUNSTICK_RANGE; }
 	float		GetFireRate( void )		{ return STUNSTICK_REFIRE; }
-
+	void		AddViewKick( void ); // should be client-side, much like the crowbar
 
 	bool		Deploy( void );
 	bool		Holster( CBaseCombatWeapon *pSwitchingTo = NULL );
@@ -244,9 +244,21 @@ void CWeaponStunStick::ImpactEffect( trace_t &traceHit )
 	UTIL_ImpactTrace( &traceHit, DMG_CLUB );
 }
 
+
+void CWeaponStunStick::AddViewKick( void )
+{
+	CBasePlayer *pPlayer = ToBasePlayer( GetOwner() );
+
+	if ( pPlayer == NULL )
+		return;
+
+	QAngle punchAng;
+	punchAng.x = SharedRandomFloat( "crowbarpax", 1.0f, 2.0f );
+	punchAng.y = SharedRandomFloat( "crowbarpay", -2.0f, -1.0f );
+	punchAng.z = 0.0f;
+	pPlayer->ViewPunch( punchAng );
+}
 #ifndef CLIENT_DLL
-
-
 int CWeaponStunStick::WeaponMeleeAttack1Condition( float flDot, float flDist )
 {
 	// Attempt to lead the target (needed because citizens can't hit manhacks with the crowbar!)


### PR DESCRIPTION
**Issue**:
None of the melee has view kick. The screen therefore remains static while the attack is performed.

**Fix**:
Apply the `AddViewKick()` function to the crowbar and the stunstick.