### PR TITLE
[TF2] Make the respawn timer display "Respawning is not available" for extremely long respawn time

### DIFF
--- a/src/game/client/tf/tf_teamstatus.cpp
+++ b/src/game/client/tf/tf_teamstatus.cpp
@@ -298,7 +298,7 @@ bool CTFTeamStatusPlayerPanel::Update( void )
 		if ( iRespawnWait != m_iPrevRespawnWait )
 		{
 			m_iPrevRespawnWait = iRespawnWait;
-			if ( ( iRespawnWait < 0 ) || !bSameTeamAsLocalPlayer || ( iRespawnWait >= 9990.0 ) )
+			if ( ( iRespawnWait < 0 ) || !bSameTeamAsLocalPlayer || ( iRespawnWait >= 1000.0 ) )
 			{
 				SetDialogVariable( "respawntime", "" );
 			}

--- a/src/game/client/tf/tf_teamstatus.cpp
+++ b/src/game/client/tf/tf_teamstatus.cpp
@@ -298,7 +298,7 @@ bool CTFTeamStatusPlayerPanel::Update( void )
 		if ( iRespawnWait != m_iPrevRespawnWait )
 		{
 			m_iPrevRespawnWait = iRespawnWait;
-			if ( ( iRespawnWait < 0 ) || !bSameTeamAsLocalPlayer )
+			if ( ( iRespawnWait < 0 ) || !bSameTeamAsLocalPlayer || ( iRespawnWait >= 9990.0 ) )
 			{
 				SetDialogVariable( "respawntime", "" );
 			}

--- a/src/game/client/tf/vgui/tf_playerpanel.cpp
+++ b/src/game/client/tf/vgui/tf_playerpanel.cpp
@@ -231,7 +231,7 @@ bool CTFPlayerPanel::Update( void )
 			if ( iRespawnWait != m_iPrevRespawnWait )
 			{
 				m_iPrevRespawnWait = iRespawnWait;
-				if ( iRespawnWait < 0 )
+				if ( iRespawnWait < 0 || iRespawnWait >= 9990.0 )
 				{
 					SetDialogVariable( "respawntime", "" );
 				}

--- a/src/game/client/tf/vgui/tf_playerpanel.cpp
+++ b/src/game/client/tf/vgui/tf_playerpanel.cpp
@@ -231,7 +231,7 @@ bool CTFPlayerPanel::Update( void )
 			if ( iRespawnWait != m_iPrevRespawnWait )
 			{
 				m_iPrevRespawnWait = iRespawnWait;
-				if ( iRespawnWait < 0 || iRespawnWait >= 9990.0 )
+				if ( iRespawnWait < 0 || iRespawnWait >= 1000.0 )
 				{
 					SetDialogVariable( "respawntime", "" );
 				}

--- a/src/game/client/tf/vgui/tf_spectatorgui.cpp
+++ b/src/game/client/tf/vgui/tf_spectatorgui.cpp
@@ -406,6 +406,10 @@ void CTFSpectatorGUI::UpdateReinforcements( void )
 		{
 			g_pVGuiLocalize->ConstructString_safe( wLabel, g_pVGuiLocalize->Find("#game_respawntime_in_sec" ), 0 );
 		}
+		else if ( iRespawnWait >= 9990.0 )
+		{
+			g_pVGuiLocalize->ConstructString_safe( wLabel, g_pVGuiLocalize->Find("#game_respawntime_disabled" ), 0 );
+		}
 		else
 		{
 			char szSecs[6];

--- a/src/game/client/tf/vgui/tf_spectatorgui.cpp
+++ b/src/game/client/tf/vgui/tf_spectatorgui.cpp
@@ -406,7 +406,7 @@ void CTFSpectatorGUI::UpdateReinforcements( void )
 		{
 			g_pVGuiLocalize->ConstructString_safe( wLabel, g_pVGuiLocalize->Find("#game_respawntime_in_sec" ), 0 );
 		}
-		else if ( iRespawnWait >= 9990.0 )
+		else if ( iRespawnWait >= 1000.0 )
 		{
 			g_pVGuiLocalize->ConstructString_safe( wLabel, g_pVGuiLocalize->Find("#game_respawntime_disabled" ), 0 );
 		}


### PR DESCRIPTION
On certain featured maps (Halloween Arena and VS Saxton Hale) and many community maps respawn is "disabled" by setting the respawn wave time to a very high number (e.g. 99999), but the game still displays it as "Respawning in N seconds...".

This PR makes the game display "Respawning is not available" in such a case, which will add a touch of "legitimacy".
It also hides the respawn countdown from the team composition panel.

This PR requires the addition of a new locale
`"game_respawntime_disabled"		"Respawning is not available"`

Because this PR checks the time _left_ until respawn, mappers shall set the respawn wave time way above 1000 seconds used in this code commit.

![image](https://github.com/user-attachments/assets/d2948291-a590-4515-91c4-5744040e2e2d)