### PR TITLE
[HL2MP] Fix item respawns

### DIFF
--- a/src/game/server/item_world.cpp
+++ b/src/game/server/item_world.cpp
@@ -307,8 +307,11 @@ void CItem::FallThink ( void )
 	{
 		SetThink ( NULL );
 
-		m_vOriginalSpawnOrigin = GetAbsOrigin();
-		m_vOriginalSpawnAngles = GetAbsAngles();
+		if ( GetOriginalSpawnOrigin() == vec3_origin )
+		{
+			m_vOriginalSpawnOrigin = GetAbsOrigin();
+			m_vOriginalSpawnAngles = GetAbsAngles();
+		}
 
 		HL2MPRules()->AddLevelDesignerPlacedObject( this );
 	}


### PR DESCRIPTION
**Issue**: 
Items may not spawn at their right location in some situations.

**Fix**:
Ensure items properly respawn at a proper location (duh) by adding a check to ensure that if an item’s original spawn origin is `vec3_origin` i.e., uninitialized or invalid, it is properly set to the current position and angles of the entity.