### PR TITLE
[TF2] Allow custom mission briefings in vsh and zi

### DIFF
--- a/src/game/client/tf/vgui/tf_mapinfomenu.cpp
+++ b/src/game/client/tf/vgui/tf_mapinfomenu.cpp
@@ -385,14 +385,6 @@ void CTFMapInfoMenu::LoadMapPage()
 	{
 		m_pMapInfo->SetText( wszMapDescription );
 	}
-	else if ( StringHasPrefix( m_szMapName, "vsh_" ) )
-	{
-		m_pMapInfo->SetText( "#default_vsh_description" );
-	}
-	else if ( StringHasPrefix( m_szMapName, "zi_" ) )
-	{
-		m_pMapInfo->SetText( "#default_zi_description" );
-	}
 	else
 	{
 		// try loading map descriptions from .txt files first
@@ -497,7 +489,15 @@ void CTFMapInfoMenu::LoadMapPage()
 
 			if( !g_pVGuiLocalize->Find( mapInfoKey ) )
 			{
-				if ( TFGameRules() )
+				if ( StringHasPrefix( m_szMapName, "vsh_" ) )
+				{
+					pszDescription = "#default_vsh_description";
+				}
+				else if ( StringHasPrefix( m_szMapName, "zi_" ) )
+				{
+					pszDescription = "#default_zi_description";
+				}
+				else if ( TFGameRules() )
 				{
 					if ( TFGameRules()->IsMannVsMachineMode() )
 					{


### PR DESCRIPTION
TF2 supports a feature, which [lets mappers change the whiteboard text](https://developer.valvesoftware.com/wiki/TF2/Modifying_the_Mission_Briefing), that you see upon loading a map.

Due to an oversight, this feature doesn't work in Versus Saxton Hale and Zombie Infection, because of their mission briefings being tied to the map prefix, and the check for said prefix being done before the check for the custom mission briefing text files.

![Source-sdk-2013 Screenshot 2025 03 24 - 19 36 25 03](https://github.com/user-attachments/assets/ae4efc77-555c-4a17-b8ce-058205f9fa25)

This PR moves the check to be after the text file check, which makes custom mission briefings work again.

![Source-sdk-2013 Screenshot 2025 03 24 - 19 37 32 23](https://github.com/user-attachments/assets/814cb539-f6b2-4ef8-9312-9b978199f5a2)
