### PR TITLE
Fix uninitialized field use in `CParticleEffectBinding`

### DIFF
--- a/src/game/client/particlemgr.cpp
+++ b/src/game/client/particlemgr.cpp
@@ -146,6 +146,7 @@ CParticleEffectBinding::CParticleEffectBinding()
 	m_LastMin = m_Min;
 	m_LastMax = m_Max;
 
+	m_flParticleCullRadius = -1.f; // dummy value, is overwritten below
 	SetParticleCullRadius( 0.0f );
 	m_nActiveParticles = 0;
 


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description

The title of this PR should hopefully explain it well. The constructor for `CParticleEffectBinding` calls a function that uses the value of its field `m_flParticleCullRadius` before the field is initialized. The offending function call occurs on this line:

https://github.com/ValveSoftware/source-sdk-2013/blob/48809cb86c0990b35f190404aa85d0483d306fa4/src/game/client/particlemgr.cpp#L149

This results in multiple (although seemingly ignorable) assertion errors occurring when loading maps in a fresh copy of the TF2 SDK after compiling it with the debug profile.

This PR fixes this by initializing `m_flParticleCullRadius` to a dummy value before its initial use (where it is then overwritten).