### PR TITLE
Prevent division by zero in `CGameMovement::ClipVelocity`

### DIFF
--- a/src/game/shared/gamemovement.cpp
+++ b/src/game/shared/gamemovement.cpp
@@ -3179,7 +3179,10 @@ int CGameMovement::ClipVelocity( Vector& in, Vector& normal, Vector& out, float 
 	{
 		// Redirect clipped velocity along angle of movement
 		float flLen = out.Length();
-		out *= ( -1.f * flBlocked * flRedirectCoeff + flLen ) / flLen;
+		if ( flLen != 0.0f )
+		{
+			out *= ( -1.f * flBlocked * flRedirectCoeff + flLen ) / flLen;
+		}
 	}
 
 	// Return blocking flags.


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description

Hopefully explained by the title. `CGameMovement::ClipVelocity` may perform division by zero on line 3182 below:

https://github.com/ValveSoftware/source-sdk-2013/blob/ceb6d4d78370879986d911df9bdf27f2d931759b/src/game/shared/gamemovement.cpp#L3178-L3183

This occurs when `flLen` is zero, which is true when `out`'s magnitude is zero. This division causes `out`'s elements to all be NaN, which may in turn cause the error `PM  Got a NaN velocity x/y/z` to be printed to the console.

This PR prevents this from occurring by checking that `flLen` is nonzero before performing the division.