### PR TITLE
[HL2MP] Adjust melee hit trace

### DIFF
--- a/src/game/server/basecombatcharacter.cpp
+++ b/src/game/server/basecombatcharacter.cpp
@@ -1139,6 +1139,9 @@ bool CTraceFilterMelee::ShouldHitEntity( IHandleEntity *pHandleEntity, int conte
 		if ( pEntity->m_takedamage == DAMAGE_NO )
 			return false;
 
+		if ( m_pPassEnt && !pEntity->CanBeHitByMeleeAttack( const_cast< CBaseEntity * >( EntityFromEntityHandle( m_pPassEnt ) ) ) )
+			return false;
+
 		// FIXME: Do not translate this to the driver because the driver only accepts damage from the vehicle
 		// Translate the vehicle into its driver for damage
 		/*
@@ -1182,7 +1185,8 @@ bool CTraceFilterMelee::ShouldHitEntity( IHandleEntity *pHandleEntity, int conte
 		}
 		else
 		{
-			m_pHit = pEntity;
+			if ( !m_pHit )
+				m_pHit = pEntity;
 
 			// Make sure if the player is holding this, he drops it
 			Pickup_ForcePlayerToDropThisObject( pEntity );


### PR DESCRIPTION
**Issue**:  
Melee attacks weren't filtering out entities that shouldn't take damage, which leads to situations where melee hits affected immune entities. Additionally, passive entities (like props) weren't getting the right melee damage when neither the attacker nor the victim was a combat character.

**Fix**:  
We added a check to see if an entity can actually be hit by a melee attack before dealing damage, which stops melee strikes from hitting the wrong targets. Now, if neither the attacker nor the victim is a combat character (like NPCs), melee damage is correctly applied to passive entities such as props, making melee interactions with objects in the game more reliable.