### PR TITLE
[TF2 SDK] Add TF-specific search path tags to TF mod gameinfo

### DIFF
--- a/game/mod_tf/gameinfo.txt
+++ b/game/mod_tf/gameinfo.txt
@@ -32,15 +32,16 @@
 			// folder.
 			//
 			// Note that this folder is scanned only when the game is booted.
-			game+mod	mod_tf/custom/*
+			game+mod+custom_mod	mod_tf/custom/*
 			// Enable this if you want to load your TF custom content.
-			//game+mod	|appid_440|tf/custom/*
+			//game+mod+custom_mod	|appid_440|tf/custom/*
 
 			// Now search loose files.  We'll set the directory containing the gameinfo.txt file
 			// as the first "mod" search path (after any user customizations).  This is also the one
 			// that's used when writing to the "mod" path.
 			mod+mod_write		|gameinfo_path|.
 			game+game_write		|gameinfo_path|.
+			vgui				|gameinfo_path|.
 			default_write_path	|gameinfo_path|.
 			gamebin				|gameinfo_path|bin
 


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description

TF2 uses two additional kinds of search path tags on top of the standard ones used by HL2DM: `custom_mod` and `vgui`. Currently, the `gameinfo.txt` included for the TF2 SDK mod does not mark any of its own (i.e. not base TF2's) assets with either of these tags, which can cause issues when trying to override TF2 assets.

This PR adds these tags to their appropriate mod asset paths, allowing affected custom assets to load correctly.

This PR resolves https://github.com/ValveSoftware/source-sdk-2013/issues/691.
