### PR TITLE
Fix net_graph not rounding interp to nearest tick

### DIFF
--- a/src/game/client/vgui_netgraphpanel.cpp
+++ b/src/game/client/vgui_netgraphpanel.cpp
@@ -768,10 +768,10 @@ void CNetGraphPanel::DrawTextFields( int graphvalue, int x, int y, int w, netban
 
 	g_pMatSystemSurface->DrawColoredText( font, x, y, GRAPH_RED, GRAPH_GREEN, GRAPH_BLUE, 255, "%s", sz );
 
-	Q_snprintf( sz, sizeof( sz ), "lerp: %5.1f ms", GetClientInterpAmount() * 1000.0f );
+	Q_snprintf( sz, sizeof( sz ), "lerp: %5.1f ms", ROUND_TO_TICKS( GetClientInterpAmount() ) * 1000.0f );
 
 	int interpcolor[ 3 ] = { (int)GRAPH_RED, (int)GRAPH_GREEN, (int)GRAPH_BLUE }; 
-	float flInterp = GetClientInterpAmount();
+	float flInterp = ROUND_TO_TICKS( GetClientInterpAmount() );
 	if ( flInterp > 0.001f )
 	{
 		// Server framerate is lower than interp can possibly deal with
@@ -782,7 +782,7 @@ void CNetGraphPanel::DrawTextFields( int graphvalue, int x, int y, int w, netban
 			interpcolor[ 2 ] = 31;
 		}
 		// flInterp is below recommended setting!!!
-		else if ( flInterp < ( 2.0f / cl_updaterate->GetFloat() ) )
+		else if ( flInterp < ROUND_TO_TICKS( 2.0f / cl_updaterate->GetFloat() ) )
 		{
 			interpcolor[ 0 ] = 255;
 			interpcolor[ 1 ] = 125;


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
Currently, net_graph is the only place in the entire codebase where the player's cl_interp value is not rounded to the nearest tick instead displaying the raw value of `GetClientInterpAmount()`. This PR fixes that by adding `ROUND_TO_TICKS` to the code that displays it on net_graph.

Because I know that interp is a touchy subject inside the TF2 community and as such I'd like to cover my bases, I would like to clarify that this PR _DOES NOT_ change interpolation or cl_interp in any way shape or form. This is a consistency fix to make net_graph show the same client interp value that the rest of the game reads.
Over the years many people have experimented with interp values in attempting to find the best value for gameplay, and frankly I've seen quite a few people stand by interp values which are technically invalid, its only fair to show them what they're actually getting.
For further clarification, interp is calculated by taking the maximum value of cl_interp and cl_interp_ratio/cl_updaterate, and then that value is rounded to the nearest tick.

There are a couple odd little things that I also would like to mention:
the function that is used to convert interp in ms to ticks, `TIME_TO_TICKS` is `(int)( 0.5f + (float)(dt) / TICK_INTERVAL )`. `dt` is the input, and `TICK_INTERVAL` is set to 0.15, which notably is slightly off from how long 1 tick is supposed to take with an cmdrate/updaterate of 66. Because of this, players used to seeing numbers like 15.2ms on their net_graph will now see 15ms instead.
Also in case people who are not programmers are reading this, the `(int)` on the left of that equation converts the whole thing to an integer, or whole number, so you can't get a value like "1.5" ticks.
And lastly, the default settings of cl_interp 0.1 and cmdrate/updaterate of 20 is actually technically 105ms lerp, which I think is kind of funny
![image](https://github.com/user-attachments/assets/10eb11da-afe5-477b-8674-298bfd841868)

