### PR TITLE
[HL2MP] Fix infinite stack loop on "angle" entity KeyValue

### DIFF
--- a/src/game/shared/baseentity_shared.cpp
+++ b/src/game/shared/baseentity_shared.cpp
@@ -408,7 +408,7 @@ bool CBaseEntity::KeyValue( const char *szKeyName, const char *szValue )
 		}
 
 		// Do this so inherited classes looking for 'angles' don't have to bother with 'angle'
-		return KeyValue( szKeyName, szBuf );
+		return KeyValue( "angles", szBuf );
 	}
 
 	// NOTE: Have to do these separate because they set two values instead of one


### PR DESCRIPTION
**Issue**:
When attempting to set the angle keyvalue on an entity, there is a risk of encountering an endless stack loop.

**Fix**:
The update ensures that the angle keyvalue is assigned properly, preventing any unintended recursion. By modifying the method of processing the keyvalue, this fix eliminates the infinite loop and ensures that angles are assigned securely, thus avoiding any stack overflow issues.