### PR TITLE
[TF2] Add `mp_timelimit_min` to control the min time limit required to switch maps after a round ends

### DIFF
--- a/src/game/shared/multiplay_gamerules.cpp
+++ b/src/game/shared/multiplay_gamerules.cpp
@@ -88,6 +88,7 @@ ConVar mp_timelimit( "mp_timelimit", "0", FCVAR_NOTIFY|FCVAR_REPLICATED, "game t
 					, MPTimeLimitCallback 
 #endif
 					);
+ConVar mp_timelimit_min( "mp_timelimit_min", "5", FCVAR_NOTIFY|FCVAR_REPLICATED, "Minimum timelimit (in minutes) when the map should end after a round ends." );
 
 ConVar fraglimit( "mp_fraglimit","0", FCVAR_NOTIFY|FCVAR_REPLICATED, "The number of kills at which the map ends");
 

--- a/src/game/shared/teamplayroundbased_gamerules.cpp
+++ b/src/game/shared/teamplayroundbased_gamerules.cpp
@@ -1170,9 +1170,8 @@ bool CTeamplayRoundBasedRules::CheckTimeLimit( bool bAllowEnd /*= true*/ )
 
 	if ( ( mp_timelimit.GetInt() > 0 && CanChangelevelBecauseOfTimeLimit() ) || m_bChangelevelAfterStalemate )
 	{
-		// If there's less than 5 minutes to go, just switch now. This avoids the problem
-		// of sudden death modes starting shortly after a new round starts.
-		const int iMinTime = 5;
+		extern ConVar mp_timelimit_min;
+		int iMinTime = mp_timelimit_min.GetInt();
 		bool bSwitchDueToTime = ( mp_timelimit.GetInt() > iMinTime && GetTimeLeft() < (iMinTime * 60) );
 
 		if ( IsInTournamentMode() == true  )


### PR DESCRIPTION
### Notes:
- The following doesn't include Arena or Tournament mode because Sudden Death cannot occur in these modes
- Time limit refers to the map time remaining from `mp_timelimit`

### Proposal
Currently, once a round ends and the time limit is below a hardcoded 5 minutes, the map will change rather than playing out the remaining map time, and if `mp_match_end_at_timelimit 0` then the full round would play out before switching maps. This PR proposes a new convar `mp_timelimit_min (default: 5)` that allows server operators to change the minimum time limit to any number they'd like. The requirement of `mp_timelimit_min` being under the value of `mp_timelimit` is still required.

### Theory Behind The Old Hardcoded Value
In September of 2007 there was a patch note `When a round finishes, if there are less than 5 minutes left on the time limit, the server now goes ahead and switches level right away, instead of going into Sudden Death.`, wherein the hardcoded minimum time limit was most likely to have been added. There was also a comment left next to the code explaining why this change was made. `If there's less than 5 minutes to go, just switch now. This avoids the problem of sudden death modes starting shortly after a new round starts.` 

Sudden Death will trigger under two conditions
1. During an active round if `mp_match_end_at_timelimit 1` and the time limit hits 0
2. During an active round if `mp_stalemate_enable 1` and a stalemate occurs due to the round timer running out of time

### Why I Believe The Hardcoded Value Is Outdated
In January of 2008, `mp_stalemate_enable (default: 0)` was added for server operators to decide if they want Sudden Death to occur. However, the hardcoded minimum time limit of 5 minutes still takes effect regardless of `mp_stalemate_enable`'s value. This doesn't make sense because the comment suggests that the minimum time limit of 5 minutes was set _specifically_ to prevent Sudden Death from occuring when rounds were given less than 5 minutes to play out. In 2025 where server operators have the choice of enabling Sudden Death, and when Sudden Death is off by default, it makes sense to me that server operators should have the ability to modify the minimum time limit. For example, if `tf_timelimit_min 0` maps can run the full `mp_timelimit` and start new rounds up until the very last second before changing maps. Any rounds which start in the last few seconds could be considered a bonus round with `mp_match_end_at_timelimit 0`. Should servers want Sudden Death enabled then the default value of `mp_timelimit_min 5` is there to accomodate them. Servers have been running with this minimum time limit for over a decade and a half so I believe having the default value mimic the hardcoded value of 5 is justified.

### Video Preview
**Note: When the scoreboard appears and my weapon disappears, that means the server is going to changelevel. `mp_bonusroundtime` is set to 5 seconds**

https://github.com/user-attachments/assets/8607fffd-7b8e-4477-88d5-4cb122b673c5

