### PR TITLE
[VScript] Add ability to send UserMessages

### DIFF
--- a/src/game/server/vscript_server.h
+++ b/src/game/server/vscript_server.h
@@ -72,6 +72,60 @@ public:
 	KeyValues *m_pKeyValues;	// actual KeyValue entity
 };
 
+// ----------------------------------------------------------------------------
+// Player Messages access
+// ----------------------------------------------------------------------------
+#define MAX_SCRIPT_USERMESSAGE_DATA 48
+
+enum eScriptPlayerMessageType {
+	TYPE_NULL,
+	TYPE_BYTE,
+	TYPE_CHAR,
+	TYPE_SHORT,
+	TYPE_WORD,
+	TYPE_LONG,
+	TYPE_FLOAT,
+	TYPE_ANGLE,
+	TYPE_COORD,
+	TYPE_VEC3COORD,
+	TYPE_VEC3NORMAL,
+	TYPE_ANGLES,
+	TYPE_STRING,
+	TYPE_BOOL,
+	TYPE_MAX
+};
+
+class CScriptUserMessage
+{
+public:
+	CScriptUserMessage( const char* szMessageName );
+
+	void Execute( HSCRIPT filterParams );
+
+	void WriteByte( int iValue );
+	void WriteChar( int iValue );
+	void WriteShort( int iValue );
+	void WriteWord( int iValue );
+	void WriteLong( int iValue );
+	void WriteFloat( float flValue );
+	void WriteAngle( float flValue );
+	void WriteCoord( float flValue );
+	void WriteVec3Coord( const Vector& rgflValue );
+	void WriteVec3Normal( const Vector& rgflValue );
+	void WriteAngles( const QAngle& rgflValue );
+	void WriteString( const char* szValue );
+	void WriteBool( bool bValue );
+
+private:
+	void WriteValue( const char* szValue, int iType );
+	
+	char m_szMessageName[64];
+
+	int iDataCount = 0;
+	char m_szDataValues[MAX_SCRIPT_USERMESSAGE_DATA][512];
+	int m_iDataTypes[MAX_SCRIPT_USERMESSAGE_DATA];
+};
+
 class CVScriptGameEventListener : public CGameEventListener
 {
 public:


### PR DESCRIPTION
# Description
This PR adds the `CScriptUserMessage` class which allows VScript to write data to an instance of this class and then call a member function to execute the message inside.
This would allow scripters to call User Messages only called by certain entities like `game_text`, `game_text_tf`, `env_shake` without the need to spawn them or messages that are currently impossible to call with VScript like `ShowMenu`, `VGUIMenu` and various others.

# Usage
To execute a User Message in VScript, the user will call the global function `UserMessageBegin()` which takes a parameter for the message name.
After that, they can write any data they wish and then call the `Execute()` member function with a filter parameter.
This way, User Messages can be stored, modified and executed at any point in time.

# Example Script
```
local UserMessage = UserMessageBegin("KeyHintText")
UserMessage.WriteByte(1)
local UserMessageInstance = UserMessage

UserMessage.WriteString("%+attack% Press this key.")
UserMessageInstance.WriteString("%+attack2% Or this key.")

UserMessage.Execute({
	filter_type = RECIPIENT_FILTER_SINGLE_PLAYER
	filter_entity = GetPlayerFromUserID(2)
})

UserMessage.Execute({
	filter_type = RECIPIENT_FILTER_SINGLE_PLAYER
	filter_entity = GetPlayerFromUserID(3)
})

UserMessageInstance.Execute({
	filter_type = RECIPIENT_FILTER_SINGLE_PLAYER
	filter_entity = GetPlayerFromUserID(4)
})
```