### PR TITLE
ent_setname fix

### DIFF
--- a/src/game/server/baseentity.cpp
+++ b/src/game/server/baseentity.cpp
@@ -5805,9 +5805,9 @@ void CC_Ent_SetName( const CCommand& args )
 			CBaseEntity *ent = NULL;
 			while ( (ent = gEntList.NextEnt(ent)) != NULL )
 			{
-				if (  (ent->GetEntityName() != NULL_STRING	&& FStrEq(args[1], STRING(ent->GetEntityName())))	|| 
-					  (ent->m_iClassname != NULL_STRING	&& FStrEq(args[1], STRING(ent->m_iClassname))) ||
-					  (ent->GetClassname()!=NULL && FStrEq(args[1], ent->GetClassname())))
+				if (  (ent->GetEntityName() != NULL_STRING	&& FStrEq(args[2], STRING(ent->GetEntityName())))	|| 
+					  (ent->m_iClassname != NULL_STRING	&& FStrEq(args[2], STRING(ent->m_iClassname))) ||
+					  (ent->GetClassname()!=NULL && FStrEq(args[2], ent->GetClassname())))
 				{
 					pEntity = ent;
 					break;


### PR DESCRIPTION
ent_setname's 2nd argument is not used correctly. It's supposed to be checking the 2nd argument in this function as 1st argument is the name we want found entities to be changed to.

<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
