### PR TITLE
Update player visibility when changing observer mode

### DIFF
--- a/src/game/client/c_baseplayer.cpp
+++ b/src/game/client/c_baseplayer.cpp
@@ -632,6 +632,8 @@ void C_BasePlayer::SetObserverMode ( int iNewMode )
 			// On a change of viewing mode or target, we may want to reset both head and torso to point at the new target.
 			g_ClientVirtualReality.AlignTorsoAndViewToWeapon();
 		}
+
+		UpdateVisibility();
 	}
 }
 


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description

This PR changes `C_BasePlayer::SetObserverMode` to call `UpdateVisibility()` after updating the value of `m_iObserverMode`. This is because the value of `m_iObserverMode` can affect the visibility state calculated for the player (ex. the value of `m_hRender`) when `UpdateVisibility()` is called. Because this call is currently not made, a player's visibility state may reflect having a different observer mode than their current mode, which may cause visual discrepancies.

This PR resolves https://github.com/ValveSoftware/source-sdk-2013/issues/1160. In particular, this is because this change means that the client player is properly marked as not visible when their observer mode is set to `OBS_MODE_NONE` upon spawning.