### PR TITLE
Added `level_visits` userinfo convar

### DIFF
--- a/src/game/client/cdll_util.cpp
+++ b/src/game/client/cdll_util.cpp
@@ -33,6 +33,7 @@
 #include "tier0/memdbgon.h"
 																						
 ConVar localplayer_visionflags( "localplayer_visionflags", "0", FCVAR_DEVELOPMENTONLY );
+ConVar level_visits( "level_visits", "0", FCVAR_USERINFO, "The number of times the player has visited the current map" );
 																						
 //-----------------------------------------------------------------------------
 // ConVars
@@ -1243,7 +1244,7 @@ void UTIL_IncrementMapKey( const char *pszCustomKey )
 			KeyValues *pNewKey = new KeyValues( mapname );
 			if ( pNewKey )
 			{
-				pNewKey->SetString( pszCustomKey, "1" );
+				pNewKey->SetInt( pszCustomKey, iCount );
 				kvMapLoadFile->AddSubKey( pNewKey );
 			}
 		}
@@ -1259,6 +1260,8 @@ void UTIL_IncrementMapKey( const char *pszCustomKey )
 
 		kvMapLoadFile->deleteThis();
 	}
+
+	level_visits.SetValue( iCount );
 
 	if ( IsX360() )
 	{


### PR DESCRIPTION
In VScript projects, it would be useful to know if a particular player is new to the map/gamemode, to, for example, display hint messages. Even TF2 itself does this when displaying the map's goal description on round start.

Fortunately, the game already keeps track of this statistic - all we need is to put into a userinfo convar so that VScript could retrieve it using `GetClientConvarValue`. I think it's a good compromise between safety and versatility, giving that cookies are most likely out of the question due to privacy and security reasons.