### PR TITLE
Add autocomplete for script_execute command

### DIFF
--- a/src/game/shared/vscript_shared.cpp
+++ b/src/game/shared/vscript_shared.cpp
@@ -58,6 +58,17 @@ private:
 };*/
 #endif
 
+#define SCRIPT_PATH "scripts/vscripts"
+
+static const char *g_pszScriptExtensions[] =
+{
+	"",		// SL_NONE
+	".gm",	// SL_GAMEMONKEY
+	".nut",	// SL_SQUIRREL
+	".lua", // SL_LUA
+	".py",  // SL_PYTHON
+};
+
 HSCRIPT VScriptCompileScript( const char *pszScriptName, bool bWarnMissing )
 {
 	if ( !g_pScriptVM )
@@ -65,16 +76,7 @@ HSCRIPT VScriptCompileScript( const char *pszScriptName, bool bWarnMissing )
 		return NULL;
 	}
 
-	static const char *pszExtensions[] =
-	{
-		"",		// SL_NONE
-		".gm",	// SL_GAMEMONKEY
-		".nut",	// SL_SQUIRREL
-		".lua", // SL_LUA
-		".py",  // SL_PYTHON
-	};
-
-	const char *pszVMExtension = pszExtensions[g_pScriptVM->GetLanguage()];
+	const char *pszVMExtension = g_pszScriptExtensions[g_pScriptVM->GetLanguage()];
 	const char *pszIncomingExtension = V_strrchr( pszScriptName , '.' );
 	if ( pszIncomingExtension && V_strcmp( pszIncomingExtension, pszVMExtension ) != 0 )
 	{
@@ -85,11 +87,11 @@ HSCRIPT VScriptCompileScript( const char *pszScriptName, bool bWarnMissing )
 	CFmtStr scriptPath;
 	if ( pszIncomingExtension )
 	{
-		scriptPath.sprintf( "scripts/vscripts/%s", pszScriptName );
+		scriptPath.sprintf( SCRIPT_PATH "/%s", pszScriptName );
 	}
 	else
 	{	
-		scriptPath.sprintf( "scripts/vscripts/%s%s", pszScriptName,  pszVMExtension );
+		scriptPath.sprintf( SCRIPT_PATH "/%s%s", pszScriptName,  pszVMExtension );
 	}
 
 	const char *pBase;
@@ -244,12 +246,66 @@ CON_COMMAND( script, "Run the text as a script" )
 	}
 }
 
+static void ScriptFileAutocompleteRecursive( const char* pDirectory, const char* pExtension, 
+	const char* pMatch, int& nMatches, const char* pCommandName, char commands[ COMMAND_COMPLETION_MAXITEMS ][ COMMAND_COMPLETION_ITEM_LENGTH ] )
+{
+	char szDirectory[MAX_PATH];
+    V_snprintf( szDirectory, sizeof(szDirectory), "%s/*", pDirectory );
 
+	FileFindHandle_t hFile;
+	const char *pFileName = filesystem->FindFirst( szDirectory, &hFile );
+	while ( pFileName )
+	{
+		if ( *pFileName != '.' )
+		{
+			char szCompleteFilename[MAX_PATH];
+			V_snprintf( szCompleteFilename, sizeof(szCompleteFilename), "%s/%s", pDirectory, pFileName );
+			if ( g_pFullFileSystem->FindIsDirectory( hFile ) )
+			{
+				ScriptFileAutocompleteRecursive( szCompleteFilename, pExtension, pMatch, nMatches, pCommandName, commands );
+			}
+			else
+			{
+				const char *pFileExtension = V_strrchr( pFileName, '.' );
+				if ( pFileExtension && !V_stricmp( pFileExtension, pExtension ) )
+				{
+					if ( V_strstr( pFileName, pMatch ) )
+						V_snprintf( commands[nMatches++], COMMAND_COMPLETION_ITEM_LENGTH, "%s %s", 
+							pCommandName, szCompleteFilename + sizeof(SCRIPT_PATH) );
+				}
+			}
+		}
+
+		if ( nMatches >= COMMAND_COMPLETION_MAXITEMS )
+			break;
+
+		pFileName = filesystem->FindNext( hFile );
+	}
+	filesystem->FindClose( hFile );
+}
+
+static int script_execute_autocomplete( const char *partial, char commands[ COMMAND_COMPLETION_MAXITEMS ][ COMMAND_COMPLETION_ITEM_LENGTH ] )
+{
+	int nMatches = 0;
+	if ( g_pScriptVM )
+	{
+		const char* pExtension = g_pszScriptExtensions[ g_pScriptVM->GetLanguage() ];
+#ifdef CLIENT_DLL
+		const char* pCommandName = "script_execute_client";
+#else
+		const char* pCommandName = "script_execute";
+#endif
+		const char* pMatch = partial + V_strlen( pCommandName ) + 1;
+
+		ScriptFileAutocompleteRecursive( SCRIPT_PATH, pExtension, pMatch, nMatches, pCommandName, commands );
+	}
+	return nMatches;
+}
 
 #ifdef CLIENT_DLL
-CON_COMMAND( script_execute_client, "Run a vscript file" )
+CON_COMMAND_F_COMPLETION( script_execute_client, "Run a vscript file", FCVAR_NONE, script_execute_autocomplete )
 #else
-CON_COMMAND( script_execute, "Run a vscript file" )
+CON_COMMAND_F_COMPLETION( script_execute, "Run a vscript file", FCVAR_NONE, script_execute_autocomplete )
 #endif
 {
 #ifdef CLIENT_DLL


### PR DESCRIPTION
Adds autocomplete of relevant script files in `scripts/vscripts/* (including subdirectories) for the `script_execute`/`script_execute_client` command, as a quality of life improvement

![image](https://github.com/user-attachments/assets/ba2c6887-d032-4949-88b7-d7897a4251c8)
