### PR TITLE
[HL2MP] Fixed roll grenade sound missing

### DIFF
--- a/src/game/shared/hl2mp/weapon_frag.cpp
+++ b/src/game/shared/hl2mp/weapon_frag.cpp
@@ -546,6 +546,7 @@ void CWeaponFrag::RollGrenade( CBasePlayer *pPlayer )
 
 #endif
 
+	CDisablePredictionFiltering disablePred;
 	WeaponSound( SPECIAL1 );
 
 	// player "shoot" animation


### PR DESCRIPTION
**Issue**:
The frag grenade doesn't use its rolling sound when using the secondary attack.

**Fix**:
Suppress prediction to restore this missing sound.