### PR TITLE
[HL2MP] Fix a prediction bug when dying while holding a prop

### DIFF
--- a/src/game/shared/hl2mp/weapon_physcannon.cpp
+++ b/src/game/shared/hl2mp/weapon_physcannon.cpp
@@ -1128,7 +1128,7 @@ void CWeaponPhysCannon::Drop( const Vector &vecVelocity )
 	ForceDrop();
 
 #ifndef CLIENT_DLL
-	UTIL_Remove( this );
+	Delete();
 #endif
 }
 


### PR DESCRIPTION
**Issue**:
When dying while holding a prop, said prop remains predicted and is not cleared, which causes a mismatch between the server and the client i.e. the prop will be seen by the client in one place and the server will see it in another, which causes the prop to be impossible to pick up again unless both sync up again, either by using the fix below, issuing `cl_fullupdate` or reconnecting.

**Fix**:
Use `Delete();` instead of `UTIL_Remove( this );`.