### PR TITLE
[VScript] Fix leaked file handle in FileToString

### DIFF
--- a/src/game/server/vscript_server.cpp
+++ b/src/game/server/vscript_server.cpp
@@ -1766,6 +1766,8 @@ static const char *Script_FileToString( const char *pszFileName )
 	if ( iFLen > FILE_TO_STRING_BUF_SIZE )
 	{
 		Warning("File %s (from %s) is len %d too long for a ScriptFileRead\n", szFilePath, pszFileName, iFLen );
+		g_pFullFileSystem->Close( hFile );
+
 		return NULL;
 	}
 	g_pFullFileSystem->Seek( hFile, 0, FILESYSTEM_SEEK_HEAD );


### PR DESCRIPTION
Not closing the handle when files are bigger than 16384 bytes does not allow the file to be deleted until the server is closed.
