### PR TITLE
[TF2] Fixed Flamethrower flames initial spawn position offset not flipping with flipped viewmodels.

### DIFF
--- a/src/game/shared/tf/tf_weapon_flamethrower.cpp
+++ b/src/game/shared/tf/tf_weapon_flamethrower.cpp
@@ -724,7 +724,7 @@ void CTFFlameThrower::PrimaryAttack()
 	// Make sure the weapon can't fire in this condition by tracing a line between the eye point and the end of the muzzle.
 	trace_t trace;	
 	Vector vecEye = pOwner->EyePosition();
-	Vector vecMuzzlePos = GetVisualMuzzlePos();
+	Vector vecMuzzlePos = GetFlameOriginPos();
 	CTraceFilterIgnoreObjects traceFilter( this, COLLISION_GROUP_NONE );
 	UTIL_TraceLine( vecEye, vecMuzzlePos, MASK_SOLID, &traceFilter, &trace );
 	if ( trace.fraction < 1.0 && ( !trace.m_pEnt || trace.m_pEnt->m_takedamage == DAMAGE_NO ) )
@@ -2121,6 +2121,13 @@ Vector CTFFlameThrower::GetMuzzlePosHelper( bool bVisualPos )
 			UTIL_StringToVector( vecOffset.Base(), tf_flamethrower_new_flame_offset.GetString() );
 
 			vecOffset *= pOwner->GetModelScale();
+
+			// Inverts the horizontal offset for flipped view models.
+			if ( IsViewModelFlipped() )
+			{
+				vecOffset.y *= -1;
+			}
+
 			vecMuzzlePos = pOwner->EyePosition() + vecOffset.x * vecForward + vecOffset.y * vecRight + vecOffset.z * vecUp;
 		}
 	}


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description

Made the initial spawn point offset of flames from the Flamethrowers flip when cl_flippedviewmodels is active. This makes the Flamethrowers consistent with the other projectile weapons in Team Fortress 2.

All video was record with cl_flippedviewmodels 1.

## Before

https://github.com/user-attachments/assets/aef47c5f-c18c-4916-827b-4d5969b7af94

## After

https://github.com/user-attachments/assets/97d41789-18bd-4c4d-941a-fdb8d6a09feb

