### PR TITLE
all games: Add sv_infinite_ammo ConVar

### DIFF
--- a/src/game/shared/baseplayer_shared.cpp
+++ b/src/game/shared/baseplayer_shared.cpp
@@ -298,19 +298,22 @@ void CBasePlayer::ItemPostFrame()
 	{
 		CBaseCombatWeapon* pWeapon = GetActiveWeapon();
 
-		// dont give clip ammo if set higher than 1 -copperpixel
+		// only refill clip when sv_infinite_ammo == 1 -copperpixel
 		if( sv_infinite_ammo.GetInt() == 1 )
 		{
 #ifdef TF_DLL
-			CTFWeaponBase* pTFWeapon = static_cast< CTFWeaponBase* >( pWeapon );
-			if( pTFWeapon->IsEnergyWeapon() )
+			CTFWeaponBase* pTFWeapon = dynamic_cast< CTFWeaponBase* >( pWeapon );
+			if( pTFWeapon )
 			{
-				pTFWeapon->Energy_SetEnergy( pTFWeapon->Energy_GetMaxEnergy() );
-			}
-			else
-			{
-				pTFWeapon->m_iClip1 = pTFWeapon->GetMaxClip1();
-				pTFWeapon->m_iClip2 = pTFWeapon->GetMaxClip2();
+				if( pTFWeapon->IsEnergyWeapon() )
+				{
+					pTFWeapon->WeaponRegenerate();
+				}
+				else
+				{
+					pTFWeapon->m_iClip1 = pTFWeapon->GetMaxClip1();
+					pTFWeapon->m_iClip2 = pTFWeapon->GetMaxClip2();
+				}
 			}
 #else
 			pWeapon->m_iClip1 = pWeapon->GetMaxClip1();
@@ -343,12 +346,16 @@ void CBasePlayer::ItemPostFrame()
 		CTFPlayer* pTFPlayer = ToTFPlayer( this );
 		if( pTFPlayer )
 		{
-			pTFPlayer->GiveAmmo( 200, TF_AMMO_METAL, true );			// metal
-			pTFPlayer->m_Shared.AddToSpyCloakMeter( 100.0f, true );		// spy cloak
-			pTFPlayer->AddToSpyKnife( 100.0f, true );					// spy-cicle recharge 
-			pTFPlayer->m_Shared.SetDemomanChargeMeter( 100.0f );		// shields charge
-			pTFPlayer->m_Shared.SetScoutEnergyDrinkMeter( 100.0f );		// bonk/crit-a-cola
-			pTFPlayer->m_Shared.SetScoutHypeMeter( 100.0f );			// soda popper hype
+			pTFPlayer->GiveAmmo( pTFPlayer->GetMaxAmmo( TF_AMMO_METAL ), TF_AMMO_METAL, true, kAmmoSource_Resupply );
+			pTFPlayer->AddToSpyKnife( 100.0f, true );
+			pTFPlayer->m_Shared.SetSpyCloakMeter( 100.0f );
+			pTFPlayer->m_Shared.SetScoutHypeMeter( 100.0f );
+			pTFPlayer->m_Shared.SetDemomanChargeMeter( 100.0f );
+			pTFPlayer->m_Shared.SetRageMeter( 100.f );
+			for( int i = FIRST_LOADOUT_SLOT_WITH_CHARGE_METER; i <= LAST_LOADOUT_SLOT_WITH_CHARGE_METER; ++i )
+			{
+				pTFPlayer->m_Shared.SetItemChargeMeter( ( loadout_positions_t )i, 100.f );
+			}
 		}
 #endif
 	}

--- a/src/game/shared/baseplayer_shared.cpp
+++ b/src/game/shared/baseplayer_shared.cpp
@@ -301,8 +301,21 @@ void CBasePlayer::ItemPostFrame()
 		// dont give clip ammo if set higher than 1 -copperpixel
 		if( sv_infinite_ammo.GetInt() == 1 )
 		{
+#ifdef TF_DLL
+			CTFWeaponBase* pTFWeapon = static_cast< CTFWeaponBase* >( pWeapon );
+			if( pTFWeapon->IsEnergyWeapon() )
+			{
+				pTFWeapon->Energy_SetEnergy( pTFWeapon->Energy_GetMaxEnergy() );
+			}
+			else
+			{
+				pTFWeapon->m_iClip1 = pTFWeapon->GetMaxClip1();
+				pTFWeapon->m_iClip2 = pTFWeapon->GetMaxClip2();
+			}
+#else
 			pWeapon->m_iClip1 = pWeapon->GetMaxClip1();
 			pWeapon->m_iClip2 = pWeapon->GetMaxClip2();
+#endif
 		}
 
 		int iPrimaryAmmoType = pWeapon->GetPrimaryAmmoType();

--- a/src/game/shared/baseplayer_shared.cpp
+++ b/src/game/shared/baseplayer_shared.cpp
@@ -320,6 +320,20 @@ void CBasePlayer::ItemPostFrame()
 				true
 			);
 		}
+
+#ifdef TF_DLL
+		// tf: additionally replenish spy cloak, engineer metal, etc. -copperpixel
+		CTFPlayer* pTFPlayer = ToTFPlayer( this );
+		if( pTFPlayer )
+		{
+			pTFPlayer->GiveAmmo( 200, TF_AMMO_METAL, false );		// metal
+			pTFPlayer->m_Shared.AddToSpyCloakMeter( 100.0f, true ); // spy cloak
+			pTFPlayer->AddToSpyKnife( 100.0f, true );				// spy-cicle recharge 
+			pTFPlayer->m_Shared.SetDemomanChargeMeter( 100.0f );	// shields charge
+			pTFPlayer->m_Shared.SetScoutEnergyDrinkMeter( 100.0f ); // bonk/crit-a-cola
+			pTFPlayer->m_Shared.SetScoutHypeMeter( 100.0f );		// soda popper hype
+		}
+#endif
 	}
 #else
 	// NOTE: If we ever support full impulse commands on the client,

--- a/src/game/shared/baseplayer_shared.cpp
+++ b/src/game/shared/baseplayer_shared.cpp
@@ -330,12 +330,12 @@ void CBasePlayer::ItemPostFrame()
 		CTFPlayer* pTFPlayer = ToTFPlayer( this );
 		if( pTFPlayer )
 		{
-			pTFPlayer->GiveAmmo( 200, TF_AMMO_METAL, false );		// metal
-			pTFPlayer->m_Shared.AddToSpyCloakMeter( 100.0f, true ); // spy cloak
-			pTFPlayer->AddToSpyKnife( 100.0f, true );				// spy-cicle recharge 
-			pTFPlayer->m_Shared.SetDemomanChargeMeter( 100.0f );	// shields charge
-			pTFPlayer->m_Shared.SetScoutEnergyDrinkMeter( 100.0f ); // bonk/crit-a-cola
-			pTFPlayer->m_Shared.SetScoutHypeMeter( 100.0f );		// soda popper hype
+			pTFPlayer->GiveAmmo( 200, TF_AMMO_METAL, true );			// metal
+			pTFPlayer->m_Shared.AddToSpyCloakMeter( 100.0f, true );		// spy cloak
+			pTFPlayer->AddToSpyKnife( 100.0f, true );					// spy-cicle recharge 
+			pTFPlayer->m_Shared.SetDemomanChargeMeter( 100.0f );		// shields charge
+			pTFPlayer->m_Shared.SetScoutEnergyDrinkMeter( 100.0f );		// bonk/crit-a-cola
+			pTFPlayer->m_Shared.SetScoutHypeMeter( 100.0f );			// soda popper hype
 		}
 #endif
 	}

--- a/src/game/shared/baseplayer_shared.cpp
+++ b/src/game/shared/baseplayer_shared.cpp
@@ -319,8 +319,8 @@ void CBasePlayer::ItemPostFrame()
 		if( iSecondaryAmmoType >= 0 )
 		{
 			GiveAmmo(
-				GetAmmoDef()->MaxCarry( iPrimaryAmmoType ),
-				GetAmmoDef()->GetAmmoOfIndex( iPrimaryAmmoType )->pName,
+				GetAmmoDef()->MaxCarry( iSecondaryAmmoType ),
+				GetAmmoDef()->GetAmmoOfIndex( iSecondaryAmmoType )->pName,
 				true
 			);
 		}

--- a/src/game/shared/baseplayer_shared.cpp
+++ b/src/game/shared/baseplayer_shared.cpp
@@ -299,14 +299,27 @@ void CBasePlayer::ItemPostFrame()
 		CBaseCombatWeapon* pWeapon = GetActiveWeapon();
 
 		pWeapon->m_iClip1 = pWeapon->GetMaxClip1();
+		pWeapon->m_iClip2 = pWeapon->GetMaxClip2();
+
 		int iPrimaryAmmoType = pWeapon->GetPrimaryAmmoType();
 		if( iPrimaryAmmoType >= 0 )
-			SetAmmoCount( GetAmmoDef()->MaxCarry( iPrimaryAmmoType ), iPrimaryAmmoType );
+		{
+			GiveAmmo( 
+				GetAmmoDef()->MaxCarry( iPrimaryAmmoType ),
+				GetAmmoDef()->GetAmmoOfIndex( iPrimaryAmmoType )->pName,
+				true
+			);
+		}
 
-		pWeapon->m_iClip2 = pWeapon->GetMaxClip2();
 		int iSecondaryAmmoType = pWeapon->GetSecondaryAmmoType();
 		if( iSecondaryAmmoType >= 0 )
-			SetAmmoCount( GetAmmoDef()->MaxCarry( iSecondaryAmmoType ), iSecondaryAmmoType );
+		{
+			GiveAmmo(
+				GetAmmoDef()->MaxCarry( iPrimaryAmmoType ),
+				GetAmmoDef()->GetAmmoOfIndex( iPrimaryAmmoType )->pName,
+				true
+			);
+		}
 	}
 #else
 	// NOTE: If we ever support full impulse commands on the client,

--- a/src/game/shared/baseplayer_shared.cpp
+++ b/src/game/shared/baseplayer_shared.cpp
@@ -32,6 +32,7 @@
 	#include "doors.h"
 	#include "ai_basenpc.h"
 	#include "env_zoom.h"
+	#include "ammodef.h"
 
 	extern int TrainSpeed(int iSpeed, int iMax);
 	
@@ -56,7 +57,9 @@
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"
 
-#if defined(GAME_DLL) && !defined(_XBOX)
+#if defined(GAME_DLL)
+	ConVar sv_infinite_ammo( "sv_infinite_ammo", "0", FCVAR_CHEAT, "Player's active weapon will never run out of ammo" );
+#if !defined(_XBOX)
 	extern ConVar sv_pushaway_max_force;
 	extern ConVar sv_pushaway_force;
 	extern ConVar sv_turbophysics;
@@ -85,6 +88,7 @@
 			return g_pGameRules->CanEntityBeUsePushed( pEntity );
 		}
 	};
+#endif
 #endif
 
 #ifdef CLIENT_DLL
@@ -289,6 +293,21 @@ void CBasePlayer::ItemPostFrame()
 
 #if !defined( CLIENT_DLL )
 	ImpulseCommands();
+
+	if( sv_infinite_ammo.GetBool() && GetActiveWeapon() )
+	{
+		CBaseCombatWeapon* pWeapon = GetActiveWeapon();
+
+		pWeapon->m_iClip1 = pWeapon->GetMaxClip1();
+		int iPrimaryAmmoType = pWeapon->GetPrimaryAmmoType();
+		if( iPrimaryAmmoType >= 0 )
+			SetAmmoCount( GetAmmoDef()->MaxCarry( iPrimaryAmmoType ), iPrimaryAmmoType );
+
+		pWeapon->m_iClip2 = pWeapon->GetMaxClip2();
+		int iSecondaryAmmoType = pWeapon->GetSecondaryAmmoType();
+		if( iSecondaryAmmoType >= 0 )
+			SetAmmoCount( GetAmmoDef()->MaxCarry( iSecondaryAmmoType ), iSecondaryAmmoType );
+	}
 #else
 	// NOTE: If we ever support full impulse commands on the client,
 	// remove this line and call ImpulseCommands instead.

--- a/src/game/shared/baseplayer_shared.cpp
+++ b/src/game/shared/baseplayer_shared.cpp
@@ -58,7 +58,7 @@
 #include "tier0/memdbgon.h"
 
 #if defined(GAME_DLL)
-	ConVar sv_infinite_ammo( "sv_infinite_ammo", "0", FCVAR_CHEAT, "Player's active weapon will never run out of ammo" );
+	ConVar sv_infinite_ammo( "sv_infinite_ammo", "0", FCVAR_CHEAT, "Player's active weapon will never run out of ammo. If set to 2 then player has infinite total ammo but still has to reload the magazine." );
 #if !defined(_XBOX)
 	extern ConVar sv_pushaway_max_force;
 	extern ConVar sv_pushaway_force;
@@ -298,13 +298,17 @@ void CBasePlayer::ItemPostFrame()
 	{
 		CBaseCombatWeapon* pWeapon = GetActiveWeapon();
 
-		pWeapon->m_iClip1 = pWeapon->GetMaxClip1();
-		pWeapon->m_iClip2 = pWeapon->GetMaxClip2();
+		// dont give clip ammo if set higher than 1 -copperpixel
+		if( sv_infinite_ammo.GetInt() == 1 )
+		{
+			pWeapon->m_iClip1 = pWeapon->GetMaxClip1();
+			pWeapon->m_iClip2 = pWeapon->GetMaxClip2();
+		}
 
 		int iPrimaryAmmoType = pWeapon->GetPrimaryAmmoType();
 		if( iPrimaryAmmoType >= 0 )
 		{
-			GiveAmmo( 
+			GiveAmmo(
 				GetAmmoDef()->MaxCarry( iPrimaryAmmoType ),
 				GetAmmoDef()->GetAmmoOfIndex( iPrimaryAmmoType )->pName,
 				true


### PR DESCRIPTION
This PR implements the `sv_infinite_ammo` cheat-protected ConVar from Left 4 Dead/Alien Swarm. When enabled, it prevents the player's active weapon from depleting ammo.
Furthermore, added functionality from Counter-Strike : GO where setting the ConVar to 2 or higher will only replenish the weapon's reserve (so the player still has to reload).

In Team Fortress 2, it also refills metal and weapon/item charges.

Partially closes https://github.com/ValveSoftware/Source-1-Games/issues/3673, closes https://github.com/ValveSoftware/Source-1-Games/issues/3828