### PR TITLE
[TF2] Fixed lunchbox items consuming ammo before applying effects and inconsistently switching weapons

### DIFF
--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -10728,22 +10728,6 @@ int CTFPlayer::OnTakeDamage_Alive( const CTakeDamageInfo &info )
 		}
 	}
 
-	// Prevents a sandwich ignore-ammo-while-taking-damage-and-eating alias exploit
-	if ( m_Shared.InCond( TF_COND_TAUNTING ) && m_Shared.GetTauntIndex() == TAUNT_BASE_WEAPON )
-	{
-		if ( IsPlayerClass( TF_CLASS_HEAVYWEAPONS ) )
-		{
-			CTFLunchBox *pLunchBox = dynamic_cast <CTFLunchBox *> ( m_Shared.GetActiveTFWeapon() );
-			if ( pLunchBox )
-			{
-				if ( ( pLunchBox->GetLunchboxType() != LUNCHBOX_CHOCOLATE_BAR ) && ( pLunchBox->GetLunchboxType() != LUNCHBOX_FISHCAKE ) )
-				{
-					pLunchBox->DrainAmmo( true );
-				}
-			}
-		}
-	}
-
 	// Fire a global game event - "player_hurt"
 	IGameEvent * event = gameeventmanager->CreateEvent( "player_hurt" );
 	if ( event )
@@ -18547,7 +18531,7 @@ void CTFPlayer::DoTauntAttack( void )
 		CTFWeaponBase *pActiveWeapon = m_Shared.GetActiveTFWeapon();
 		if ( pActiveWeapon && pActiveWeapon->GetWeaponID() == TF_WEAPON_LUNCHBOX )
 		{
-			CTFLunchBox *pLunchbox = (CTFLunchBox*)pActiveWeapon;
+			CTFLunchBox *pLunchbox = (CTFLunchBox *)pActiveWeapon;
 			pLunchbox->ApplyBiteEffects( this );
 		}
 
@@ -18634,32 +18618,37 @@ void CTFPlayer::DoTauntAttack( void )
 				float flDropDeadTime = ( 100.f / tf_scout_energydrink_consume_rate.GetFloat() ) + 1.f;	// Just in case.  Normally over in 8 seconds.
 
 				CTFLunchBox *pLunchbox = static_cast< CTFLunchBox* >( pActiveWeapon );
-				if ( pLunchbox && pLunchbox->GetLunchboxType() == LUNCHBOX_ADDS_MINICRITS )
+				if (pLunchbox)
 				{
-					m_Shared.AddCond( TF_COND_ENERGY_BUFF, flDropDeadTime );
-				}
-				else
-				{
-					m_Shared.AddCond( TF_COND_PHASE, flDropDeadTime );
-
-					if ( HasTheFlag() )
+					if ( pLunchbox->GetLunchboxType() == LUNCHBOX_ADDS_MINICRITS )
 					{
-						bool bShouldDrop = true;
-
-						// Always allow teams to hear each other in TD mode
-						if ( TFGameRules()->IsMannVsMachineMode() && GetTeamNumber() == TF_TEAM_PVE_INVADERS )
-						{
-							bShouldDrop = false;
-						}
-
-						if ( bShouldDrop )
-						{
-							DropFlag();
-						}
+						m_Shared.AddCond( TF_COND_ENERGY_BUFF, flDropDeadTime );
 					}
-				}
+					else
+					{
+						m_Shared.AddCond( TF_COND_PHASE, flDropDeadTime );
 
-				SelectLastItem();
+						if ( HasTheFlag() )
+						{
+							bool bShouldDrop = true;
+
+							// Always allow teams to hear each other in TD mode
+							if ( TFGameRules()->IsMannVsMachineMode() && GetTeamNumber() == TF_TEAM_PVE_INVADERS )
+							{
+								bShouldDrop = false;
+							}
+
+							if ( bShouldDrop )
+							{
+								DropFlag();
+							}
+						}
+
+					}
+
+					pLunchbox->DrainAmmo();
+					m_Shared.SetBiteEffectWasApplied();
+				}
 			}
 		}
 	}

--- a/src/game/shared/tf/tf_player_shared.cpp
+++ b/src/game/shared/tf/tf_player_shared.cpp
@@ -3991,15 +3991,6 @@ void CTFPlayerShared::OnAddTaunting( void )
 	// Unzoom if we are a sniper zoomed!
 	InstantlySniperUnzoom();
 
-	if ( ( m_pOuter->IsPlayerClass( TF_CLASS_HEAVYWEAPONS ) || m_pOuter->IsPlayerClass( TF_CLASS_SCOUT ) ) && GetTauntIndex() == TAUNT_BASE_WEAPON )
-	{
-		CTFLunchBox *pLunchBox = dynamic_cast <CTFLunchBox *> ( pWpn );
-		if ( pLunchBox )
-		{
-			pLunchBox->DrainAmmo();
-		}
-	}
-
 #ifdef GAME_DLL
 	m_pOuter->PlayWearableAnimsForPlaybackEvent( WAP_START_TAUNTING );
 #else
@@ -4037,23 +4028,55 @@ void CTFPlayerShared::OnRemoveTaunting( void )
 	}
 
 #ifdef GAME_DLL
-	// Switch to our melee weapon, if we are at the end of a type 2 lunchbox taunt.
-	if ( m_bBiteEffectWasApplied && InCond( TF_COND_CANNOT_SWITCH_FROM_MELEE ) )
+	
+	// Switch weapons after lunchbox effects were applied
+	if ( m_bBiteEffectWasApplied )
 	{
-		CBaseCombatWeapon *pWpn = m_pOuter->Weapon_GetSlot( TF_WPN_TYPE_MELEE );
-		if ( pWpn )
+		bool bSwitchWeapon = false;
+		// Switch to our melee weapon, if we are at the end of a type 2 lunchbox taunt or finished eating.
+		if ( InCond( TF_COND_CANNOT_SWITCH_FROM_MELEE ) )
 		{
-			m_pOuter->Weapon_Switch( pWpn );
+			CBaseCombatWeapon* pWpn = m_pOuter->Weapon_GetSlot( TF_WPN_TYPE_MELEE );
+			if ( pWpn )
+			{
+				m_pOuter->Weapon_Switch( pWpn );
+			}
+			else
+			{
+				// Safety net
+				RemoveCond( TF_COND_ENERGY_BUFF );
+				RemoveCond( TF_COND_CANNOT_SWITCH_FROM_MELEE );
+				bSwitchWeapon = true;
+			}
 		}
 		else
 		{
-			// Safety net
-			RemoveCond( TF_COND_ENERGY_BUFF );
-			RemoveCond( TF_COND_CANNOT_SWITCH_FROM_MELEE );
-		}
-	}
+			CBaseCombatWeapon *pActiveWpn = m_pOuter->GetActiveTFWeapon();
 
-	m_bBiteEffectWasApplied = false;
+			// Drink effects should always switch away
+			// Heavy might still be hungry, don't switch away if he has more lunchbox ammo
+			if ( InCond( TF_COND_ENERGY_BUFF ) || InCond( TF_COND_PHASE ) || ( pActiveWpn && !pActiveWpn->HasAnyAmmo() ) )
+			{
+				bSwitchWeapon = true;
+			}
+		}
+
+		// Switch to last weapon, otherwise the next best weapon
+		if ( bSwitchWeapon )
+		{
+			CBaseCombatWeapon *pLastWeapon = m_pOuter->GetLastWeapon();
+			if ( pLastWeapon && m_pOuter->Weapon_CanSwitchTo( pLastWeapon ) )
+			{
+				m_pOuter->Weapon_Switch( pLastWeapon );
+			}
+			else
+			{
+				m_pOuter->SwitchToNextBestWeapon( pLastWeapon );
+			}
+		}
+
+		m_bBiteEffectWasApplied = false;
+	}
 
 	if ( m_pOuter->m_hTauntItem != NULL )
 	{

--- a/src/game/shared/tf/tf_weapon_lunchbox.h
+++ b/src/game/shared/tf/tf_weapon_lunchbox.h
@@ -62,7 +62,7 @@ public:
 	virtual bool	DropAllowed( void );
 	int				GetLunchboxType( void ) const { int iMode = 0; CALL_ATTRIB_HOOK_INT( iMode, set_weapon_mode ); return iMode; };
 
-	void			DrainAmmo( bool bForceCooldown = false );
+	void			DrainAmmo( void );
 
 	virtual void	Detach( void ) OVERRIDE;
 	virtual bool	Holster( CBaseCombatWeapon *pSwitchingTo = NULL ) OVERRIDE;


### PR DESCRIPTION
# Bug Description
There is a bug with all lunchbox items where being forced out of your drinking/eating taunt **before** the item's effects have been applied, will consume ammo and keep your lunchbox item drawn with 0 ammo for the duration of the taunt before switching weapons. I'll first explain how the current lunchbox mechanics work, and then I'll explain the proposed changes I made to overall improve the way ammo is consumed, the way weapons are switched, and the time when conditions are applied.

# How Do Lunchboxes Currently Work?
## Mechanics
`1.` Once you begin your lunchbox taunt , `DrainAmmo()` is called.
`2.` Next, `m_flTauntAttackTime` is set to a future timestamp for the item's effects to be applied.
`3.` Then, once the current game time passes the timestamp, your effects are applied and `m_flTauntAttackTime` will be set to the next time the item's effects should be applied (ex: Healing items with multiple noms).
`4.` Finally, your taunt will end once your taunt finishes with the duration of `GetSceneDuration()`.
`5.` If conditions were applied, your weapons will be forcefully switched off of your lunchbox item.

Although this system does the job of applying effects during your taunt, it's very primitive and prone to bugs. If your taunt is interrupted before any effects are applied, only steps `1.` and `4.` are run, meaning you lose ammo, and gain nothing after your taunt ends. You'll also be put into an awkward state of holding out your lunchbox item out with 0 ammo for the rest of the duration that your taunt would have lasted. Only once that duration ends will the game switch your weapons automatically.

## Quirks
- **Sandvich Reskins & Banana** - Performing a lunchbox taunt with health missing will instantly consume your lunchbox ammo. These can be eaten continuously without consuming ammo if you begin eating while at full health, but taking any damage while eating will consume ammo **each time you take damage throughout your taunt**. Evidently, this was done to fix a bug back in 2010 [Fixed the Sandvich cooldown not occurring when the Heavy is hurt](https://wiki.teamfortress.com/wiki/October_6,_2010_Patch#Team_Fortress_2). But not so evidently, looking through the hundreds of bug videos on youtube from `before:2011`, I couldn't find any video sharing how that bug was produced.
- **Buffalo Steak** - Makes sure that you're forcefully swapped to your melee weapon once your item's effects have been applied. Otherwise if you can't swap to your melee, your effects will be removed when your taunt ends. This is done to prevent an exploit where you can use mini-crits from `TF_COND_ENERGY_BUFF` with your Minigun.
- **Unused Ammo Lunchbox** - This attribute is not only unused, but unfinished. It'll give you 25% of your reserve ammo for each nom, but it won't consume your Sandvich unless you're missing health. You can use this Sandvich by applying the `lunchbox adds minicrits` attribute with a value of `5` on the Sandvich. This attribute is an alias for [set_weapon_mode](https://gist.github.com/sigsegv-mvm/f72e3047c58dc2674493)

## Lunchbox Video
This video will show off bugs and failsafes for each item in this order:
`1. & 2. & 3. & 4.` **Bonk! & Crit-a-Cola & Dalokohs Bar & Buffalo Steak** - Loses ammo when interrupted early with no effect.
`4a.` - **Failsafe** - Without a melee weapon, you'll be forced onto your Minigun and you won't receive any conditions.
`5.` **Sandvich** - Loses ammo when interrupted early with no effect.
`5a.` - **Failsafe** - Every time you take damage while eating, your ammo will be consumed and your charge meter will reset.
`6.` - **Unused Ammo Sandvich** - Your Sandvich doesn't get consumed despite restoring your ammo.

**Note: After being interrupted, the game automatically switches my weapon to my Minigun only after my taunt's duration would be finished. I did not switch to my Minigun manually.**

https://github.com/user-attachments/assets/7408631e-e06c-4c23-a93a-beb53d904459

# My Proposed Lunchbox Mechanics
- Rather than immediately draining your ammo upon beginning a lunchbox taunt, your ammo will only be consumed **once you've received your item's effects for the first time**, not specifically your first 'nom'. 
- If your taunt is interrupted before you've received your item's effects, both your ammo and charge meter will remain unchanged. 
- If your taunt is interrupted after you've received your item's effects, you'll be automatically & instantly switched to your last weapon, if not your next best weapon to avoid awkwardly holding out your lunchbox item with 0 ammo in it. 
- However, if your taunt is interrupted or finishes after you've received your item's effects with more than 0 ammo left, and your lunchbox item is the Sandvich, Banana, or Dalokohs Bar, you won't automatically switch weapons in the case you want to eat again. This covers the case where you start with more than 1 Sandvich ammo on servers that modify your lunchbox ammo count and want to continuously heal yourself.

## Proposed Lunchbox Video 
This video will show off the proposed lunchbox changes in this order:
`All` - When interrupted before you receive your lunchbox item's effects, your ammo and charge meter will remain unchanged.
`1 & 2 & 3. & 4.` **Bonk! & Crit-a-Cola & Dalokohs Bar & Buffalo Steak** - `All`
`4a.` - **Failsafe** - As before, without a melee weapon, you'll be forced onto your Minigun and you won't receive any conditions.
`5.` **Sandvich** - Your item will only be consumed on the first nom that healed you. In the video example, it was the third nom.
`5a.` - **Removed Failsafe** - The changes I made ensure that you lose ammo only when effects are given, so the failsafe is no longer necessary. You'll **only** consume one ammo per taunt if one of the noms healed you.
`6.` - **Unused Ammo Sandvich** - Your Sandvich will now be consumed if ammo was restored by one of the noms, as with every other lunchbox item.

**Note: During the video I interrupted most taunts after effects were applied to keep the video as short as possible. If I had let those taunts finish, my weapons would still be switched automatically. Watch for when the charge meter resets.**

https://github.com/user-attachments/assets/5405c3ab-4b21-4b00-8ab9-3391233166ae

## Proposed Code Changes
- Removed code within `OnAddTaunting()` that consumes ammo now that ammo is only consumed during a lunchbox taunt.
- Removed code within `OnTakeDamage_Alive()` which removed Heavy's lunchbox ammo when he takes damage, due to it being obsolete now that `DrainAmmo()` is properly called in the same function that applies lunchbox item effects, making the bug that this patch fixes from 2010 [Fixed the Sandvich cooldown not occurring when the Heavy is hurt](https://wiki.teamfortress.com/wiki/October_6,_2010_Patch#Team_Fortress_2) impossible to produce. This also makes taking damage with lots of Sandvich ammo no longer needlessly drain your ammo, which was caused by the old code.
- Duplicate conditional operations that were shared between `DrainAmmo()` and `ApplyBiteEffects()` were either removed from `DrainAmmo` or appropriately moved into `ApplyBiteEffects()` to check against all conditions neatly in one place. This also makes `DrainAmmo()` able to be used with all lunchbox items.
- `m_Shared.m_bBiteEffectWasApplied` is now used for all lunchbox items to determine if the item's effects were received after the taunt was interrupted or finished.
- Removed a now obsolete call to `SelectLastItem()` for lunchbox drinks in `DoTauntAttack()` now that `OnRemoveTaunting()` handles weapon switching of all lunchbox items in a more robust way when `m_Shared.m_bBiteEffectWasApplied` is true. The reason for this is, `SelectLastItem()` doesn't account for whether the last weapon is available. This means that if your drinking taunt is interrupted and your last item is invalid, `SelectLastItem()` will cause you to awkwardly hold out your drink with 0 ammo until your taunt's duration has ended.

### Closing Notes
I tried my best to be as thorough as possible with both testing and explaining each case. I apologize for the the low quality videos.