### PR TITLE
[TF2] Make it so Vita-Saw attacks on MvM robots spawn a bolt instead of a spleen (outside of Wave 666)

### DIFF
--- a/src/game/server/tf/tf_objective_resource.h
+++ b/src/game/server/tf/tf_objective_resource.h
@@ -66,7 +66,8 @@ public:
 	void SetMvMPopfileName( string_t iszMvMPopfileName ) { m_iszMvMPopfileName = iszMvMPopfileName; }
 	string_t GetMvMPopfileName( void ) const { return m_iszMvMPopfileName.Get(); }
 
-	void SetMannVsMachineEventPopfileType( int nType ){ m_nMvMEventPopfileType.Set( nType ); }
+	void SetMannVsMachineEventPopfileType( int nType ) { m_nMvMEventPopfileType.Set( nType ); }
+	int	GetMvMEventPopfileType(void) { return m_nMvMEventPopfileType; }
 
 	string_t GetTeleporterString() const { return m_teleporterString; }
 

--- a/src/game/server/tf/tf_objective_resource.h
+++ b/src/game/server/tf/tf_objective_resource.h
@@ -67,7 +67,7 @@ public:
 	string_t GetMvMPopfileName( void ) const { return m_iszMvMPopfileName.Get(); }
 
 	void SetMannVsMachineEventPopfileType( int nType ) { m_nMvMEventPopfileType.Set( nType ); }
-	int	GetMvMEventPopfileType(void) { return m_nMvMEventPopfileType; }
+	int GetMvMEventPopfileType(void) { return m_nMvMEventPopfileType; }
 
 	string_t GetTeleporterString() const { return m_teleporterString; }
 

--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -9113,7 +9113,7 @@ int CTFPlayer::OnTakeDamage( const CTakeDamageInfo &inputInfo )
 				pRandomInternalOrgan->KeyValue( "origin", buf );
 				Q_snprintf( buf, sizeof( buf ), "%.10f %.10f %.10f", GetAbsAngles().x, GetAbsAngles().y, GetAbsAngles().z );
 				pRandomInternalOrgan->KeyValue( "angles", buf );
-				if (TFGameRules()->IsMannVsMachineMode() && GetTeamNumber() == TF_TEAM_BLUE)
+				if (TFGameRules() && TFGameRules()->IsMannVsMachineMode() && GetTeamNumber() == TF_TEAM_PVE_INVADERS)
 				{
 					//robots don't have spleens....
 					pRandomInternalOrgan->KeyValue("model", "models/player/gibs/gibs_bolt.mdl");

--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -2774,6 +2774,8 @@ void CTFPlayer::PrecacheMvM()
 	PrecacheModel( "models/items/currencypack_large.mdl" );
 
 	PrecacheModel( "models/bots/tw2/boss_bot/twcarrier_addon.mdl" );
+    
+    PrecacheModel( "models/player/gibs/gibs_bolt.mdl" );
 
 	PrecacheParticleSystem( "bot_impact_light" );
 	PrecacheParticleSystem( "bot_impact_heavy" );
@@ -3072,7 +3074,6 @@ void CTFPlayer::PrecacheTFPlayer()
 	PrecacheModel( "effects/beam001_blu.vmt" );
 	PrecacheModel( "effects/beam001_white.vmt" );
 	PrecacheModel( "models/player/gibs/random_organ.mdl" );
-    PrecacheModel( "models/player/gibs/gibs_bolt.mdl" );
 
 	PrecacheScriptSound( "Weapon_Mantreads.Impact" );
 
@@ -9113,14 +9114,14 @@ int CTFPlayer::OnTakeDamage( const CTakeDamageInfo &inputInfo )
 				pRandomInternalOrgan->KeyValue( "origin", buf );
 				Q_snprintf( buf, sizeof( buf ), "%.10f %.10f %.10f", GetAbsAngles().x, GetAbsAngles().y, GetAbsAngles().z );
 				pRandomInternalOrgan->KeyValue( "angles", buf );
-				if (TFGameRules() && TFGameRules()->IsMannVsMachineMode() && GetTeamNumber() == TF_TEAM_PVE_INVADERS)
+				if (TFGameRules()->IsMannVsMachineMode() && GetTeamNumber() == TF_TEAM_PVE_INVADERS && BloodColor() == DONT_BLEED)
 				{
 					//robots don't have spleens....
-					pRandomInternalOrgan->KeyValue("model", "models/player/gibs/gibs_bolt.mdl");
+					pRandomInternalOrgan->KeyValue( "model", "models/player/gibs/gibs_bolt.mdl" );
 				}
 				else
 				{
-					pRandomInternalOrgan->KeyValue("model", "models/player/gibs/random_organ.mdl");
+					pRandomInternalOrgan->KeyValue( "model", "models/player/gibs/random_organ.mdl" );
 				}
 				pRandomInternalOrgan->KeyValue( "fademindist", "-1" );
 				pRandomInternalOrgan->KeyValue( "fademaxdist", "0" );

--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -3072,6 +3072,7 @@ void CTFPlayer::PrecacheTFPlayer()
 	PrecacheModel( "effects/beam001_blu.vmt" );
 	PrecacheModel( "effects/beam001_white.vmt" );
 	PrecacheModel( "models/player/gibs/random_organ.mdl" );
+    PrecacheModel( "models/player/gibs/gibs_bolt.mdl" );
 
 	PrecacheScriptSound( "Weapon_Mantreads.Impact" );
 
@@ -9112,7 +9113,15 @@ int CTFPlayer::OnTakeDamage( const CTakeDamageInfo &inputInfo )
 				pRandomInternalOrgan->KeyValue( "origin", buf );
 				Q_snprintf( buf, sizeof( buf ), "%.10f %.10f %.10f", GetAbsAngles().x, GetAbsAngles().y, GetAbsAngles().z );
 				pRandomInternalOrgan->KeyValue( "angles", buf );
-				pRandomInternalOrgan->KeyValue( "model", "models/player/gibs/random_organ.mdl" );
+				if (TFGameRules()->IsMannVsMachineMode() && GetTeamNumber() == TF_TEAM_BLUE)
+				{
+					//robots don't have spleens....
+					pRandomInternalOrgan->KeyValue("model", "models/player/gibs/gibs_bolt.mdl");
+				}
+				else
+				{
+					pRandomInternalOrgan->KeyValue("model", "models/player/gibs/random_organ.mdl");
+				}
 				pRandomInternalOrgan->KeyValue( "fademindist", "-1" );
 				pRandomInternalOrgan->KeyValue( "fademaxdist", "0" );
 				pRandomInternalOrgan->KeyValue( "fadescale", "1" );

--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -9114,7 +9114,7 @@ int CTFPlayer::OnTakeDamage( const CTakeDamageInfo &inputInfo )
 				pRandomInternalOrgan->KeyValue( "origin", buf );
 				Q_snprintf( buf, sizeof( buf ), "%.10f %.10f %.10f", GetAbsAngles().x, GetAbsAngles().y, GetAbsAngles().z );
 				pRandomInternalOrgan->KeyValue( "angles", buf );
-				if (TFGameRules()->IsMannVsMachineMode() && GetTeamNumber() == TF_TEAM_PVE_INVADERS && BloodColor() == DONT_BLEED)
+				if ( TFGameRules()->IsMannVsMachineMode() && GetTeamNumber() == TF_TEAM_PVE_INVADERS && BloodColor() == DONT_BLEED && TFObjectiveResource()->GetMvMEventPopfileType() != MVM_EVENT_POPFILE_HALLOWEEN )
 				{
 					//robots don't have spleens....
 					pRandomInternalOrgan->KeyValue( "model", "models/player/gibs/gibs_bolt.mdl" );

--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -2775,7 +2775,7 @@ void CTFPlayer::PrecacheMvM()
 
 	PrecacheModel( "models/bots/tw2/boss_bot/twcarrier_addon.mdl" );
     
-    PrecacheModel( "models/player/gibs/gibs_bolt.mdl" );
+	PrecacheModel( "models/player/gibs/gibs_bolt.mdl" );
 
 	PrecacheParticleSystem( "bot_impact_light" );
 	PrecacheParticleSystem( "bot_impact_heavy" );


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description

When using the Vita-Saw in MVM, it spawns a spleen despite the robots being, well, robots. This PR makes robots spawn a bolt gib rather than a spleen in MVM.