### PR TITLE
[HL2MP] Stop flames on player death

### DIFF
--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -2137,7 +2137,7 @@ void CBasePlayer::PlayerDeathThink(void)
 	}
 	
 	StopAnimation();
-
+	Extinguish();
 	IncrementInterpolationFrame();
 	m_flPlaybackRate = 0.0;
 	


### PR DESCRIPTION
**Issue**:
When a player dies while burning, the fire will not extinguish.

**Fix**:
Extinguish fire on player death.