### PR TITLE
[TF2] Fix CTFHudPlayerStatus Being Positioned In Front Of CCurrencyStatusPanel

### DIFF
--- a/src/game/client/tf/tf_hud_mann_vs_machine_status.cpp
+++ b/src/game/client/tf/tf_hud_mann_vs_machine_status.cpp
@@ -950,7 +950,7 @@ void CWaveStatusPanel::UpdateEnemyCounts( void )
 //-----------------------------------------------------------------------------
 // Purpose: 
 //-----------------------------------------------------------------------------
-DECLARE_HUDELEMENT( CCurrencyStatusPanel );
+DECLARE_HUDELEMENT_DEPTH( CCurrencyStatusPanel, 49 );
 
 CCurrencyStatusPanel::CCurrencyStatusPanel( const char *pElementName )
 	: CHudElement( pElementName )
@@ -1610,7 +1610,7 @@ void CMvMBombCarrierProgress::ApplySchemeSettings( IScheme *pScheme )
 //-----------------------------------------------------------------------------
 // CTFHudMannVsMachineStatus 
 //-----------------------------------------------------------------------------
-DECLARE_HUDELEMENT( CTFHudMannVsMachineStatus );
+DECLARE_HUDELEMENT_DEPTH( CTFHudMannVsMachineStatus, 48 );
 
 CTFHudMannVsMachineStatus::CTFHudMannVsMachineStatus( const char *pElementName ) :
 CHudElement( pElementName ), BaseClass( NULL, "HudMannVsMachineStatus" )


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description

There is a bug with the Linux version of TF2, where the player's HUD will be positioned in front of the green currency HUD.

![image](https://github.com/user-attachments/assets/15f3461e-3e3b-46d1-ab64-98d111d7f403)

This PR changes the position of `CCurrencyStatusPanel` and `CTFHudMannVsMachineStatus` to always be in front of `CTFHudPlayerStatus`

![image](https://github.com/user-attachments/assets/8dfe6a42-fc9e-4d03-8fbb-5cf367be2f09)


Resolves ValveSoftware/Source-1-Games#6937