### PR TITLE
[TF2] Always update Sentry m_flFireRate

### DIFF
--- a/src/game/server/tf/tf_obj_sentrygun.cpp
+++ b/src/game/server/tf/tf_obj_sentrygun.cpp
@@ -275,6 +275,21 @@ void CObjectSentrygun::SentryThink( void )
 		CALL_ATTRIB_HOOK_FLOAT_ON_OTHER( GetOwner(), m_flSentryRange, mult_sentry_range );
 	}
 
+	m_flFireRate = 1.f;
+	CALL_ATTRIB_HOOK_FLOAT_ON_OTHER( GetOwner(), m_flFireRate, mult_sentry_firerate );
+	if ( m_bPlayerControlled )
+	{
+		m_flFireRate *= 0.5f;
+	}
+	if ( IsMiniBuilding() && !IsDisposableBuilding() )
+	{
+		m_flFireRate *= 0.75f;
+	}
+	if ( GetBuilder() && GetBuilder()->m_Shared.InCond( TF_COND_CRITBOOSTED_USER_BUFF ) )
+	{
+		m_flFireRate *= 0.4f;
+	}
+
 	switch( m_iState )
 	{
 	case SENTRY_STATE_INACTIVE:
@@ -1265,24 +1280,6 @@ void CObjectSentrygun::Attack()
 		{
 			m_bFireNextFrame = false;
 			Fire();
-		}
-
-		m_flFireRate = 1.f;
-		CALL_ATTRIB_HOOK_FLOAT_ON_OTHER( GetOwner(), m_flFireRate, mult_sentry_firerate );
-
-		if ( m_bPlayerControlled )
-		{
-			m_flFireRate *= 0.5f;
-		}
-			
-		if ( IsMiniBuilding() && !IsDisposableBuilding() )
-		{
-			m_flFireRate *= 0.75f;
-		}
-
-		if ( GetBuilder() && GetBuilder()->m_Shared.InCond( TF_COND_CRITBOOSTED_USER_BUFF ) )
-		{
-			m_flFireRate *= 0.4f;
 		}
 
 		if ( m_iUpgradeLevel == 1 )


### PR DESCRIPTION
# Description
This PR moves the `m_flFireRate` check that resided in `Attack()` earlier to `SentryThink()` as this fixes two issues.
1. Unwrangling the Sentry would cause it to beep like a mini sentry due to not updating the m_flFireRate.
2. Using a Crit Boost Canteen would not make the sentry beep with a higher pitch as it should if it has a boosted fire rate.