### PR TITLE
Fix unreachable BSP lumpsize warning messages

### DIFF
--- a/src/utils/common/bsplib.cpp
+++ b/src/utils/common/bsplib.cpp
@@ -2829,16 +2829,16 @@ void	WriteLumpToFile( char *filename, int lump, int nLumpVersion, void *pBuffer,
 
 int ArrayUsage( const char *szItem, int items, int maxitems, int itemsize )
 {
-	float	percentage = maxitems ? items * 100.0 / maxitems : 0.0;
+	float	percentage = maxitems ? items * 100.0f / maxitems : 0.0f;
 
     Msg("%-17.17s %8i/%-8i %8i/%-8i (%4.1f%%) ", 
 		   szItem, items, maxitems, items * itemsize, maxitems * itemsize, percentage );
-	if ( percentage > 80.0 )
-		Msg( "VERY FULL!\n" );
-	else if ( percentage > 95.0 )
-		Msg( "SIZE DANGER!\n" );
-	else if ( percentage > 99.9 )
+	if ( percentage > 100.0f )
 		Msg( "SIZE OVERFLOW!!!\n" );
+	else if ( percentage > 95.0f )
+		Msg( "SIZE DANGER!\n" );
+	else if ( percentage > 80.0f )
+		Msg( "VERY FULL!\n" );
 	else
 		Msg( "\n" );
 	return items * itemsize;
@@ -2846,15 +2846,15 @@ int ArrayUsage( const char *szItem, int items, int maxitems, int itemsize )
 
 int GlobUsage( const char *szItem, int itemstorage, int maxstorage )
 {
-	float	percentage = maxstorage ? itemstorage * 100.0 / maxstorage : 0.0;
+	float	percentage = maxstorage ? itemstorage * 100.0f / maxstorage : 0.0f;
     Msg("%-17.17s     [variable]    %8i/%-8i (%4.1f%%) ", 
 		   szItem, itemstorage, maxstorage, percentage );
-	if ( percentage > 80.0 )
-		Msg( "VERY FULL!\n" );
-	else if ( percentage > 95.0 )
-		Msg( "SIZE DANGER!\n" );
-	else if ( percentage > 99.9 )
+	if ( percentage > 100.0f )
 		Msg( "SIZE OVERFLOW!!!\n" );
+	else if ( percentage > 95.0f )
+		Msg( "SIZE DANGER!\n" );
+	else if ( percentage > 80.0f )
+		Msg( "VERY FULL!\n" );
 	else
 		Msg( "\n" );
 	return itemstorage;


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
The map compilers print out a nice table of stats showing how much space of the various BSP lumps is filled, and there is supposed to be 3 messages that display if the filled space ranges from >80% full ("VERY FULL!"), >95% full ("SIZE DANGER!"), and >99.9% full ("SIZE OVERFLOW!!!"). However the ordering of the if/else if statements only allows the first message to be displayed, since 80% is the first if statement that is checked, and anything above that, including 95% and 99.9%, are of course greater than 80%, and only show the message associated with that.

This PR fixes that by simply swapping the order of the if/else if statements around, checking against 100% first, then 95%, and then 80%, rather than 80 -> 95 -> 100.

## Additional changes
- Changed the >99.9% check to >100%, since you can have a lump be 100% full and not have any issues, and its not an overflow until it goes over 100%
- changed the percentage constants to floats instead of doubles. Minor thing, just noticed it and figured I'd change it since the percentage variable is a float anyway.

## Notes
- I don't think in most situations the 100% one will be hit? I believe most if not all of the lumps cause the compiler to error out and stop the compiler if overflowed preventing it from even getting to this list. I have heard of some of the percentages not getting calculated correctly and going over 100%, but at that point its inaccurate anyway and doesn't really matter.
- This is a super duper minor thing to change, and honestly the one message at >80% is enough to get the attention of the mapper to let them know how high their usage is, but I noticed these messages were here and figured I might as well just fix them.

the previously unused messages in action:
![image](https://github.com/user-attachments/assets/2833e6e4-6cfb-45a0-a54e-7cee16513e14)
![image](https://github.com/user-attachments/assets/264aabe3-b28b-4c74-84e7-e834df2017b6)
