### PR TITLE
[TF2] Fix being able to taunt while loading the Beggar's Bazooka

### DIFF
--- a/src/game/shared/tf/tf_weapon_rocketlauncher.cpp
+++ b/src/game/shared/tf/tf_weapon_rocketlauncher.cpp
@@ -225,6 +225,14 @@ void CTFRocketLauncher::ModifyEmitSoundParams( EmitSound_t &params )
 	}
 }
 
+bool CTFRocketLauncher::OwnerCanTaunt( void )
+{
+	if ( AutoFiresFullClip() && ( m_iClip1 > 0 ) )
+		return false;
+
+	return BaseClass::OwnerCanTaunt();
+}
+
 void CTFRocketLauncher::Misfire( void )
 {
 	BaseClass::Misfire();

--- a/src/game/shared/tf/tf_weapon_rocketlauncher.h
+++ b/src/game/shared/tf/tf_weapon_rocketlauncher.h
@@ -55,6 +55,8 @@ public:
 
 	virtual int		GetWeaponID( void ) const			{ return TF_WEAPON_ROCKETLAUNCHER; }
 
+	virtual bool	OwnerCanTaunt( void ) OVERRIDE;
+
 	virtual void	Misfire( void );
 	virtual CBaseEntity *FireProjectile( CTFPlayer *pPlayer );
 	virtual void	ItemPostFrame( void );


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description

In TF2, if a player taunts while loading rockets into the Beggar's Bazooka, the loaded rockets will only fire after the taunt finishes playing. Using this with a looping taunt effectively allows a Bazooka user to store their loaded rockets for as long as they want and fire them whenever they want. (This doesn't significantly impact gameplay, but it has been used to troll players in friendly scenarios.)

This PR fixes this by not allowing a Bazooka user to taunt while any rockets are loaded into the Bazooka.

This resolves https://github.com/ValveSoftware/Source-1-Games/issues/2703.
