### PR TITLE
[HL2MP] Fix hud_showtargetid doing nothing

### DIFF
--- a/src/game/client/hl2mp/c_hl2mp_player.cpp
+++ b/src/game/client/hl2mp/c_hl2mp_player.cpp
@@ -135,6 +135,12 @@ void C_HL2MP_Player::UpdateIDTarget()
 	if ( !IsLocalPlayer() )
 		return;
 
+	if ( !hud_showtargetid.GetBool() )
+	{
+		m_iIDEntIndex = 0;
+		return;
+	}
+
 	// Clear old target and find a new one
 	m_iIDEntIndex = 0;
 

--- a/src/game/client/hl2mp/c_hl2mp_player.h
+++ b/src/game/client/hl2mp/c_hl2mp_player.h
@@ -14,6 +14,8 @@ class C_HL2MP_Player;
 #include "hl2mp_player_shared.h"
 #include "beamdraw.h"
 
+extern ConVar hud_showtargetid;
+
 //=============================================================================
 //=============================================================================
 class CSuitPowerDevice

--- a/src/game/client/hl2mp/hl2mp_hud_target_id.cpp
+++ b/src/game/client/hl2mp/hl2mp_hud_target_id.cpp
@@ -21,7 +21,7 @@
 #define PLAYER_HINT_DISTANCE_SQ	(PLAYER_HINT_DISTANCE*PLAYER_HINT_DISTANCE)
 
 static ConVar hud_centerid( "hud_centerid", "1" );
-static ConVar hud_showtargetid( "hud_showtargetid", "1" );
+ConVar hud_showtargetid( "hud_showtargetid", "1" );
 
 //-----------------------------------------------------------------------------
 // Purpose: 


### PR DESCRIPTION
**Issue**:
The client console ConVar `hud_showtargetid` does... absolutely nothing. It is declared but never referenced elsewhere in the code, meaning that setting it to 0 has no effect on hiding the target ID when aiming at a player.

**Fix**:
Implement the missing functionality by checking the value of `hud_showtargetid` and conditionally displaying or hiding the HUD target ID when the player aims at another player.