### PR TITLE
[TF2] Restore unused MvM Wave Win/Lose response rules

### DIFF
--- a/src/game/server/tf/bot/behavior/tf_bot_mvm_deploy_bomb.cpp
+++ b/src/game/server/tf/bot/behavior/tf_bot_mvm_deploy_bomb.cpp
@@ -123,6 +123,7 @@ ActionResult< CTFBot > CTFBotMvMDeployBomb::Update( CTFBot *me, float interval )
 
 			m_timer.Start( 2.0f );
 			TFGameRules()->BroadcastSound( 255, "Announcer.MVM_Robots_Planted" );
+			TFGameRules()->HaveAllPlayersSpeakConceptIfAllowed( MP_CONCEPT_MVM_WAVE_LOSE ); // Added wave lose vo trigger
 			me->SetDeployingBombState( TF_BOMB_DEPLOYING_COMPLETE );
 			me->m_takedamage = DAMAGE_NO;
 			me->AddEffects( EF_NODRAW );

--- a/src/game/server/tf/player_vs_environment/tf_populators.cpp
+++ b/src/game/server/tf/player_vs_environment/tf_populators.cpp
@@ -2211,6 +2211,9 @@ void CWave::WaveCompleteUpdate( void )
 		}
 	}
 
+	// Trigger wave win vo for players that survived
+	TFGameRules()->HaveAllPlayersSpeakConceptIfAllowed( MP_CONCEPT_MVM_WAVE_WIN );
+
 	CBroadcastRecipientFilter filter;
 	filter.MakeReliable();
 	UserMessageBegin( filter, "MVMAnnouncement" );

--- a/src/game/server/tf/player_vs_environment/tf_tank_boss.cpp
+++ b/src/game/server/tf/player_vs_environment/tf_tank_boss.cpp
@@ -860,6 +860,9 @@ void CTFTankBoss::TankBossThink( void )
 		m_isDroppingBomb = false;
 
 		TFGameRules()->BroadcastSound( 255, "Announcer.MVM_Tank_Planted" );
+
+		// Added wave lose vo trigger
+		TFGameRules()->HaveAllPlayersSpeakConceptIfAllowed( MP_CONCEPT_MVM_WAVE_LOSE );
 	}
 
 	// if the Tank is driving under something, shut off its smokestack


### PR DESCRIPTION
Updated game code to add triggers for the currently unused MvM Wave Win/Lose response rules.

https://github.com/user-attachments/assets/4d146c92-4dc7-49c0-8904-7bcb0f3634b0

Recommended to add predelay to Wave Lose voice response lines for less overlap (tested with value of '1.8').

https://github.com/user-attachments/assets/6a90ad9f-73d2-45ae-b68b-bf8b92937f22

<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
