### PR TITLE
[TF2] Fix unusual particles appear on wrong place

### DIFF
--- a/src/game/shared/particle_property.cpp
+++ b/src/game/shared/particle_property.cpp
@@ -552,7 +552,7 @@ void CParticleProperty::UpdateControlPoint( ParticleEffectList_t *pEffect, int i
 	Vector vecOrigin, vecForward, vecRight, vecUp;
 
 	float flOffset = 0.0f;
-	bool bUsingHeadOrigin = false;
+	bool bUsingUnusual = false;
 
 #ifdef TF_CLIENT_DLL
 
@@ -560,38 +560,90 @@ void CParticleProperty::UpdateControlPoint( ParticleEffectList_t *pEffect, int i
 	if ( pWearable && GetAttribInterface( pWearable ) && !pWearable->IsPlayer() )
 	{
 		C_BaseAnimating *pAnimating = pPoint->hEntity->GetBaseAnimating();
+		// Do not use this now. It asks players to use particle from head attachment.
+		// But unusual particles for wearables are made for head attachment already.
+		// int bUseHeadOrigin = 1;
+		// CALL_ATTRIB_HOOK_INT_ON_OTHER( pAnimating, bUseHeadOrigin, particle_effect_use_head_origin );
 		if ( pAnimating )
 		{
-			int bUseHeadOrigin = 0;
-			CALL_ATTRIB_HOOK_INT_ON_OTHER( pAnimating, bUseHeadOrigin, particle_effect_use_head_origin );
-			if ( bUseHeadOrigin > 0 )
+			// Reference from bone_merge_cache
+			CUtlVector<CUtlString> 		BoneNames;
+			CUtlVector<unsigned short> 	ParentBones;
+
+			int nFollowBoneSetupMask 	= 0;
+			CStudioHdr *pWearableHdr 	= pAnimating->GetModelPtr();
+			C_BaseAnimating *pFollow 	= pAnimating->FindFollowedEntity();
+			CStudioHdr *pFollowHdr 		= (pFollow ? pFollow->GetModelPtr() : NULL);
+
+			if ( pWearableHdr && pFollowHdr )
 			{
-				int iBone = Studio_BoneIndexByName( pAnimating->GetModelPtr(), "bip_head" );
-				if ( iBone < 0 )
+				CUtlVector<unsigned char> BoneMergeBits;	// One bit for each bone. The bit is set if the bone gets merged.
+				BoneMergeBits.SetSize( pWearableHdr->numbones() / 8 + 1 );
+				memset( BoneMergeBits.Base(), 0, BoneMergeBits.Count() );
+
+				mstudiobone_t *pWearableBones = pWearableHdr->pBone( 0 );
+
+				nFollowBoneSetupMask = BONE_USED_BY_BONE_MERGE;
+				for ( int i = 0; i < pWearableHdr->numbones(); i++ )
 				{
-					iBone = Studio_BoneIndexByName( pAnimating->GetModelPtr(), "prp_helmet" );
-					if ( iBone < 0 )
+					const CUtlString sBoneName = pWearableBones[i].pszName();
+					const int parentBoneIndex = Studio_BoneIndexByName( pFollowHdr, sBoneName );
+					if ( parentBoneIndex < 0 )
+						continue;
+
+					BoneNames.AddToTail( sBoneName );
+					ParentBones.AddToTail( parentBoneIndex );
+
+					BoneMergeBits[i>>3] |= ( 1 << ( i & 7 ) );
+
+					if ( ( pFollowHdr->boneFlags( parentBoneIndex ) & BONE_USED_BY_BONE_MERGE ) == 0 )
 					{
-						iBone = Studio_BoneIndexByName( pAnimating->GetModelPtr(), "prp_hat" );
+						nFollowBoneSetupMask = BONE_USED_BY_ANYTHING;
 					}
 				}
-				if ( iBone < 0 )
+
+				if ( !ParentBones.Count() )
 				{
-					iBone = 0;
+					nFollowBoneSetupMask = 0;
 				}
+			}
+			else
+			{
+				nFollowBoneSetupMask = 0;
+			}
 
-				bUsingHeadOrigin = true;
-				const matrix3x4_t headBone = pAnimating->GetBone( iBone );
-				MatrixVectors( headBone, &vecForward, &vecRight, &vecUp );
-				MatrixPosition( headBone, vecOrigin );
+			matrix3x4_t rootBone;
+			if ( pWearableHdr && BoneNames.Count() )
+			{
+				pFollow->SetupBones( NULL, -1, nFollowBoneSetupMask, gpGlobals->curtime );
+				int iBone = -1;
+				int iHead = BoneNames.Find( "bip_head" );
+				int iHelmet = BoneNames.Find( "prp_helmet" );
+				int iHat = BoneNames.Find( "prp_hat" );
+				if ( iHead >= 0 )
+					iBone = iHead;
+				else if ( iHelmet >= 0 )
+					iBone = iHelmet;
+				else if ( iHat >= 0 )
+					iBone = iHat;
 
-				CALL_ATTRIB_HOOK_FLOAT_ON_OTHER( pAnimating, flOffset, particle_effect_vertical_offset );	
+				if ( iBone >= 0 )
+					rootBone = pFollow->GetBone( ParentBones[iBone] );
+				else
+					rootBone = pFollow->GetBone( ParentBones[0] );
+
+				bUsingUnusual = true;
+
+				MatrixVectors( rootBone, &vecForward, &vecRight, &vecUp );
+				MatrixPosition( rootBone, vecOrigin );
+
+				CALL_ATTRIB_HOOK_FLOAT_ON_OTHER( pAnimating, flOffset, particle_effect_vertical_offset );
 			}
 		}
 	}
 #endif
 
-	if ( !bUsingHeadOrigin )
+	if ( !bUsingUnusual )
 	{
 		switch ( pPoint->iAttachType )
 		{

--- a/src/game/shared/particle_property.cpp
+++ b/src/game/shared/particle_property.cpp
@@ -557,15 +557,15 @@ void CParticleProperty::UpdateControlPoint( ParticleEffectList_t *pEffect, int i
 #ifdef TF_CLIENT_DLL
 
 	CBaseEntity *pWearable = (CBaseEntity*) pPoint->hEntity.Get();
-	if ( pWearable && GetAttribInterface( pWearable ) && !pWearable->IsPlayer() )
+	if ( pWearable && GetAttribInterface( pWearable ) && !pWearable->IsPlayer() && V_strcmp( pWearable->GetClassname(), "tf_wearable" ) == 0 )
 	{
 		C_BaseAnimating *pAnimating = pPoint->hEntity->GetBaseAnimating();
-		// Do not use this now. It asks players to use particle from head attachment.
-		// But unusual particles for wearables are made for head attachment already.
-		// int bUseHeadOrigin = 1;
-		// CALL_ATTRIB_HOOK_INT_ON_OTHER( pAnimating, bUseHeadOrigin, particle_effect_use_head_origin );
 		if ( pAnimating )
 		{
+			// Do not use this now. It asks players to use particle from head attachment.
+			// But unusual particles for wearables are made for head attachment already.
+			// CALL_ATTRIB_HOOK_INT_ON_OTHER( pAnimating, bUseHeadOrigin, particle_effect_use_head_origin );
+
 			// Reference from bone_merge_cache
 			CUtlVector<CUtlString> 		BoneNames;
 			CUtlVector<unsigned short> 	ParentBones;
@@ -575,7 +575,11 @@ void CParticleProperty::UpdateControlPoint( ParticleEffectList_t *pEffect, int i
 			C_BaseAnimating *pFollow 	= pAnimating->FindFollowedEntity();
 			CStudioHdr *pFollowHdr 		= (pFollow ? pFollow->GetModelPtr() : NULL);
 
-			if ( pWearableHdr && pFollowHdr )
+			bool bIsUnusual 			= false;
+			bool bIsUnusualStatic 		= false;
+			CALL_ATTRIB_HOOK_INT_ON_OTHER( pAnimating, bIsUnusual, set_attached_particle );
+			CALL_ATTRIB_HOOK_INT_ON_OTHER( pAnimating, bIsUnusualStatic, set_attached_particle_static );
+			if ( pWearableHdr && pFollowHdr && ( bIsUnusual || bIsUnusualStatic ) )
 			{
 				CUtlVector<unsigned char> BoneMergeBits;	// One bit for each bone. The bit is set if the bone gets merged.
 				BoneMergeBits.SetSize( pWearableHdr->numbones() / 8 + 1 );
@@ -612,28 +616,27 @@ void CParticleProperty::UpdateControlPoint( ParticleEffectList_t *pEffect, int i
 				nFollowBoneSetupMask = 0;
 			}
 
-			matrix3x4_t rootBone;
 			if ( pWearableHdr && BoneNames.Count() )
 			{
 				pFollow->SetupBones( NULL, -1, nFollowBoneSetupMask, gpGlobals->curtime );
+				const char * const pPriorityBones[] = { "bip_head", "prp_helmet", "prp_hat" };
 				int iBone = -1;
-				int iHead = BoneNames.Find( "bip_head" );
-				int iHelmet = BoneNames.Find( "prp_helmet" );
-				int iHat = BoneNames.Find( "prp_hat" );
-				if ( iHead >= 0 )
-					iBone = iHead;
-				else if ( iHelmet >= 0 )
-					iBone = iHelmet;
-				else if ( iHat >= 0 )
-					iBone = iHat;
-
-				if ( iBone >= 0 )
-					rootBone = pFollow->GetBone( ParentBones[iBone] );
-				else
-					rootBone = pFollow->GetBone( ParentBones[0] );
+				bool bFound = false;
+				for ( int j = 0; j < ARRAYSIZE(pPriorityBones) && !bFound; j++ )
+				{
+					for ( int i = 0; i < BoneNames.Count(); i++ )
+					{
+						if ( BoneNames[i] == pPriorityBones[j] )
+						{
+							iBone = i;
+							bFound = true;
+							break;
+						}
+					}
+				}
 
 				bUsingUnusual = true;
-
+				const matrix3x4_t rootBone = iBone >= 0 ? pFollow->GetBone( ParentBones[iBone] ) : pFollow->GetBone( ParentBones[0] );
 				MatrixVectors( rootBone, &vecForward, &vecRight, &vecUp );
 				MatrixPosition( rootBone, vecOrigin );
 


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
This PR fixes the following issues:

1. Particles appearing on the wrong bone (ex: Merc's Mohawk, Corona Australis, etc.) https://github.com/ValveSoftware/Source-1-Games/issues/4836
2. Particles with long lifetime, such as orbiting or clouds, escape from their attach point (not fully tested) 
3. Laggy visual during movement https://github.com/ValveSoftware/Source-1-Games/issues/4076

This is because function finds first bone whether it is head or not when player didn't adjusted. If it's adjusted, attachment point is set to tf_wearable's merged bone which calculated client's pvs only.

Reference: [Steam Guide: Broken Unusuals. What they are and how to fix Them.](https://steamcommunity.com/sharedfiles/filedetails/?id=3005439844)
