### PR TITLE
[TF2] Fix `CHealthAccountPanel` not using `NegativeColor` for negative values

### DIFF
--- a/src/game/client/tf/tf_hud_account.cpp
+++ b/src/game/client/tf/tf_hud_account.cpp
@@ -198,7 +198,7 @@ public:
 	virtual const char *GetResFileName( void ) { return "resource/UI/HudAccountPanel.res"; }
 
 protected:
-	virtual Color GetColor( const account_delta_t::eAccountDeltaType_t& type );
+	virtual Color GetColor( const account_delta_t::eAccountDeltaType_t& type, const int iDeltaValue = 0 );
 
 	CUtlVector <account_delta_t> m_AccountDeltaItems;
 
@@ -1030,7 +1030,7 @@ account_delta_t *CAccountPanel::OnAccountValueChanged( int iOldValue, int iNewVa
 		pNewDeltaItem->m_bLargeFont = false;
 		pNewDeltaItem->m_eDataType = type;
 		pNewDeltaItem->m_wzText[0] = NULL;
-		pNewDeltaItem->m_color = GetColor( type ); 
+		pNewDeltaItem->m_color = GetColor( type, iDelta );
 		pNewDeltaItem->m_bShadows = false;
 		return &m_AccountDeltaItems[index];
 	}
@@ -1038,7 +1038,7 @@ account_delta_t *CAccountPanel::OnAccountValueChanged( int iOldValue, int iNewVa
 	return NULL;
 }
 
-Color CAccountPanel::GetColor( const account_delta_t::eAccountDeltaType_t& type )
+Color CAccountPanel::GetColor( const account_delta_t::eAccountDeltaType_t& type, const int iDeltaValue )
 {
 	if ( type == account_delta_t::ACCOUNT_DELTA_BONUS_POINTS )
 	{
@@ -1046,7 +1046,7 @@ Color CAccountPanel::GetColor( const account_delta_t::eAccountDeltaType_t& type 
 	}
 	else if ( type == account_delta_t::ACCOUNT_DELTA_HEALING )
 	{
-		return m_DeltaPositiveColor;
+		return iDeltaValue < 0 ? m_DeltaNegativeColor : m_DeltaPositiveColor;
 	}
 	else if ( type == account_delta_t::ACCOUNT_DELTA_DAMAGE )
 	{


### PR DESCRIPTION
This PR restores the use of the `"CHealthAccountPanel" { "NegativeColor" "255 0 0 255" }` keyvalue within `hudhealthaccount.res`. This is particularly useful when sending the `player_healonhit` event with a negative value to indicate lost health. Players will no longer be confused by green numbers with a `-` symbol.

**Current**
![hudhealthaccount-negative-bugged](https://github.com/user-attachments/assets/615493ed-8855-448f-9795-703af262d001)

**Fixed**
![hudhealthaccount-negative-fixed](https://github.com/user-attachments/assets/fea8337a-694d-48ff-a909-8571395cef1e)
