### PR TITLE
[HL2MP] Fix grenade ownership

### DIFF
--- a/src/game/server/hl2/grenade_frag.cpp
+++ b/src/game/server/hl2/grenade_frag.cpp
@@ -298,14 +298,31 @@ void CGrenadeFrag::SetTimer( float detonateDelay, float warnDelay )
 	CreateEffects();
 }
 
+
 void CGrenadeFrag::OnPhysGunPickup( CBasePlayer *pPhysGunUser, PhysGunPickup_t reason )
 {
+	IPhysicsObject *pPhysicsObject = VPhysicsGetObject();
+
+	if ( pPhysicsObject && ( pPhysicsObject->GetGameFlags() & FVPHYSICS_PLAYER_HELD ) )
+	{
+		CBasePlayer *pCurrentOwner = ToBasePlayer( GetOwnerEntity() );
+		if ( pCurrentOwner && pCurrentOwner != pPhysGunUser )
+		{
+#ifdef HL2MP
+			SetTimer( FRAG_GRENADE_GRACE_TIME_AFTER_PICKUP, FRAG_GRENADE_GRACE_TIME_AFTER_PICKUP / 2 );
+			m_flNextBlipTime = gpGlobals->curtime + FRAG_GRENADE_BLIP_FAST_FREQUENCY;
+			m_bHasWarnedAI = true;
+#endif
+			return;
+		}
+	}
+
+	// If not being held, set the new owner
 	SetThrower( pPhysGunUser );
 
 #ifdef HL2MP
-	SetTimer( FRAG_GRENADE_GRACE_TIME_AFTER_PICKUP, FRAG_GRENADE_GRACE_TIME_AFTER_PICKUP / 2);
-
-	BlipSound();
+	SetTimer( FRAG_GRENADE_GRACE_TIME_AFTER_PICKUP, FRAG_GRENADE_GRACE_TIME_AFTER_PICKUP / 2 );
+	// BlipSound();
 	m_flNextBlipTime = gpGlobals->curtime + FRAG_GRENADE_BLIP_FAST_FREQUENCY;
 	m_bHasWarnedAI = true;
 #else


### PR DESCRIPTION
**Issue**
When player 1 holds a frag grenade in their physcannon and player 2 punts the frag grenade that player 1 is still holding, it resets the grenade's timer and switches the ownership to player 2.

**Fix**:
Prevent ownership from ever being transferred for as long as a player is holding a frag grenade with their physcannon and prevent any other player from ever punting the frag grenade of another player.