### PR TITLE
[TF2 Enhancement] Consistently pitch up sentry beeps with fire rate

### DIFF
--- a/src/game/server/tf/tf_obj_sentrygun.cpp
+++ b/src/game/server/tf/tf_obj_sentrygun.cpp
@@ -1735,10 +1735,10 @@ void CObjectSentrygun::SentryRotate( void )
 				EmitSentrySound( "Building_Sentrygun.Idle" );
 				break;
 			case 2:
-				EmitSound( "Building_Sentrygun.Idle2" );
+				EmitSentrySound( "Building_Sentrygun.Idle2" );
 				break;
 			case 3:
-				EmitSound( "Building_Sentrygun.Idle3" );
+				EmitSentrySound( "Building_Sentrygun.Idle3" );
 				break;
 			}
 


### PR DESCRIPTION
# Description
As with other sounds the Sentry Gun emits, the beeps it produces only pitch up if it's a Mini Sentry or a level 1 with a fire rate buff. This PR makes it so the level 2 & 3 Sentry Gun beeps also pitch up when under a fire rate buff, currently only possible in MvM with the Crit Buff Canteen.