### PR TITLE
Make inspection less awkward with sniper rifles

### DIFF
--- a/src/game/shared/tf/tf_weapon_sniperrifle.cpp
+++ b/src/game/shared/tf/tf_weapon_sniperrifle.cpp
@@ -545,7 +545,7 @@ void CTFSniperRifle::ZoomIn( void )
 
 
 //-----------------------------------------------------------------------------
-bool CTFSniperRifle::IsZoomed( void )
+bool CTFSniperRifle::IsZoomed( void ) const
 {
 	CTFPlayer *pPlayer = GetTFPlayerOwner();
 

--- a/src/game/shared/tf/tf_weapon_sniperrifle.cpp
+++ b/src/game/shared/tf/tf_weapon_sniperrifle.cpp
@@ -326,6 +326,14 @@ void CTFSniperRifle::HandleZooms( void )
 //-----------------------------------------------------------------------------
 // Purpose:
 //-----------------------------------------------------------------------------
+bool CTFSniperRifle::CanInspect() const
+{
+	return BaseClass::CanInspect() && !IsZoomed() && m_flChargedDamage == 0.f;
+}
+
+//-----------------------------------------------------------------------------
+// Purpose:
+//-----------------------------------------------------------------------------
 void CTFSniperRifle::ItemPostFrame( void )
 {
 	// If we're lowered, we're not allowed to fire

--- a/src/game/shared/tf/tf_weapon_sniperrifle.cpp
+++ b/src/game/shared/tf/tf_weapon_sniperrifle.cpp
@@ -1925,6 +1925,9 @@ void CTFSniperRifleClassic::ItemPostFrame( void )
 			CreateSniperDot();
 			pPlayer->ClearExpression();	
 #endif
+			// Stop inspecting and reset our animation.
+			StopInspect();
+			SendWeaponAnim( ACT_VM_IDLE );
 		}
 
 		float fSniperRifleChargePerSec = m_flChargePerSec;

--- a/src/game/shared/tf/tf_weapon_sniperrifle.h
+++ b/src/game/shared/tf/tf_weapon_sniperrifle.h
@@ -117,6 +117,8 @@ public:
 
 	virtual void WeaponReset( void );
 
+	virtual bool CanInspect() const OVERRIDE;
+
 	virtual bool CanFireCriticalShot( bool bIsHeadshot = false, CBaseEntity *pTarget = NULL ) OVERRIDE;
 
 	virtual void PlayWeaponShootSound( void );

--- a/src/game/shared/tf/tf_weapon_sniperrifle.h
+++ b/src/game/shared/tf/tf_weapon_sniperrifle.h
@@ -130,7 +130,7 @@ public:
 	virtual bool ShouldEjectBrass();
 #endif
 
-	bool IsZoomed( void );
+	bool IsZoomed( void ) const;
 	bool IsFullyCharged( void ) const;			// have we been zoomed in long enough for our shot to do max damage
 
 	virtual void OnControlStunned( void );

--- a/src/game/shared/tf/tf_weaponbase.cpp
+++ b/src/game/shared/tf/tf_weaponbase.cpp
@@ -346,8 +346,7 @@ CTFWeaponBase::CTFWeaponBase()
 	m_eStrangeType = STRANGE_UNKNOWN;
 	m_eStatTrakModuleType = MODULE_UNKNOWN;
 
-	m_flInspectAnimEndTime = -1.f;
-	m_nInspectStage = INSPECT_INVALID;
+	StopInspect();
 }
 
 CTFWeaponBase::~CTFWeaponBase()
@@ -785,8 +784,7 @@ bool CTFWeaponBase::SendWeaponAnim( int iActivity )
 		// allow other activity to override the inspect
 		if ( !IsInspectActivity( iActivity ) )
 		{
-			m_flInspectAnimEndTime = -1.f;
-			m_nInspectStage = INSPECT_INVALID;
+			StopInspect();
 			return BaseClass::SendWeaponAnim( iActivity );
 		}
 
@@ -2549,8 +2547,7 @@ void CTFWeaponBase::HandleInspect()
 	// first time pressing inspecting key
 	if ( !m_bInspecting && pPlayer->IsInspecting() )
 	{
-		m_nInspectStage = INSPECT_INVALID;
-		m_flInspectAnimEndTime = -1.f;
+		StopInspect();
 		if ( SendWeaponAnim( GetInspectActivity( INSPECT_START ) ) )
 		{
 			m_flInspectAnimEndTime = gpGlobals->curtime + SequenceDuration();
@@ -2582,14 +2579,22 @@ void CTFWeaponBase::HandleInspect()
 			}
 			else if ( m_nInspectStage == INSPECT_END )
 			{
-				m_flInspectAnimEndTime = -1.f;
-				m_nInspectStage = INSPECT_INVALID;
+				StopInspect();
 				SendWeaponAnim( ACT_VM_IDLE );
 			}
 		}
 	}
 
 	m_bInspecting = pPlayer->IsInspecting();
+}
+
+//-----------------------------------------------------------------------------
+// Purpose:
+//-----------------------------------------------------------------------------
+void CTFWeaponBase::StopInspect()
+{
+	m_flInspectAnimEndTime = -1.f;
+	m_nInspectStage = INSPECT_INVALID;
 }
 
 //-----------------------------------------------------------------------------

--- a/src/game/shared/tf/tf_weaponbase.h
+++ b/src/game/shared/tf/tf_weaponbase.h
@@ -760,6 +760,7 @@ public:
 
 	virtual bool CanInspect() const { return true; }
 	void HandleInspect();
+	void StopInspect();
 	
 	virtual void HookAttributes( void ) {};
 	virtual void OnUpgraded( void ) { HookAttributes(); }

--- a/src/game/shared/tf/tf_weaponbase_gun.cpp
+++ b/src/game/shared/tf/tf_weaponbase_gun.cpp
@@ -1050,6 +1050,10 @@ void CTFWeaponBaseGun::ZoomIn( void )
 	if ( !pPlayer )
 		return;
 
+	// Stop inspecting and reset our animation.
+	StopInspect();
+	SendWeaponAnim( ACT_VM_IDLE );
+
 	// Set the weapon zoom.
 	// TODO: The weapon fov should be gotten from the script file.
 	float fBaseZoom = TF_WEAPON_ZOOM_FOV;


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description

Weapon inspections currently interact awkwardly with sniper rifles in multiple ways:

- A sniper rifle can be inspected while it is zoomed in (although it cannot be seen while zoomed in).
- Zooming in with a sniper rifle does not interrupt its inspection animation.
- The Classic can be inspected while charging a shot.

These interactions can look awkward in gameplay, as the below videos demonstrate:

<details>

<summary><b>Videos</b></summary>

https://github.com/user-attachments/assets/ca281483-d39d-49c6-a15f-04d96da84220

https://github.com/user-attachments/assets/61e1641b-ca33-45e5-9f68-9e37cca8f5cf

</details>

To prevent these issues, this PR limits when sniper rifles can be inspected in the following ways:

- Sniper rifles cannot be inspected while zoomed in.
- Zooming in with a sniper rifle will immediately stop its inspect animation.
- Charging a shot with the Classic will immediately stop its inspect animation.

This PR is in the same spirit as my other inspection-related PR #1118, but I decided to place these changes in their own PR because they're slightly more involved than the changes in #1118.