### PR TITLE
[TF2] Fix flipped viewmodels for Scout's baseball/bauble and Botkiller heads

### DIFF
--- a/src/game/client/c_baseviewmodel.cpp
+++ b/src/game/client/c_baseviewmodel.cpp
@@ -213,6 +213,7 @@ bool C_BaseViewModel::ShouldFlipViewModel()
 	{
 		return pWeapon->m_bFlipViewModel != cl_flipviewmodels.GetBool();
 	}
+	return cl_flipviewmodels.GetBool(); // hack for scout ball projeciles to have properly flipped viewmodels
 #endif
 
 	return false;

--- a/src/game/shared/tf/tf_item_wearable.cpp
+++ b/src/game/shared/tf/tf_item_wearable.cpp
@@ -302,7 +302,24 @@ int	CTFWearable::InternalDrawModel( int flags )
 		modelrender->ForcedMaterialOverride( *pOwner->GetInvulnMaterialRef() );
 	}
 
+	CMatRenderContextPtr pRenderContext( materials );
+
+	if ( IsViewModelWearable() )
+	{
+		CTFWeaponBase *pWeapon = assert_cast< CTFWeaponBase* >( GetWeaponAssociatedWith() );
+
+		if ( pWeapon )
+		{
+			if ( pWeapon->IsViewModelFlipped() )
+			{
+				pRenderContext->CullMode( MATERIAL_CULLMODE_CW );
+			}
+		}
+	}
+
 	int ret = BaseClass::InternalDrawModel( flags );
+
+	pRenderContext->CullMode( MATERIAL_CULLMODE_CCW );
 
 	if ( bUseInvulnMaterial && (flags & STUDIO_RENDER) )
 	{
@@ -794,6 +811,34 @@ ShadowType_t CTFWearableVM::ShadowCastType( void )
 	}
 
 	return SHADOWS_RENDER_TO_TEXTURE;
+}
+
+//-----------------------------------------------------------------------------
+// Purpose:
+//		Allow botkiller attachments and server mod viewmodel VMs to properly flip with the player's weapon.
+//-----------------------------------------------------------------------------
+int CTFWearableVM::InternalDrawModel(int flags)
+{
+	C_TFPlayer* pOwner = ToTFPlayer(GetOwnerEntity());
+
+	CMatRenderContextPtr pRenderContext(materials);
+
+	if (pOwner)
+	{
+		CTFWeaponBase* pWpn = pOwner->GetActiveTFWeapon();
+
+		if (pWpn)
+		{
+			if (pWpn->IsViewModelFlipped())
+				pRenderContext->CullMode(MATERIAL_CULLMODE_CW);
+		}
+	}
+
+	int ret = BaseClass::InternalDrawModel(flags);
+
+	pRenderContext->CullMode(MATERIAL_CULLMODE_CCW);
+
+	return ret;
 }
 #endif
 

--- a/src/game/shared/tf/tf_item_wearable.h
+++ b/src/game/shared/tf/tf_item_wearable.h
@@ -109,6 +109,8 @@ public:
 
 #if defined( CLIENT_DLL )
 	virtual ShadowType_t ShadowCastType( void );
+
+	virtual int			InternalDrawModel(int flags);
 #endif
 };
 


### PR DESCRIPTION
# Description
This pull request introduces two visual fixes related to flipped viewmodels. Currently, the held baseball/bauble while the Sandman/Wrap Assassin is active and all botkiller weapon attachment models in first person have inverted normals while the client's viewmodels are flipped, 

Below is a before and after of these changes (all screenshots are taken with cl_flipviewmodels set to 1):
## Before:
![image](https://github.com/user-attachments/assets/8e3d2c23-838e-424a-83c5-e64b1419e6f8)
![image](https://github.com/user-attachments/assets/e8e2f331-939a-45a3-b067-e28d74d05eab)

## After:
![image](https://github.com/user-attachments/assets/8de26e21-2462-48f5-a8e1-023aae7fc806)
![image](https://github.com/user-attachments/assets/c1b7dfc7-14c4-40ea-98a2-f525a30dd611)
