### PR TITLE
[TF2] Fix not being able to deploy BASE Jumper parachute in certain situations

### DIFF
--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -4082,6 +4082,7 @@ void CTFPlayer::Regenerate( bool bRefillHealthAndAmmo /*= true*/ )
 		if ( m_Shared.InCond( TF_COND_PARACHUTE_ACTIVE ) )
 		{
 			m_Shared.RemoveCond( TF_COND_PARACHUTE_ACTIVE );
+			m_Shared.RemoveCond( TF_COND_PARACHUTE_DEPLOYED );
 		}
 
 		if ( m_Shared.InCond( TF_COND_PLAGUE ) )

--- a/src/game/shared/tf/tf_player_shared.cpp
+++ b/src/game/shared/tf/tf_player_shared.cpp
@@ -3105,6 +3105,7 @@ void CTFPlayerShared::ConditionThink( void )
 		if ( InCond( TF_COND_PARACHUTE_ACTIVE ) )
 		{
 			RemoveCond( TF_COND_PARACHUTE_ACTIVE );
+			RemoveCond( TF_COND_PARACHUTE_DEPLOYED );
 		}
 
 		if ( InCond( TF_COND_ROCKETPACK ) )


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
This PR fixes an issue where walking into freefall after landing with the parachute deployed whilst not holding the jump key will prevent you from redeploying the parachute as the `TF_COND_PARACHUTE_DEPLOYED` condition will still be active as the ground check only happens when the jump key is held. This also occurs when touching the resupply cabinet.

The change I've made to fix this issue is to remove the aforementioned cond whenever we remove the `TF_COND_PARACHUTE_ACTIVE` cond under normal circumstances.

https://github.com/user-attachments/assets/4907b0f9-c47c-44e7-b1ac-19d3f90444c3

