### PR TITLE
[TF2] Fix the weapon being invisible after the stun period expires

### DIFF
--- a/src/game/shared/tf/tf_player_shared.cpp
+++ b/src/game/shared/tf/tf_player_shared.cpp
@@ -7361,6 +7361,11 @@ void CTFPlayerShared::OnRemoveStunned( void )
 #endif
 
 	m_pOuter->TeamFortress_SetSpeed();
+
+	if ( m_pOuter->GetActiveWeapon() && !InCond( TF_COND_TAUNTING ) && !InCond( TF_COND_HALLOWEEN_KART ) )
+	{
+		m_pOuter->GetActiveWeapon()->SetWeaponVisible( true );
+	}
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
When a stun is applied to the player, the weapon is set to be invisible. But after the stun is over, there isn't any code to set the weapon back to the visible state. This PR fixes this.

Before:

https://github.com/user-attachments/assets/c056985f-caa5-45dd-8a4a-134889212ec9

After:

https://github.com/user-attachments/assets/8612d024-d737-4cc0-9d6a-82fc5bf37cdc

