### PR TITLE
[TF2] Potential fix for chat window out of position in Casual/Competitive Match Start/End

### DIFF
--- a/src/game/client/tf/c_tf_player.cpp
+++ b/src/game/client/tf/c_tf_player.cpp
@@ -7873,7 +7873,13 @@ void C_TFPlayer::ClientPlayerRespawn( void )
 		m_bNotifiedWeaponInspectThisLife = false;
 
 		// make sure the chat window has been restored to the appropriate place
-		g_pClientMode->GetViewportAnimationController()->StartAnimationSequence( "CompetitiveGame_RestoreChatWindow", false );
+		if ( TFGameRules() && (TFGameRules()->ShowMatchSummary() || TFGameRules()->PlayersAreOnMatchSummaryStage()) )
+		{
+			g_pClientMode->GetViewportAnimationController()->StartAnimationSequence("CompetitiveGame_LowerChatWindow", false);
+		}
+		else
+			g_pClientMode->GetViewportAnimationController()->StartAnimationSequence("CompetitiveGame_RestoreChatWindow", false);
+
 	}
 
 	UpdateVisibility();

--- a/src/game/client/tf/tf_hud_match_status.cpp
+++ b/src/game/client/tf/tf_hud_match_status.cpp
@@ -596,6 +596,8 @@ void CTFHudMatchStatus::FireGameEvent( IGameEvent * event )
 			{
 				g_pClientMode->GetViewportAnimationController()->StartAnimationSequence( this, "HudMatchStatus_ShowMatchWinDoors_NoOpen", false );
 			}
+
+			g_pClientMode->GetViewportAnimationController()->StartAnimationSequence("CompetitiveGame_LowerChatWindow", false);
 		}
 	}
 }
@@ -612,6 +614,7 @@ void CTFHudMatchStatus::HandleCountdown( int nTime )
 		if ( TFGameRules()->GetRoundsPlayed() == 0 )
 		{
 			ShowRoundSign( TFGameRules()->GetRoundsPlayed() );
+			g_pClientMode->GetViewportAnimationController()->StartAnimationSequence("CompetitiveGame_RestoreChatWindow", false);
 		}
 		break;
 	case 10:
@@ -655,6 +658,7 @@ void CTFHudMatchStatus::ShowMatchStartDoors()
 		m_pMatchStartModelPanel->SetSkin( nSkin );
 
 		g_pClientMode->GetViewportAnimationController()->StartAnimationSequence( this, "HudMatchStatus_ShowMatchStartDoors", false );
+		g_pClientMode->GetViewportAnimationController()->StartAnimationSequence(this, "CompetitiveGame_LowerChatWindow", false);	// Lowering chat window to minimize overlap with team lineup ui
 
 		bool bUsesStickyRanks = pMatchDesc->BUsesStickyRanks();
 		SetControlVisible( "RankUpLabel", bUsesStickyRanks, true );


### PR DESCRIPTION
Potential fix for https://github.com/ValveSoftware/Source-1-Games/issues/3523

The game uses HUD animations (CompetitiveGame_LowerChatWindow and CompetitiveGame_RestoreChatWindow) to handle moving the chat box for the post-game screens. However, the chat window returns to its in-game position when transitioning to the Competitive 'Results' sequence as it is forced to reposition when players respawn for the podium.

https://github.com/user-attachments/assets/ef85a4e8-ed19-48d2-ae90-bd25e7aac811

This pr adds a check for if player is at end of Casual/Competitive match to retain chat window in lower position. This will minimize overlap with match summary UI on screen.

The live client also fails to relocate the chat window at the start of a match to a lower position. This results in some of the match start UI overlapping significantly:
https://user-images.githubusercontent.com/58406587/153318924-636f0fea-b32b-4a28-8798-d7037d631e25.png

This was previously not an issue in older versions of the game (picture below is from 2016 competitive beta):
![image](https://github.com/user-attachments/assets/719af6c3-de1d-44a4-bfd1-65170afa024d)

Adds triggers for chat window to raise/lower during match start sequence to minimize overlap with team lineup UI.

<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
