### PR TITLE
[TF] Move replay definitions from Base Source VPCs to Mod VPCs

### DIFF
--- a/src/game/client/client_base.vpc
+++ b/src/game/client/client_base.vpc
@@ -15,7 +15,6 @@ $MacroRequired "GAMENAME"
 
 $Include "$SRCDIR\vpc_scripts\source_dll_base.vpc"
 $include "$SRCDIR\vpc_scripts\protobuf_builder.vpc"
-$Include "$SRCDIR\vpc_scripts\source_replay.vpc"	[$TF]
 $Include "$SRCDIR\game\protobuf_include.vpc"
 
 $Configuration	"Debug"
@@ -57,7 +56,6 @@ $Configuration
 		$PreprocessorDefinitions		"$BASE;NO_STRING_T;CLIENT_DLL;VECTOR;VERSION_SAFE_STEAM_API_INTERFACES;PROTECTED_THINGS_ENABLE;strncpy=use_Q_strncpy_instead;_snprintf=use_Q_snprintf_instead" 
 		$PreprocessorDefinitions		"$BASE;INCLUDED_STEAM2_USERID_STRUCTS" 
 		$PreprocessorDefinitions		"$BASE;fopen=dont_use_fopen" [$WIN32]
-		$PreprocessorDefinitions		"$BASE;USE_WEBM_FOR_REPLAY;" [$LINUXALL]
 		$Create/UsePrecompiledHeader	"Use Precompiled Header (/Yu)"
 		$Create/UsePCHThroughFile		"cbase.h"
 		$PrecompiledHeaderFile			"$(IntDir)/client.pch"
@@ -74,108 +72,11 @@ $Configuration
 		$SystemLibraries				"rt;z" [$LINUXALL]
 		$IgnoreImportLibrary			"TRUE"
 		$AdditionalDependencies			"$BASE winmm.lib"	[$WINDOWS]
-		$AdditionalDependencies			"$BASE wsock32.lib Ws2_32.lib" [$BUILD_REPLAY&&$WINDOWS]
 	}
 }
 
 $Project
-{
-	$Folder "Replay"
-	{
-		$File	"replay/replaycamera.cpp"
-		$File	"replay/replaycamera.h"
-		$File	"replay/cdll_replay.cpp"
-		$File	"replay/cdll_replay.h"
-		
-		$File	"replay/gamedefs.h"	[$BUILD_REPLAY]
-		$File	"replay/gamedefs.cpp"	[$BUILD_REPLAY]
-		$File	"replay/replay_ragdoll.cpp"	[$BUILD_REPLAY]
-		$File	"replay/replay_ragdoll.h"	[$BUILD_REPLAY]
-		$File	"replay/replay_screenshot.cpp"	[$BUILD_REPLAY]
-		$File	"replay/replay_screenshot.h"	[$BUILD_REPLAY]
-		$File	"replay/replayperformanceplaybackhandler.h"	[$BUILD_REPLAY]
-		$File	"replay/replayperformanceplaybackhandler.cpp"	[$BUILD_REPLAY]
-		$File	"replay/replayrenderer.cpp"	[$BUILD_REPLAY]
-		$File	"replay/replayrenderer.h"	[$BUILD_REPLAY]
-		$File	"replay/replayvideo.cpp"	[$BUILD_REPLAY]
-		$File	"replay/replayvideo.h"	[$BUILD_REPLAY]
-		
-		$File	"replay/genericclassbased_replay.cpp"	[$BUILD_REPLAY]
-		$File	"replay/genericclassbased_replay.h"	[$BUILD_REPLAY]
-		
-		$File	"$SRCDIR\game\shared\replay_gamestats_shared.cpp"	[$BUILD_REPLAY]
-		$File	"$SRCDIR\game\shared\replay_gamestats_shared.h"	[$BUILD_REPLAY]
-		
-		$File	"$SRCDIR\game\client\youtubeapi.h"	[$BUILD_REPLAY]
-		$File	"$SRCDIR\game\client\youtubeapi.cpp"	[$BUILD_REPLAY]
-		{
-			$Configuration
-			{
-				$Compiler
-				{
-					$Create/UsePrecompiledHeader	"Not Using Precompiled Headers"
-				}
-			}
-		}
-		
-		$Folder "UI"	[$BUILD_REPLAY]
-		{
-			$File	"replay\vgui\replaybrowserbasepage.cpp"
-			$File	"replay\vgui\replaybrowserbasepage.h"
-			$File	"replay\vgui\replaybrowserbasepanel.cpp"
-			$File	"replay\vgui\replaybrowserbasepanel.h"
-			$File	"replay\vgui\replayconfirmquitdlg.cpp"
-			$File	"replay\vgui\replayconfirmquitdlg.h"
-			$File	"replay\vgui\replaybrowserdetailspanel.cpp"
-			$File	"replay\vgui\replaybrowserdetailspanel.h"
-			$File	"replay\vgui\replaybrowseritemmanager.cpp"
-			$File	"replay\vgui\replaybrowseritemmanager.h"
-			$File	"replay\vgui\replaybrowserlistitempanel.cpp"
-			$File	"replay\vgui\replaybrowserlistitempanel.h"
-			$File	"replay\vgui\replaybrowserlistpanel.cpp"
-			$File	"replay\vgui\replaybrowserlistpanel.h"
-			$File	"replay\vgui\replaybrowsermainpanel.cpp"
-			$File	"replay\vgui\replaybrowsermainpanel.h"
-			$File	"replay\vgui\replaybrowsermovieplayerpanel.cpp"
-			$File	"replay\vgui\replaybrowsermovieplayerpanel.h"
-			$File	"replay\vgui\replaybrowserpreviewpanel.cpp"
-			$File	"replay\vgui\replaybrowserpreviewpanel.h"
-			$File	"replay\vgui\replaybrowserrenderdialog.cpp"
-			$File	"replay\vgui\replaybrowserrenderdialog.h"
-			$File	"replay\vgui\replayinputpanel.cpp"
-			$File	"replay\vgui\replayinputpanel.h"
-			$File	"replay\vgui\replaymessagepanel.cpp"
-			$File	"replay\vgui\replaymessagepanel.h"
-			$File	"replay\vgui\replayperformanceeditor.cpp"
-			$File	"replay\vgui\replayperformanceeditor.h"
-			$File	"replay\vgui\replayperformancesavedlg.cpp"
-			$File	"replay\vgui\replayperformancesavedlg.h"
-			$File	"replay\vgui\replayrenderoverlay.cpp"
-			$File	"replay\vgui\replayrenderoverlay.h"
-			$File	"replay\vgui\replayreminderpanel.cpp"
-			$File	"replay\vgui\replayreminderpanel.h"
-			$File	"replay\replayyoutubeapi.cpp"
-			$File	"replay\replayyoutubeapi.h"
-			$File	"replay\replayyoutubeapi_key.cpp" [!$SOURCESDK]
-			$File	"replay\replayyoutubeapi_key_sdk.cpp" [$SOURCESDK]
-			
-			$File	"game_controls\slideshowpanel.cpp"
-			$File	"game_controls\slideshowpanel.h"
-			
-			$File	"$SRCDIR\common\movieobjects\timeutils.cpp"
-			{
-				$Configuration
-				{
-					$Compiler
-					{
-						$Create/UsePrecompiledHeader	"Not Using Precompiled Headers"
-					}
-				}
-			}
-			$File	"$SRCDIR\public\movieobjects\timeutils.h"
-		}
-	}
-		
+{	
 	$Folder	"Source Files"
 	{
 		$File	"hl2\C_Func_Monitor.cpp"

--- a/src/game/client/client_replay_base.vpc
+++ b/src/game/client/client_replay_base.vpc
@@ -1,0 +1,119 @@
+//-----------------------------------------------------------------------------
+//	CLIENT_REPLAY_BASE.VPC
+//
+//	Project Base Script
+//-----------------------------------------------------------------------------
+
+$Include "$SRCDIR\vpc_scripts\source_replay.vpc"
+
+$Configuration
+{
+	$Compiler
+	{
+        $PreprocessorDefinitions		"$BASE;USE_WEBM_FOR_REPLAY" [$LINUXALL]
+	}
+    
+    $Linker
+	{
+        $AdditionalDependencies			"$BASE wsock32.lib Ws2_32.lib" [$BUILD_REPLAY&&$WINDOWS]
+	}
+}
+
+$Project
+{
+    $Folder "Replay"
+	{
+		$File	"replay/replaycamera.cpp"
+		$File	"replay/replaycamera.h"
+		$File	"replay/cdll_replay.cpp"
+		$File	"replay/cdll_replay.h"
+		
+		$File	"replay/gamedefs.h"	[$BUILD_REPLAY]
+		$File	"replay/gamedefs.cpp"	[$BUILD_REPLAY]
+		$File	"replay/replay_ragdoll.cpp"	[$BUILD_REPLAY]
+		$File	"replay/replay_ragdoll.h"	[$BUILD_REPLAY]
+		$File	"replay/replay_screenshot.cpp"	[$BUILD_REPLAY]
+		$File	"replay/replay_screenshot.h"	[$BUILD_REPLAY]
+		$File	"replay/replayperformanceplaybackhandler.h"	[$BUILD_REPLAY]
+		$File	"replay/replayperformanceplaybackhandler.cpp"	[$BUILD_REPLAY]
+		$File	"replay/replayrenderer.cpp"	[$BUILD_REPLAY]
+		$File	"replay/replayrenderer.h"	[$BUILD_REPLAY]
+		$File	"replay/replayvideo.cpp"	[$BUILD_REPLAY]
+		$File	"replay/replayvideo.h"	[$BUILD_REPLAY]
+		
+		$File	"replay/genericclassbased_replay.cpp"	[$BUILD_REPLAY]
+		$File	"replay/genericclassbased_replay.h"	[$BUILD_REPLAY]
+		
+		$File	"$SRCDIR\game\shared\replay_gamestats_shared.cpp"	[$BUILD_REPLAY]
+		$File	"$SRCDIR\game\shared\replay_gamestats_shared.h"	[$BUILD_REPLAY]
+		
+		$File	"$SRCDIR\game\client\youtubeapi.h"	[$BUILD_REPLAY]
+		$File	"$SRCDIR\game\client\youtubeapi.cpp"	[$BUILD_REPLAY]
+		{
+			$Configuration
+			{
+				$Compiler
+				{
+					$Create/UsePrecompiledHeader	"Not Using Precompiled Headers"
+				}
+			}
+		}
+		
+		$Folder "UI"	[$BUILD_REPLAY]
+		{
+			$File	"replay\vgui\replaybrowserbasepage.cpp"
+			$File	"replay\vgui\replaybrowserbasepage.h"
+			$File	"replay\vgui\replaybrowserbasepanel.cpp"
+			$File	"replay\vgui\replaybrowserbasepanel.h"
+			$File	"replay\vgui\replayconfirmquitdlg.cpp"
+			$File	"replay\vgui\replayconfirmquitdlg.h"
+			$File	"replay\vgui\replaybrowserdetailspanel.cpp"
+			$File	"replay\vgui\replaybrowserdetailspanel.h"
+			$File	"replay\vgui\replaybrowseritemmanager.cpp"
+			$File	"replay\vgui\replaybrowseritemmanager.h"
+			$File	"replay\vgui\replaybrowserlistitempanel.cpp"
+			$File	"replay\vgui\replaybrowserlistitempanel.h"
+			$File	"replay\vgui\replaybrowserlistpanel.cpp"
+			$File	"replay\vgui\replaybrowserlistpanel.h"
+			$File	"replay\vgui\replaybrowsermainpanel.cpp"
+			$File	"replay\vgui\replaybrowsermainpanel.h"
+			$File	"replay\vgui\replaybrowsermovieplayerpanel.cpp"
+			$File	"replay\vgui\replaybrowsermovieplayerpanel.h"
+			$File	"replay\vgui\replaybrowserpreviewpanel.cpp"
+			$File	"replay\vgui\replaybrowserpreviewpanel.h"
+			$File	"replay\vgui\replaybrowserrenderdialog.cpp"
+			$File	"replay\vgui\replaybrowserrenderdialog.h"
+			$File	"replay\vgui\replayinputpanel.cpp"
+			$File	"replay\vgui\replayinputpanel.h"
+			$File	"replay\vgui\replaymessagepanel.cpp"
+			$File	"replay\vgui\replaymessagepanel.h"
+			$File	"replay\vgui\replayperformanceeditor.cpp"
+			$File	"replay\vgui\replayperformanceeditor.h"
+			$File	"replay\vgui\replayperformancesavedlg.cpp"
+			$File	"replay\vgui\replayperformancesavedlg.h"
+			$File	"replay\vgui\replayrenderoverlay.cpp"
+			$File	"replay\vgui\replayrenderoverlay.h"
+			$File	"replay\vgui\replayreminderpanel.cpp"
+			$File	"replay\vgui\replayreminderpanel.h"
+			$File	"replay\replayyoutubeapi.cpp"
+			$File	"replay\replayyoutubeapi.h"
+			$File	"replay\replayyoutubeapi_key.cpp" [!$SOURCESDK]
+			$File	"replay\replayyoutubeapi_key_sdk.cpp" [$SOURCESDK]
+			
+			$File	"game_controls\slideshowpanel.cpp"
+			$File	"game_controls\slideshowpanel.h"
+			
+			$File	"$SRCDIR\common\movieobjects\timeutils.cpp"
+			{
+				$Configuration
+				{
+					$Compiler
+					{
+						$Create/UsePrecompiledHeader	"Not Using Precompiled Headers"
+					}
+				}
+			}
+			$File	"$SRCDIR\public\movieobjects\timeutils.h"
+		}
+	}
+}

--- a/src/game/client/client_tf.vpc
+++ b/src/game/client/client_tf.vpc
@@ -12,6 +12,7 @@ $Macro GAMENAME 	"mod_tf" [$SOURCESDK]
 $Conditional WORKSHOP_IMPORT_ENABLE	1 [$WINDOWS && !$SOURCESDK]
 
 $Include "$SRCDIR\game\client\client_base.vpc"
+$Include "$SRCDIR\vpc_scripts\source_replay.vpc"
 $include "$SRCDIR\game\shared\tf\tf_gcmessages_include.vpc"
 $include "$SRCDIR\game\shared\tf\tf_proto_def_messages_include.vpc"
 $Include "$SRCDIR\game\client\client_econ_base.vpc"
@@ -26,13 +27,115 @@ $Configuration
 		$PreprocessorDefinitions		"$BASE;TF_CLIENT_DLL;USES_ECON_ITEMS;ENABLE_GC_MATCHMAKING;GLOWS_ENABLE;USE_DYNAMIC_ASSET_LOADING;VOTING_ENABLED;NEXT_BOT"
 		$PreprocessorDefinitions		"$BASE;SAXXYMAINMENU_ENABLED" [$SAXXYAWARDS_ENABLE]
 		$PreprocessorDefinitions		"$BASE;WORKSHOP_IMPORT_ENABLED" [$WORKSHOP_IMPORT_ENABLE]
+        $PreprocessorDefinitions		"$BASE;USE_WEBM_FOR_REPLAY" [$LINUXALL]
 		$PreprocessorDefinitions		"$BASE;SIXENSE" [!$SOURCESDK]
 		$PreprocessorDefinitions		"$BASE;DISABLE_GC_CONNECTION;DISABLE_IN_SOURCESDK;INVENTORY_VIA_WEBAPI" [$SOURCESDK]
+	}
+    
+    $Linker
+	{
+        $AdditionalDependencies			"$BASE wsock32.lib Ws2_32.lib" [$BUILD_REPLAY&&$WINDOWS]
 	}
 }
 
 $Project "Client (TF)"
 {
+	$Folder "Replay"
+	{
+		$File	"replay/replaycamera.cpp"
+		$File	"replay/replaycamera.h"
+		$File	"replay/cdll_replay.cpp"
+		$File	"replay/cdll_replay.h"
+		
+		$File	"replay/gamedefs.h"	[$BUILD_REPLAY]
+		$File	"replay/gamedefs.cpp"	[$BUILD_REPLAY]
+		$File	"replay/replay_ragdoll.cpp"	[$BUILD_REPLAY]
+		$File	"replay/replay_ragdoll.h"	[$BUILD_REPLAY]
+		$File	"replay/replay_screenshot.cpp"	[$BUILD_REPLAY]
+		$File	"replay/replay_screenshot.h"	[$BUILD_REPLAY]
+		$File	"replay/replayperformanceplaybackhandler.h"	[$BUILD_REPLAY]
+		$File	"replay/replayperformanceplaybackhandler.cpp"	[$BUILD_REPLAY]
+		$File	"replay/replayrenderer.cpp"	[$BUILD_REPLAY]
+		$File	"replay/replayrenderer.h"	[$BUILD_REPLAY]
+		$File	"replay/replayvideo.cpp"	[$BUILD_REPLAY]
+		$File	"replay/replayvideo.h"	[$BUILD_REPLAY]
+		
+		$File	"replay/genericclassbased_replay.cpp"	[$BUILD_REPLAY]
+		$File	"replay/genericclassbased_replay.h"	[$BUILD_REPLAY]
+		
+		$File	"$SRCDIR\game\shared\replay_gamestats_shared.cpp"	[$BUILD_REPLAY]
+		$File	"$SRCDIR\game\shared\replay_gamestats_shared.h"	[$BUILD_REPLAY]
+		
+		$File	"$SRCDIR\game\client\youtubeapi.h"	[$BUILD_REPLAY]
+		$File	"$SRCDIR\game\client\youtubeapi.cpp"	[$BUILD_REPLAY]
+		{
+			$Configuration
+			{
+				$Compiler
+				{
+					$Create/UsePrecompiledHeader	"Not Using Precompiled Headers"
+				}
+			}
+		}
+		
+		$Folder "UI"	[$BUILD_REPLAY]
+		{
+			$File	"replay\vgui\replaybrowserbasepage.cpp"
+			$File	"replay\vgui\replaybrowserbasepage.h"
+			$File	"replay\vgui\replaybrowserbasepanel.cpp"
+			$File	"replay\vgui\replaybrowserbasepanel.h"
+			$File	"replay\vgui\replayconfirmquitdlg.cpp"
+			$File	"replay\vgui\replayconfirmquitdlg.h"
+			$File	"replay\vgui\replaybrowserdetailspanel.cpp"
+			$File	"replay\vgui\replaybrowserdetailspanel.h"
+			$File	"replay\vgui\replaybrowseritemmanager.cpp"
+			$File	"replay\vgui\replaybrowseritemmanager.h"
+			$File	"replay\vgui\replaybrowserlistitempanel.cpp"
+			$File	"replay\vgui\replaybrowserlistitempanel.h"
+			$File	"replay\vgui\replaybrowserlistpanel.cpp"
+			$File	"replay\vgui\replaybrowserlistpanel.h"
+			$File	"replay\vgui\replaybrowsermainpanel.cpp"
+			$File	"replay\vgui\replaybrowsermainpanel.h"
+			$File	"replay\vgui\replaybrowsermovieplayerpanel.cpp"
+			$File	"replay\vgui\replaybrowsermovieplayerpanel.h"
+			$File	"replay\vgui\replaybrowserpreviewpanel.cpp"
+			$File	"replay\vgui\replaybrowserpreviewpanel.h"
+			$File	"replay\vgui\replaybrowserrenderdialog.cpp"
+			$File	"replay\vgui\replaybrowserrenderdialog.h"
+			$File	"replay\vgui\replayinputpanel.cpp"
+			$File	"replay\vgui\replayinputpanel.h"
+			$File	"replay\vgui\replaymessagepanel.cpp"
+			$File	"replay\vgui\replaymessagepanel.h"
+			$File	"replay\vgui\replayperformanceeditor.cpp"
+			$File	"replay\vgui\replayperformanceeditor.h"
+			$File	"replay\vgui\replayperformancesavedlg.cpp"
+			$File	"replay\vgui\replayperformancesavedlg.h"
+			$File	"replay\vgui\replayrenderoverlay.cpp"
+			$File	"replay\vgui\replayrenderoverlay.h"
+			$File	"replay\vgui\replayreminderpanel.cpp"
+			$File	"replay\vgui\replayreminderpanel.h"
+			$File	"replay\replayyoutubeapi.cpp"
+			$File	"replay\replayyoutubeapi.h"
+			$File	"replay\replayyoutubeapi_key.cpp" [!$SOURCESDK]
+			$File	"replay\replayyoutubeapi_key_sdk.cpp" [$SOURCESDK]
+			
+			$File	"game_controls\slideshowpanel.cpp"
+			$File	"game_controls\slideshowpanel.h"
+			
+			$File	"$SRCDIR\common\movieobjects\timeutils.cpp"
+			{
+				$Configuration
+				{
+					$Compiler
+					{
+						$Create/UsePrecompiledHeader	"Not Using Precompiled Headers"
+					}
+				}
+			}
+			$File	"$SRCDIR\public\movieobjects\timeutils.h"
+		}
+	}
+
 	$Folder "Source Files"
 	{
 		-$File	"$SRCDIR\game\shared\weapon_parse_default.cpp"

--- a/src/game/client/client_tf.vpc
+++ b/src/game/client/client_tf.vpc
@@ -12,7 +12,7 @@ $Macro GAMENAME 	"mod_tf" [$SOURCESDK]
 $Conditional WORKSHOP_IMPORT_ENABLE	1 [$WINDOWS && !$SOURCESDK]
 
 $Include "$SRCDIR\game\client\client_base.vpc"
-$Include "$SRCDIR\vpc_scripts\source_replay.vpc"
+$Include "$SRCDIR\game\client\client_replay_base.vpc"
 $include "$SRCDIR\game\shared\tf\tf_gcmessages_include.vpc"
 $include "$SRCDIR\game\shared\tf\tf_proto_def_messages_include.vpc"
 $Include "$SRCDIR\game\client\client_econ_base.vpc"
@@ -27,115 +27,13 @@ $Configuration
 		$PreprocessorDefinitions		"$BASE;TF_CLIENT_DLL;USES_ECON_ITEMS;ENABLE_GC_MATCHMAKING;GLOWS_ENABLE;USE_DYNAMIC_ASSET_LOADING;VOTING_ENABLED;NEXT_BOT"
 		$PreprocessorDefinitions		"$BASE;SAXXYMAINMENU_ENABLED" [$SAXXYAWARDS_ENABLE]
 		$PreprocessorDefinitions		"$BASE;WORKSHOP_IMPORT_ENABLED" [$WORKSHOP_IMPORT_ENABLE]
-        $PreprocessorDefinitions		"$BASE;USE_WEBM_FOR_REPLAY" [$LINUXALL]
 		$PreprocessorDefinitions		"$BASE;SIXENSE" [!$SOURCESDK]
 		$PreprocessorDefinitions		"$BASE;DISABLE_GC_CONNECTION;DISABLE_IN_SOURCESDK;INVENTORY_VIA_WEBAPI" [$SOURCESDK]
-	}
-    
-    $Linker
-	{
-        $AdditionalDependencies			"$BASE wsock32.lib Ws2_32.lib" [$BUILD_REPLAY&&$WINDOWS]
 	}
 }
 
 $Project "Client (TF)"
 {
-	$Folder "Replay"
-	{
-		$File	"replay/replaycamera.cpp"
-		$File	"replay/replaycamera.h"
-		$File	"replay/cdll_replay.cpp"
-		$File	"replay/cdll_replay.h"
-		
-		$File	"replay/gamedefs.h"	[$BUILD_REPLAY]
-		$File	"replay/gamedefs.cpp"	[$BUILD_REPLAY]
-		$File	"replay/replay_ragdoll.cpp"	[$BUILD_REPLAY]
-		$File	"replay/replay_ragdoll.h"	[$BUILD_REPLAY]
-		$File	"replay/replay_screenshot.cpp"	[$BUILD_REPLAY]
-		$File	"replay/replay_screenshot.h"	[$BUILD_REPLAY]
-		$File	"replay/replayperformanceplaybackhandler.h"	[$BUILD_REPLAY]
-		$File	"replay/replayperformanceplaybackhandler.cpp"	[$BUILD_REPLAY]
-		$File	"replay/replayrenderer.cpp"	[$BUILD_REPLAY]
-		$File	"replay/replayrenderer.h"	[$BUILD_REPLAY]
-		$File	"replay/replayvideo.cpp"	[$BUILD_REPLAY]
-		$File	"replay/replayvideo.h"	[$BUILD_REPLAY]
-		
-		$File	"replay/genericclassbased_replay.cpp"	[$BUILD_REPLAY]
-		$File	"replay/genericclassbased_replay.h"	[$BUILD_REPLAY]
-		
-		$File	"$SRCDIR\game\shared\replay_gamestats_shared.cpp"	[$BUILD_REPLAY]
-		$File	"$SRCDIR\game\shared\replay_gamestats_shared.h"	[$BUILD_REPLAY]
-		
-		$File	"$SRCDIR\game\client\youtubeapi.h"	[$BUILD_REPLAY]
-		$File	"$SRCDIR\game\client\youtubeapi.cpp"	[$BUILD_REPLAY]
-		{
-			$Configuration
-			{
-				$Compiler
-				{
-					$Create/UsePrecompiledHeader	"Not Using Precompiled Headers"
-				}
-			}
-		}
-		
-		$Folder "UI"	[$BUILD_REPLAY]
-		{
-			$File	"replay\vgui\replaybrowserbasepage.cpp"
-			$File	"replay\vgui\replaybrowserbasepage.h"
-			$File	"replay\vgui\replaybrowserbasepanel.cpp"
-			$File	"replay\vgui\replaybrowserbasepanel.h"
-			$File	"replay\vgui\replayconfirmquitdlg.cpp"
-			$File	"replay\vgui\replayconfirmquitdlg.h"
-			$File	"replay\vgui\replaybrowserdetailspanel.cpp"
-			$File	"replay\vgui\replaybrowserdetailspanel.h"
-			$File	"replay\vgui\replaybrowseritemmanager.cpp"
-			$File	"replay\vgui\replaybrowseritemmanager.h"
-			$File	"replay\vgui\replaybrowserlistitempanel.cpp"
-			$File	"replay\vgui\replaybrowserlistitempanel.h"
-			$File	"replay\vgui\replaybrowserlistpanel.cpp"
-			$File	"replay\vgui\replaybrowserlistpanel.h"
-			$File	"replay\vgui\replaybrowsermainpanel.cpp"
-			$File	"replay\vgui\replaybrowsermainpanel.h"
-			$File	"replay\vgui\replaybrowsermovieplayerpanel.cpp"
-			$File	"replay\vgui\replaybrowsermovieplayerpanel.h"
-			$File	"replay\vgui\replaybrowserpreviewpanel.cpp"
-			$File	"replay\vgui\replaybrowserpreviewpanel.h"
-			$File	"replay\vgui\replaybrowserrenderdialog.cpp"
-			$File	"replay\vgui\replaybrowserrenderdialog.h"
-			$File	"replay\vgui\replayinputpanel.cpp"
-			$File	"replay\vgui\replayinputpanel.h"
-			$File	"replay\vgui\replaymessagepanel.cpp"
-			$File	"replay\vgui\replaymessagepanel.h"
-			$File	"replay\vgui\replayperformanceeditor.cpp"
-			$File	"replay\vgui\replayperformanceeditor.h"
-			$File	"replay\vgui\replayperformancesavedlg.cpp"
-			$File	"replay\vgui\replayperformancesavedlg.h"
-			$File	"replay\vgui\replayrenderoverlay.cpp"
-			$File	"replay\vgui\replayrenderoverlay.h"
-			$File	"replay\vgui\replayreminderpanel.cpp"
-			$File	"replay\vgui\replayreminderpanel.h"
-			$File	"replay\replayyoutubeapi.cpp"
-			$File	"replay\replayyoutubeapi.h"
-			$File	"replay\replayyoutubeapi_key.cpp" [!$SOURCESDK]
-			$File	"replay\replayyoutubeapi_key_sdk.cpp" [$SOURCESDK]
-			
-			$File	"game_controls\slideshowpanel.cpp"
-			$File	"game_controls\slideshowpanel.h"
-			
-			$File	"$SRCDIR\common\movieobjects\timeutils.cpp"
-			{
-				$Configuration
-				{
-					$Compiler
-					{
-						$Create/UsePrecompiledHeader	"Not Using Precompiled Headers"
-					}
-				}
-			}
-			$File	"$SRCDIR\public\movieobjects\timeutils.h"
-		}
-	}
-
 	$Folder "Source Files"
 	{
 		-$File	"$SRCDIR\game\shared\weapon_parse_default.cpp"

--- a/src/game/server/server_base.vpc
+++ b/src/game/server/server_base.vpc
@@ -15,7 +15,6 @@ $MacroRequired "GAMENAME"
 
 $include "$SRCDIR\vpc_scripts\source_dll_base.vpc"
 $include "$SRCDIR\vpc_scripts\protobuf_builder.vpc"
-$Include "$SRCDIR\vpc_scripts\source_replay.vpc"	[$TF]
 $Include "$SRCDIR\game\protobuf_include.vpc"
 
 $Configuration	"Debug"
@@ -83,15 +82,6 @@ $Configuration
 
 $Project
 {
-	$Folder "Replay"
-	{
-		$File	"gamedll_replay.cpp"
-		$File	"$SRCDIR\common\replay\ireplaysessionrecorder.h"
-
-		$File	"$SRCDIR\game\shared\replay_gamestats_shared.cpp"	[$BUILD_REPLAY]
-		$File	"$SRCDIR\game\shared\replay_gamestats_shared.h"	[$BUILD_REPLAY]
-	}
-
 	$Folder	"Source Files"
 	{
 		$File	"$SRCDIR\game\shared\achievement_saverestore.cpp"

--- a/src/game/server/server_replay_base.vpc
+++ b/src/game/server/server_replay_base.vpc
@@ -1,0 +1,19 @@
+//-----------------------------------------------------------------------------
+//	SERVER_REPLAY_BASE.VPC
+//
+//	Project Base Script
+//-----------------------------------------------------------------------------
+
+$Include "$SRCDIR\vpc_scripts\source_replay.vpc"
+
+$Project
+{
+	$Folder "Replay"
+	{
+		$File	"gamedll_replay.cpp"
+		$File	"$SRCDIR\common\replay\ireplaysessionrecorder.h"
+
+		$File	"$SRCDIR\game\shared\replay_gamestats_shared.cpp"	[$BUILD_REPLAY]
+		$File	"$SRCDIR\game\shared\replay_gamestats_shared.h"	[$BUILD_REPLAY]
+	}
+}

--- a/src/game/server/server_tf.vpc
+++ b/src/game/server/server_tf.vpc
@@ -9,6 +9,7 @@ $Macro GAMENAME 	"tf" [!$SOURCESDK]
 $Macro GAMENAME 	"mod_tf" [$SOURCESDK]
 
 $Include "$SRCDIR\game\server\server_base.vpc"
+$Include "$SRCDIR\vpc_scripts\source_replay.vpc"
 $Include "$SRCDIR\game\server\server_econ_base.vpc"
 $include "$SRCDIR\game\shared\tf\tf_gcmessages_include.vpc"
 $include "$SRCDIR\game\shared\tf\tf_proto_def_messages_include.vpc"
@@ -26,6 +27,15 @@ $Configuration
 
 $Project "Server (TF)"
 {
+	$Folder "Replay"
+	{
+		$File	"gamedll_replay.cpp"
+		$File	"$SRCDIR\common\replay\ireplaysessionrecorder.h"
+
+		$File	"$SRCDIR\game\shared\replay_gamestats_shared.cpp"	[$BUILD_REPLAY]
+		$File	"$SRCDIR\game\shared\replay_gamestats_shared.h"	[$BUILD_REPLAY]
+	}
+
 	$Folder	"Source Files"
 	{
 		-$File	"AI_ConCommands.cpp"

--- a/src/game/server/server_tf.vpc
+++ b/src/game/server/server_tf.vpc
@@ -9,7 +9,7 @@ $Macro GAMENAME 	"tf" [!$SOURCESDK]
 $Macro GAMENAME 	"mod_tf" [$SOURCESDK]
 
 $Include "$SRCDIR\game\server\server_base.vpc"
-$Include "$SRCDIR\vpc_scripts\source_replay.vpc"
+$Include "$SRCDIR\game\server\server_replay_base.vpc"
 $Include "$SRCDIR\game\server\server_econ_base.vpc"
 $include "$SRCDIR\game\shared\tf\tf_gcmessages_include.vpc"
 $include "$SRCDIR\game\shared\tf\tf_proto_def_messages_include.vpc"
@@ -27,15 +27,6 @@ $Configuration
 
 $Project "Server (TF)"
 {
-	$Folder "Replay"
-	{
-		$File	"gamedll_replay.cpp"
-		$File	"$SRCDIR\common\replay\ireplaysessionrecorder.h"
-
-		$File	"$SRCDIR\game\shared\replay_gamestats_shared.cpp"	[$BUILD_REPLAY]
-		$File	"$SRCDIR\game\shared\replay_gamestats_shared.h"	[$BUILD_REPLAY]
-	}
-
 	$Folder	"Source Files"
 	{
 		-$File	"AI_ConCommands.cpp"


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description

When creating a TF2 mod with a copied and pasted client_ and server_ VPC file (which is the usual Source SDK workflow for mods prior to the TF2 SDK release), errors related to REPLAY_ENABLED are seen upon compilation. This is due to an $Include file in both client_base.vpc and server_base.vpc that is only allowed to be used in projects with the conditional $TF. Although this works for TF2, this doesn't work when trying to build other derived mods with this source code if you're using a copy-pasted VPC file. In addition, source_replay.vpc recommends that the file be placed in mod VPC files.

```
// If you are adding replay support to a specific game, you must include this
// file in both its client_* and server_*.vpc files.
//
// This file should not be included in client_base.vpc or server_base.vpc.
```

This PR aims to dismantle the source_replay implementation from the base source VPCs (client_base and server_base) into replay specific VPCs (server_replay_base.vpc and client_replay_base.vpc) that are included in the mod VPC (server_tf and client_tf). One respective file included into each TF VPC enables the REPLAY_ENABLED conditional. While this doesn't enable replay functionality for all mods (also according to source_replay.vpc), this an effective solution to fix the above listed issue. 

