### PR TITLE
[ALL] Sync new SP bsp limits to MP.

### DIFF
--- a/src/public/bspfile.h
+++ b/src/public/bspfile.h
@@ -57,12 +57,12 @@
 // Common limits
 // leaffaces, leafbrushes, planes, and verts are still bounded by
 // 16 bit short limits
-#define	MAX_MAP_MODELS					1024
-#define	MAX_MAP_BRUSHES					8192
+#define	MAX_MAP_MODELS					2048
+#define	MAX_MAP_BRUSHES					16384
 #define	MAX_MAP_ENTITIES				8192
-#define	MAX_MAP_TEXINFO					12288
-#define MAX_MAP_TEXDATA					2048
-#define MAX_MAP_DISPINFO				2048
+#define	MAX_MAP_TEXINFO					16384
+#define MAX_MAP_TEXDATA					8096
+#define MAX_MAP_DISPINFO				8096
 #define MAX_MAP_DISP_VERTS				( MAX_MAP_DISPINFO * ((1<<MAX_MAP_DISP_POWER)+1) * ((1<<MAX_MAP_DISP_POWER)+1) )
 #define MAX_MAP_DISP_TRIS				( (1 << MAX_MAP_DISP_POWER) * (1 << MAX_MAP_DISP_POWER) * 2 )
 #define MAX_DISPVERTS					NUM_DISP_POWER_VERTS( MAX_MAP_DISP_POWER )


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
In the Half-Life 2 anniversary update, many limits have been raised, which is especially useful for mappers since it gives them more freedom to create levels. The limits by today's standards are very low; this is not 2004, and people have much more powerful PCs, so increasing the BSP limits is not a threat. Note: CS:GO, Portal 2, and Garry's Mod already have these increased limits, so it won't cause instability while playing on servers.

```
Models 1024 -> 2048,
Brushes 8192 -> 16384, 
TexInfo 12288 -> 16384, 
TexData 2048 -> 8096, 
DispInfo 2048 -> 8096.
```
