### PR TITLE
[HL2MP] Fix ammo crate exploit

### DIFF
--- a/src/game/server/hl2/item_ammo.cpp
+++ b/src/game/server/hl2/item_ammo.cpp
@@ -877,12 +877,15 @@ void CItem_AmmoCrate::Use( CBaseEntity *pActivator, CBaseEntity *pCaller, USE_TY
 	if ( pPlayer == NULL )
 		return;
 
+	if ( !pPlayer->IsAlive() )
+		return;
+
 	m_OnUsed.FireOutput( pActivator, this );
 
 	int iSequence = LookupSequence( "Open" );
 
 	// See if we're not opening already
-	if ( GetSequence() != iSequence )
+	if ( GetSequence() != iSequence && pPlayer->IsAlive() )
 	{
 		Vector mins, maxs;
 		trace_t tr;
@@ -929,7 +932,9 @@ int CItem_AmmoCrate::OnTakeDamage( const CTakeDamageInfo &info )
 	{
 		CBaseCombatWeapon *weapon = player->GetActiveWeapon();
 
-		if (weapon && !stricmp(weapon->GetName(), "weapon_crowbar"))
+		if ( weapon && ( ( !stricmp( weapon->GetName(), "weapon_crowbar" ) // Is my weapon a crowbar?
+			|| !stricmp( weapon->GetName(), "weapon_stunstick" ) ) ) // Or a stunstick?
+			&& info.GetDamageType() & DMG_CLUB ) // Have I damaged the crate with either weapon?
 		{
 			// play the normal use sound
 			player->EmitSound( "HL2Player.Use" );

--- a/src/game/server/hl2/item_ammo.cpp
+++ b/src/game/server/hl2/item_ammo.cpp
@@ -11,6 +11,7 @@
 #include "ammodef.h"
 #include "eventlist.h"
 #include "npcevent.h"
+#include "weapon_hl2mpbasebasebludgeon.h"
 
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"
@@ -885,7 +886,7 @@ void CItem_AmmoCrate::Use( CBaseEntity *pActivator, CBaseEntity *pCaller, USE_TY
 	int iSequence = LookupSequence( "Open" );
 
 	// See if we're not opening already
-	if ( GetSequence() != iSequence && pPlayer->IsAlive() )
+	if ( GetSequence() != iSequence )
 	{
 		Vector mins, maxs;
 		trace_t tr;
@@ -928,18 +929,18 @@ int CItem_AmmoCrate::OnTakeDamage( const CTakeDamageInfo &info )
 {
 	// if it's the player hitting us with a crowbar, open up
 	CBasePlayer *player = ToBasePlayer(info.GetAttacker());
-	if (player)
+	if ( player )
 	{
 		CBaseCombatWeapon *weapon = player->GetActiveWeapon();
 
-		if ( weapon && ( ( !stricmp( weapon->GetName(), "weapon_crowbar" ) // Is my weapon a crowbar?
-			|| !stricmp( weapon->GetName(), "weapon_stunstick" ) ) ) // Or a stunstick?
-			&& info.GetDamageType() & DMG_CLUB ) // Have I damaged the crate with either weapon?
+		if ( weapon && dynamic_cast< CBaseHL2MPBludgeonWeapon * >( weapon ) )
 		{
-			// play the normal use sound
-			player->EmitSound( "HL2Player.Use" );
-			// open the crate
-			Use(info.GetAttacker(), info.GetAttacker(), USE_TOGGLE, 0.0f);
+			if ( info.GetDamageType() & DMG_CLUB )
+			{
+				// Play the normal use sound
+				player->EmitSound( "HL2Player.Use" );
+				Use( info.GetAttacker(), info.GetAttacker(), USE_TOGGLE, 0.0f );
+			}
 		}
 	}
 


### PR DESCRIPTION
**Issue**:  
If a player tosses a grenade or any explosive at an `item_ammo_crate` and then switch to a crowbar before the explosion happens, the crate will open up, giving ammo to the player who triggered it, thus creating an unfair advantage. Plus, only the crowbar can open these crates, which means the stunstick can’t do anything with them.

**Fix**:  
Implemented a check to ensure that damage is only registered from a crowbar and have also made the stunstick capable of opening this type of crate.