### PR TITLE
[HL2MP] Implement flashlight cooldown to prevent spamming on/off

### DIFF
--- a/src/game/server/hl2mp/hl2mp_player.cpp
+++ b/src/game/server/hl2mp/hl2mp_player.cpp
@@ -1228,6 +1228,11 @@ extern ConVar flashlight;
 //-----------------------------------------------------------------------------
 void CHL2MP_Player::FlashlightTurnOn( void )
 {
+	if ( IsFlashlightInCooldown() )
+		return;
+
+	SetFlashlightCooldownTime( gpGlobals->curtime + 0.25f );
+
 	if( flashlight.GetInt() > 0 && IsAlive() )
 	{
 		AddEffects( EF_DIMLIGHT );

--- a/src/game/server/hl2mp/hl2mp_player.h
+++ b/src/game/server/hl2mp/hl2mp_player.h
@@ -145,6 +145,9 @@ public:
 	bool IsThreatFiringAtMe( CBaseEntity* threat ) const;
 private:
 
+	void SetFlashlightCooldownTime( float FlashlightTime ) { m_flFlashlightCooldown = FlashlightTime; }
+	bool IsFlashlightInCooldown() const { return gpGlobals->curtime < m_flFlashlightCooldown; }
+
 	CNetworkQAngle( m_angEyeAngles );
 	CPlayerAnimState   m_PlayerAnimState;
 
@@ -168,6 +171,8 @@ private:
 
     bool m_bEnterObserver;
 	bool m_bReady;
+
+	float m_flFlashlightCooldown; // To prevent flashlight on/off spam.
 };
 
 inline CHL2MP_Player *ToHL2MPPlayer( CBaseEntity *pEntity )


### PR DESCRIPTION
**Issue**:
Some players find it funny to bind their flashlight key to mouse wheel and spam the flashlight to annoy everyone else.

**Fix**:
Apply a 0.25 second cooldown to the flashlight.