### PR TITLE
[All?] Fix exploit allowing color control characters to be used in chat under certain circumstances

### DIFF
--- a/src/game/client/hud_basechat.cpp
+++ b/src/game/client/hud_basechat.cpp
@@ -178,9 +178,9 @@ wchar_t* ReadChatTextString( bf_read &msg, OUT_Z_BYTECAP(outSizeInBytes) wchar_t
 			{
 				// mark the next seven or nine characters. one for the control character and six or eight for the code itself.
 				const int nSkip = ( *test == COLOR_HEXCODE ? 7 : 9 );
-				for ( int i = 0; i < nSkip && *test != 0; i++, test++ )
+				for ( int i = 0; i < nSkip && *test != 0; i++ )
 				{
-					*test = COLOR_NORMAL;
+					*++test = COLOR_NORMAL;
 				}
 
 				// if we reached the end of the string first, then back up


### PR DESCRIPTION
# Description
This PR fixes an oversight that causes the `ReadChatTextString` function to skip over color control characters if they are preceded by either of the hex color control codes.

This happens because the inner for-loop increments `test` one too many times, causing any following color control characters to be skipped over when the outer for-loop increments `test`, itself.

As far as I can tell, this effects all SDK2013 games.

The following screenshots use the example string `color!FFD700test` (`0x07636F6C6F7221070546464437303074657374`), generated with https://sourcecolors.neocities.org/

Before             |  After
:-------------------------:|:-------------------------:
![chat-color-before](https://github.com/user-attachments/assets/5cd14d8c-5f06-49f5-bf47-2ed0ebfa452a)  |  ![chat-color-after](https://github.com/user-attachments/assets/f6c5e1fb-7d21-4d2a-a5ec-4a41d4281694)

Note that for reasons I'm not entirely sure of, this only seems to effect *dead*/spectate/team chat. (in TF2 at least)