### PR TITLE
[TF2] Improve ammo display on target ID

### DIFF
--- a/src/game/client/tf/c_tf_player.cpp
+++ b/src/game/client/tf/c_tf_player.cpp
@@ -3695,6 +3695,7 @@ END_RECV_TABLE()
 //-----------------------------------------------------------------------------
 BEGIN_RECV_TABLE_NOBASE( C_TFPlayer, DT_TFSendHealersDataTable )
 	RecvPropInt( RECVINFO( m_nActiveWpnClip ) ),
+	RecvPropInt( RECVINFO( m_nActiveWpnReserve ) ),
 END_RECV_TABLE()
 
 IMPLEMENT_CLIENTCLASS_DT( C_TFPlayer, DT_TFPlayer, CTFPlayer )
@@ -9724,14 +9725,23 @@ void C_TFPlayer::GetTargetIDDataString( bool bIsDisguised, OUT_Z_BYTECAP(iMaxLen
 				}
 
 				// Show target's clip state to attached medics
-				if ( !sDataString[0] && m_nActiveWpnClip >= 0 )
+				if ( !sDataString[0] && m_nActiveWpnClip != UINT16_MAX )
 				{
 					C_TFPlayer *pTFHealTarget = ToTFPlayer( pLocalPlayer->MedicGetHealTarget() );
 					if ( pTFHealTarget && pTFHealTarget == this )
 					{
 						wchar_t wszClip[10];
-						V_snwprintf( wszClip, ARRAYSIZE(wszClip) - 1, L"%d", m_nActiveWpnClip );
-						g_pVGuiLocalize->ConstructString( sDataString, iMaxLenInBytes, g_pVGuiLocalize->Find( "#TF_playerid_ammo" ), 1, wszClip );
+						V_snwprintf( wszClip, ARRAYSIZE( wszClip ) - 1, L"%d", m_nActiveWpnClip );
+						if ( m_nActiveWpnReserve != UINT16_MAX )
+						{
+							wchar_t wszReserve[10];
+							V_snwprintf( wszReserve, ARRAYSIZE( wszReserve ) - 1, L"%d", m_nActiveWpnReserve );
+							g_pVGuiLocalize->ConstructString( sDataString, iMaxLenInBytes, g_pVGuiLocalize->Find( "#TF_playerid_ammo_reserve" ), 2, wszClip, wszReserve );
+						}
+						else
+						{
+							g_pVGuiLocalize->ConstructString( sDataString, iMaxLenInBytes, g_pVGuiLocalize->Find("#TF_playerid_ammo" ), 1, wszClip );
+						}
 						bIsAmmoData = true;
 					}
 				}

--- a/src/game/client/tf/c_tf_player.h
+++ b/src/game/client/tf/c_tf_player.h
@@ -874,6 +874,7 @@ private:
 
 	// Medic healtarget active weapon ammo/clip count
 	uint16	m_nActiveWpnClip;
+	uint16	m_nActiveWpnReserve;
 	
 	// Blast jump whistle
 	CSoundPatch		*m_pBlastJumpLoop;

--- a/src/game/server/tf/tf_player.h
+++ b/src/game/server/tf/tf_player.h
@@ -747,43 +747,45 @@ public:
 	void				ScriptSetCondDuration( int nCond, float flNewDuration );
 	HSCRIPT				ScriptGetDisguiseTarget();
 
-	bool				ScriptIsCarryingRune()						{ return m_Shared.IsCarryingRune(); }
-	bool				ScriptIsCritBoosted( void ) const			{ return m_Shared.IsCritBoosted(); }
-	bool				ScriptIsInvulnerable( void ) const			{ return m_Shared.IsInvulnerable(); }
-	bool				ScriptIsStealthed( void ) const				{ return m_Shared.IsStealthed(); }
-	bool				ScriptCanBeDebuffed( void ) const			{ return m_Shared.CanBeDebuffed(); }
-	bool				ScriptIsImmuneToPushback( void ) const		{ return m_Shared.IsImmuneToPushback(); }
-	int					ScriptGetDisguiseAmmoCount()				{ return m_Shared.GetDisguiseAmmoCount(); }
-	void				ScriptSetDisguiseAmmoCount( int nValue )	{ return m_Shared.SetDisguiseAmmoCount(nValue); }
-	int					ScriptGetDisguiseTeam()						{ return m_Shared.GetDisguiseTeam(); }
-	bool				ScriptIsFullyInvisible()					{ return m_Shared.IsFullyInvisible(); }
-	float				ScriptGetSpyCloakMeter()					{ return m_Shared.GetSpyCloakMeter(); }
-	void				ScriptSetSpyCloakMeter( float flValue )		{ return m_Shared.SetSpyCloakMeter( flValue ); }
-	bool				ScriptIsRageDraining()						{ return m_Shared.IsRageDraining(); }
-	float				ScriptGetRageMeter()						{ return m_Shared.GetRageMeter(); }
-	void				ScriptSetRageMeter( float flValue )			{ return m_Shared.SetRageMeter( flValue ); }
-	float				ScriptGetScoutHypeMeter()					{ return m_Shared.GetScoutHypeMeter(); }
-	void				ScriptSetScoutHypeMeter( float flValue )	{ return m_Shared.SetScoutHypeMeter( flValue ); }
-	bool				ScriptIsHypeBuffed()						{ return m_Shared.IsHypeBuffed(); }
-	bool				ScriptIsJumping()							{ return m_Shared.IsJumping(); }
-	bool				ScriptIsAirDashing()						{ return m_Shared.IsAirDashing(); }
-	bool				ScriptIsControlStunned()					{ return m_Shared.IsControlStunned(); }
-	bool				ScriptIsSnared()							{ return m_Shared.IsSnared(); }
-	int					ScriptGetCaptures() const					{ return m_Shared.GetCaptures( 0 ); }
-	int					ScriptGetDefenses() const					{ return m_Shared.GetDefenses( 0 ); }
-	int					ScriptGetDominations() const				{ return m_Shared.GetDominations( 0 ); }
-	int					ScriptGetRevenge() const					{ return m_Shared.GetRevenge( 0 ); }
-	int					ScriptGetBuildingsDestroyed() const			{ return m_Shared.GetBuildingsDestroyed( 0 ); }
-	int					ScriptGetHeadshots() const					{ return m_Shared.GetHeadshots( 0 ); }
-	int					ScriptGetBackstabs() const					{ return m_Shared.GetBackstabs( 0 ); }
-	int					ScriptGetHealPoints() const					{ return m_Shared.GetHealPoints( 0 ); }
-	int					ScriptGetInvulns() const					{ return m_Shared.GetInvulns( 0 ); }
-	int					ScriptGetTeleports() const					{ return m_Shared.GetTeleports( 0 ); }
-	int					ScriptGetResupplyPoints() const				{ return m_Shared.GetResupplyPoints( 0 ); }
-	int					ScriptGetKillAssists() const				{ return m_Shared.GetKillAssists( 0 ); }
-	int					ScriptGetBonusPoints() const				{ return m_Shared.GetBonusPoints( 0 ); }
-	void				ScriptResetScores()							{ m_Shared.ResetScores(); }
-	bool				ScriptIsParachuteEquipped()					{ return m_Shared.IsParachuteEquipped(); }
+	bool				ScriptIsCarryingRune()							{ return m_Shared.IsCarryingRune(); }
+	bool				ScriptIsCritBoosted( void ) const				{ return m_Shared.IsCritBoosted(); }
+	bool				ScriptIsInvulnerable( void ) const				{ return m_Shared.IsInvulnerable(); }
+	bool				ScriptIsStealthed( void ) const					{ return m_Shared.IsStealthed(); }
+	bool				ScriptCanBeDebuffed( void ) const				{ return m_Shared.CanBeDebuffed(); }
+	bool				ScriptIsImmuneToPushback( void ) const			{ return m_Shared.IsImmuneToPushback(); }
+	int					ScriptGetDisguiseAmmoCount()					{ return m_Shared.GetDisguiseAmmoCount(); }
+	void				ScriptSetDisguiseAmmoCount( int nValue )		{ return m_Shared.SetDisguiseAmmoCount(nValue); }
+	int					ScriptGetDisguiseAmmoReserveCount()				{ return m_Shared.GetDisguiseAmmoReserveCount(); }
+	void				ScriptSetDisguiseAmmoReserveCount( int nValue )	{ return m_Shared.SetDisguiseAmmoReserveCount(nValue); }
+	int					ScriptGetDisguiseTeam()							{ return m_Shared.GetDisguiseTeam(); }
+	bool				ScriptIsFullyInvisible()						{ return m_Shared.IsFullyInvisible(); }
+	float				ScriptGetSpyCloakMeter()						{ return m_Shared.GetSpyCloakMeter(); }
+	void				ScriptSetSpyCloakMeter( float flValue )			{ return m_Shared.SetSpyCloakMeter( flValue ); }
+	bool				ScriptIsRageDraining()							{ return m_Shared.IsRageDraining(); }
+	float				ScriptGetRageMeter()							{ return m_Shared.GetRageMeter(); }
+	void				ScriptSetRageMeter( float flValue )				{ return m_Shared.SetRageMeter( flValue ); }
+	float				ScriptGetScoutHypeMeter()						{ return m_Shared.GetScoutHypeMeter(); }
+	void				ScriptSetScoutHypeMeter( float flValue )		{ return m_Shared.SetScoutHypeMeter( flValue ); }
+	bool				ScriptIsHypeBuffed()							{ return m_Shared.IsHypeBuffed(); }
+	bool				ScriptIsJumping()								{ return m_Shared.IsJumping(); }
+	bool				ScriptIsAirDashing()							{ return m_Shared.IsAirDashing(); }
+	bool				ScriptIsControlStunned()						{ return m_Shared.IsControlStunned(); }
+	bool				ScriptIsSnared()								{ return m_Shared.IsSnared(); }
+	int					ScriptGetCaptures() const						{ return m_Shared.GetCaptures( 0 ); }
+	int					ScriptGetDefenses() const						{ return m_Shared.GetDefenses( 0 ); }
+	int					ScriptGetDominations() const					{ return m_Shared.GetDominations( 0 ); }
+	int					ScriptGetRevenge() const						{ return m_Shared.GetRevenge( 0 ); }
+	int					ScriptGetBuildingsDestroyed() const				{ return m_Shared.GetBuildingsDestroyed( 0 ); }
+	int					ScriptGetHeadshots() const						{ return m_Shared.GetHeadshots( 0 ); }
+	int					ScriptGetBackstabs() const						{ return m_Shared.GetBackstabs( 0 ); }
+	int					ScriptGetHealPoints() const						{ return m_Shared.GetHealPoints( 0 ); }
+	int					ScriptGetInvulns() const						{ return m_Shared.GetInvulns( 0 ); }
+	int					ScriptGetTeleports() const						{ return m_Shared.GetTeleports( 0 ); }
+	int					ScriptGetResupplyPoints() const					{ return m_Shared.GetResupplyPoints( 0 ); }
+	int					ScriptGetKillAssists() const					{ return m_Shared.GetKillAssists( 0 ); }
+	int					ScriptGetBonusPoints() const					{ return m_Shared.GetBonusPoints( 0 ); }
+	void				ScriptResetScores()								{ m_Shared.ResetScores(); }
+	bool				ScriptIsParachuteEquipped()						{ return m_Shared.IsParachuteEquipped(); }
 
 	int					ScriptGetPlayerClass()
 	{
@@ -1391,7 +1393,9 @@ private:
 	int					m_peakDamagePerSecond;
 
 	CNetworkVar( uint16, m_nActiveWpnClip );
+	CNetworkVar( uint16, m_nActiveWpnReserve );
 	uint16				m_nActiveWpnClipPrev;
+	uint16				m_nActiveWpnReservePrev;
 	float				m_flNextClipSendTime;
 
 	float				m_flWaterExitTime;

--- a/src/game/shared/tf/tf_player_shared.h
+++ b/src/game/shared/tf/tf_player_shared.h
@@ -389,6 +389,8 @@ public:
 	void	ProcessDisguiseImpulse( CTFPlayer *pPlayer );
 	int		GetDisguiseAmmoCount( void ) { return m_iDisguiseAmmo; }
 	void	SetDisguiseAmmoCount( int nValue ) { m_iDisguiseAmmo = nValue; }
+	int		GetDisguiseAmmoReserveCount( void ) { return m_iDisguiseAmmoReserve; }
+	void	SetDisguiseAmmoReserveCount( int nValue ) { m_iDisguiseAmmoReserve = nValue; }
 
 	bool	CanRecieveMedigunChargeEffect( medigun_charge_types eType ) const;
 #ifdef CLIENT_DLL
@@ -960,6 +962,7 @@ private:
 	CNetworkVar( int, m_nTeamTeleporterUsed ); // for disguised spies using enemy teleporters
 	CHandle<CTFPlayer>	m_hDesiredDisguiseTarget;
 	int m_iDisguiseAmmo;
+	int m_iDisguiseAmmoReserve;
 
 	bool m_bEnableSeparation;		// Keeps separation forces on when player stops moving, but still penetrating
 	Vector m_vSeparationVelocity;	// Velocity used to keep player separate from teammates


### PR DESCRIPTION
# Description
This PR makes multiple changes to how ammo displays on the TargetID Display, which appears when healing a patient.

1. Ammo count no longer displays on weapons without ammo
2. Reserve ammo shows up next to the clip ammo when available

These changes also apply to spy's disguises and two new VScript functions `GetDisguiseAmmoReserveCount()` and `SetDisguiseAmmoReserveCount()` have been added to access the disguise reserve ammo.
Similarly to how ammo appears for disguise weapons, the reserve is also randomized when viewed this way.

If this gets merged, a new language token needs to be added to show weapons with reserve ammo:
`"TF_playerid_ammo_reserve"				"    %s1 / %s2"`