### PR TITLE
[HL2MP] MP gravity gun carried objects fix

### DIFF
--- a/src/game/server/baseentity.cpp
+++ b/src/game/server/baseentity.cpp
@@ -1833,7 +1833,27 @@ int CBaseEntity::VPhysicsTakeDamage( const CTakeDamageInfo &info )
 		if ( gameFlags & FVPHYSICS_PLAYER_HELD )
 		{
 			// if the player is holding the object, use it's real mass (player holding reduced the mass)
-			CBasePlayer *pPlayer = UTIL_GetLocalPlayer();
+			CBasePlayer *pPlayer = NULL;
+
+			if ( gpGlobals->maxClients == 1 )
+			{
+				pPlayer = UTIL_GetLocalPlayer();
+			}
+			else
+			{
+				// See which MP player is holding the physics object and then use that player to get the real mass of the object.
+				// This is ugly but better than having linkage between an object and its "holding" player.
+				for ( int i = 1; i <= gpGlobals->maxClients; i++ )
+				{
+					CBasePlayer *tempPlayer = UTIL_PlayerByIndex( i );
+
+					if ( tempPlayer && ( tempPlayer->GetHeldObject() == this ) )
+					{
+						pPlayer = tempPlayer;
+						break;
+					}
+				}
+			}
 			if ( pPlayer )
 			{
 				float mass = pPlayer->GetHeldObjectMass( VPhysicsGetObject() );

--- a/src/game/server/hl2/hl2_player.cpp
+++ b/src/game/server/hl2/hl2_player.cpp
@@ -3189,6 +3189,11 @@ float CHL2_Player::GetHeldObjectMass( IPhysicsObject *pHeldObject )
 	return mass;
 }
 
+CBaseEntity *CHL2_Player::GetHeldObject( void )
+{
+	return PhysCannonGetHeldEntity( GetActiveWeapon() );
+}
+
 //-----------------------------------------------------------------------------
 // Purpose: Force the player to drop any physics objects he's carrying
 //-----------------------------------------------------------------------------

--- a/src/game/server/hl2/hl2_player.h
+++ b/src/game/server/hl2/hl2_player.h
@@ -242,6 +242,7 @@ public:
 	virtual	bool		IsHoldingEntity( CBaseEntity *pEnt );
 	virtual void		ForceDropOfCarriedPhysObjects( CBaseEntity *pOnlyIfHoldindThis );
 	virtual float		GetHeldObjectMass( IPhysicsObject *pHeldObject );
+	virtual CBaseEntity *GetHeldObject( void );
 
 	virtual bool		IsFollowingPhysics( void ) { return (m_afPhysicsFlags & PFLAG_ONBARNACLE) > 0; }
 	void				InputForceDropPhysObjects( inputdata_t &data );

--- a/src/game/server/physics_impact_damage.cpp
+++ b/src/game/server/physics_impact_damage.cpp
@@ -333,16 +333,32 @@ float CalculatePhysicsImpactDamage( int index, gamevcollisionevent_t *pEvent, co
 
 	float otherMass = pEvent->pObjects[otherIndex]->GetMass();
 
-	if ( pEvent->pObjects[otherIndex]->GetGameFlags() & FVPHYSICS_PLAYER_HELD )
+	if ( pEvent->pObjects[ otherIndex ]->GetGameFlags() & FVPHYSICS_PLAYER_HELD )
 	{
+		// if the player is holding the object, use its real mass (player holding reduced the mass)
+
+		CBasePlayer *pPlayer = NULL;
 		if ( gpGlobals->maxClients == 1 )
 		{
-			// if the player is holding the object, use it's real mass (player holding reduced the mass)
-			CBasePlayer *pPlayer = UTIL_GetLocalPlayer();
-			if ( pPlayer )
+			pPlayer = UTIL_GetLocalPlayer();
+		}
+		else
+		{
+			// See which MP player is holding the physics object and then use that player to get the real mass of the object.
+			// This is ugly but better than having linkage between an object and its "holding" player.
+			for ( int i = 1; i <= gpGlobals->maxClients; i++ )
 			{
-				otherMass = pPlayer->GetHeldObjectMass( pEvent->pObjects[otherIndex] );
+				CBasePlayer *tempPlayer = UTIL_PlayerByIndex( i );
+				if ( tempPlayer && pEvent->pEntities[ index ] == tempPlayer->GetHeldObject() )
+				{
+					pPlayer = tempPlayer;
+					break;
+				}
 			}
+		}
+		if ( pPlayer )
+		{
+			otherMass = pPlayer->GetHeldObjectMass( pEvent->pObjects[ otherIndex ] );
 		}
 	}
 
@@ -436,19 +452,34 @@ float CalculatePhysicsImpactDamage( int index, gamevcollisionevent_t *pEvent, co
 		// prop, so recompute:
 		invMass = 1.0f / pEvent->pObjects[index]->GetMass();
 	}
-	else if ( pEvent->pObjects[index]->GetGameFlags() & FVPHYSICS_PLAYER_HELD )
+	else if ( pEvent->pObjects[ index ]->GetGameFlags() & FVPHYSICS_PLAYER_HELD )
 	{
+		// if the player is holding the object, use it's real mass (player holding reduced the mass)
+		CBasePlayer *pPlayer = NULL;
 		if ( gpGlobals->maxClients == 1 )
 		{
-			// if the player is holding the object, use it's real mass (player holding reduced the mass)
-			CBasePlayer *pPlayer = UTIL_GetLocalPlayer();
-			if ( pPlayer )
+			pPlayer = UTIL_GetLocalPlayer();
+		}
+		else
+		{
+			// See which MP player is holding the physics object and then use that player to get the real mass of the object.
+			// This is ugly but better than having linkage between an object and its "holding" player.
+			for ( int i = 1; i <= gpGlobals->maxClients; i++ )
 			{
-				float mass = pPlayer->GetHeldObjectMass( pEvent->pObjects[index] );
-				if ( mass > 0 )
+				CBasePlayer *tempPlayer = UTIL_PlayerByIndex( i );
+				if ( tempPlayer && pEvent->pEntities[ index ] == tempPlayer->GetHeldObject() )
 				{
-					invMass = 1.0f / mass;
+					pPlayer = tempPlayer;
+					break;
 				}
+			}
+		}
+		if ( pPlayer )
+		{
+			float mass = pPlayer->GetHeldObjectMass( pEvent->pObjects[ index ] );
+			if ( mass > 0 )
+			{
+				invMass = 1.0f / mass;
 			}
 		}
 	}

--- a/src/game/server/physobj.h
+++ b/src/game/server/physobj.h
@@ -87,6 +87,7 @@ protected:
 	float			m_flForceToEnableMotion;
 	QAngle			m_angPreferredCarryAngles;
 	bool			m_bNotSolidToWorld;
+	CBasePlayer		*m_pLastHolder = nullptr;
 
 	// Outputs
 	COutputEvent	m_OnDamaged;

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -2890,6 +2890,10 @@ float CBasePlayer::GetHeldObjectMass( IPhysicsObject *pHeldObject )
 	return 0;
 }
 
+CBaseEntity *CBasePlayer::GetHeldObject( void )
+{
+	return NULL;
+}
 
 //-----------------------------------------------------------------------------
 // Purpose:	Server side of jumping rules.  Most jumping logic is already

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -568,6 +568,7 @@ public:
 	virtual void			PickupObject( CBaseEntity *pObject, bool bLimitMassAndSize = true ) {}
 	virtual void			ForceDropOfCarriedPhysObjects( CBaseEntity *pOnlyIfHoldindThis = NULL ) {}
 	virtual float			GetHeldObjectMass( IPhysicsObject *pHeldObject );
+	virtual CBaseEntity		*GetHeldObject( void );
 
 	void					CheckSuitUpdate();
 	void					SetSuitUpdate(const char *name, int fgroup, int iNoRepeat);

--- a/src/game/server/props.h
+++ b/src/game/server/props.h
@@ -405,6 +405,7 @@ private:
 
 protected:
 	CNetworkVar( bool, m_bAwake );
+	CBasePlayer *m_pLastHolder = nullptr;
 };
 
 


### PR DESCRIPTION
Original fix applied by Tony Sergi [here](https://github.com/ValveSoftware/source-sdk-2013/commit/7e8c33446a38bfe5b1b0bbc3e72d8c04ad696e19).

Original commit comment:

> Fix MP Gravity Gun carried objects
> This is a fix that myself and Mike Durand had applied to the 2007 SDK,
> that overcomes the UTIL_GetLocalPlayer (single player only) calls for
> physgun carried objects in multiplayer.
> This allows Gravity Gun thrown objects to have their physics mass
> calculated correctly in multiplayer.

**Issue**:
In multiplayer mode, the physcannon was not calculating the physics mass of objects that were carried or thrown properly. This was due to the reliance on `UTIL_GetLocalPlayer()`, which only works well in single-player scenarios. As a result, items tossed in multiplayer can behave in unexpected ways.

**Fix**:
Replace `UTIL_GetLocalPlayer()` with a method that’s compatible with multiplayer. This change makes sure that the physics mass of objects thrown with the physcannon is calculated properly. Now, when you use the physcannon in multiplayer, the objects you carry will act as expected, resulting in smooth and dependable interactions.