### PR TITLE
[TF2] Restructure CTFHudPlayerHealth::SetHealth for speed & added features

### DIFF
--- a/src/game/client/econ/confirm_dialog.cpp
+++ b/src/game/client/econ/confirm_dialog.cpp
@@ -819,13 +819,8 @@ void CTFReviveDialog::OnTick()
 	if ( !m_hEntity )
 		return;
 
-	float flHealth = m_hEntity->GetHealth();
-	if ( flHealth != m_flPrevHealth )
-	{
-		float flMaxHealth = m_hEntity->GetMaxHealth();
-		m_pTargetHealth->SetHealth( flHealth, flMaxHealth, flMaxHealth );
-		m_flPrevHealth = flHealth;
-	}
+	float flMaxHealth = m_hEntity->GetMaxHealth();
+	m_pTargetHealth->SetHealth( m_hEntity->GetHealth(), flMaxHealth, flMaxHealth );
 }
 
 //-----------------------------------------------------------------------------

--- a/src/game/client/econ/confirm_dialog.h
+++ b/src/game/client/econ/confirm_dialog.h
@@ -187,7 +187,6 @@ public:
 
 	CTFSpectatorGUIHealth *m_pTargetHealth;
 	CHandle< C_BaseEntity >	m_hEntity;
-	float m_flPrevHealth;
 
 protected:
 	// Revive dialog occurs in game, so we expect to be in this action set

--- a/src/game/client/tf/tf_hud_playerstatus.cpp
+++ b/src/game/client/tf/tf_hud_playerstatus.cpp
@@ -689,6 +689,11 @@ CTFHudPlayerHealth::CTFHudPlayerHealth( Panel *parent, const char *name ) : Edit
 
 	m_iAnimState = HUD_HEALTH_NO_ANIM;
 	m_bAnimate = true;
+
+	m_pPlayerLevelLabel = NULL;
+
+	m_pPlayerHealthLabel = NULL;
+	m_pPlayerMaxHealthLabel = NULL;
 }
 
 CTFHudPlayerHealth::~CTFHudPlayerHealth()
@@ -729,6 +734,7 @@ void CTFHudPlayerHealth::ApplySchemeSettings( IScheme *pScheme )
 
 	m_pPlayerLevelLabel = dynamic_cast<CExLabel*>( FindChildByName( "PlayerStatusPlayerLevel" ) );
 
+	m_pPlayerHealthLabel = dynamic_cast<CExLabel*>( FindChildByName( "PlayerStatusHealthValue" ) );
 	m_pPlayerMaxHealthLabel = dynamic_cast<CExLabel*>( FindChildByName( "PlayerStatusMaxHealthValue" ) );
 }
 
@@ -737,132 +743,139 @@ void CTFHudPlayerHealth::ApplySchemeSettings( IScheme *pScheme )
 //-----------------------------------------------------------------------------
 void CTFHudPlayerHealth::SetHealth( int iNewHealth, int iMaxHealth, int	iMaxBuffedHealth )
 {
-	// set our health
-	m_nHealth = iNewHealth;
-	m_nMaxHealth = iMaxHealth;
-	m_pHealthImage->SetHealth( (float)(m_nHealth) / (float)(m_nMaxHealth) );
 
-	if ( m_pHealthImage )
+	if ( m_nHealth != iNewHealth || m_nMaxHealth != iMaxHealth || m_nMaxBuffedHealth != iMaxBuffedHealth )
 	{
+		// set our health
+		m_nHealth = iNewHealth;
+		m_nMaxHealth = iMaxHealth;
+		m_nMaxBuffedHealth = iMaxBuffedHealth;
+
+		m_pHealthImage->SetHealth( (float)(m_nHealth) / (float)(m_nMaxHealth) );
 		m_pHealthImage->SetFgColor( Color( 255, 255, 255, 255 ) );
-	}
 
-	if ( m_nHealth <= 0 )
-	{
-		if ( m_pHealthImageBG->IsVisible() )
+		if ( m_nHealth <= 0 )
 		{
-			m_pHealthImageBG->SetVisible( false );
-		}
-		if ( m_pBuildingHealthImageBG->IsVisible() )
-		{
-			m_pBuildingHealthImageBG->SetVisible( false );
-		}
-		HideHealthBonusImage();
-	}
-	else
-	{
-		if ( !m_pHealthImageBG->IsVisible() )
-		{
-			m_pHealthImageBG->SetVisible( true );
-		}
-		m_pBuildingHealthImageBG->SetVisible( m_bBuilding );
-
-		// are we getting a health bonus?
-		if ( m_nHealth > m_nMaxHealth )
-		{
-			if ( m_pHealthBonusImage && m_nBonusHealthOrigW != -1 )
+			if ( m_pHealthImageBG->IsVisible() )
 			{
-				if ( !m_pHealthBonusImage->IsVisible() )
-				{
-					m_pHealthBonusImage->SetVisible( true );
-				}
+				m_pHealthImageBG->SetVisible( false );
+			}
+			if ( m_pBuildingHealthImageBG->IsVisible() )
+			{
+				m_pBuildingHealthImageBG->SetVisible( false );
+			}
+			HideHealthBonusImage();
 
-				if ( m_bAnimate && m_iAnimState != HUD_HEALTH_BONUS_ANIM )
-				{
-					g_pClientMode->GetViewportAnimationController()->StartAnimationSequence( this, "HudHealthDyingPulseStop" );
-					g_pClientMode->GetViewportAnimationController()->StartAnimationSequence( this, "HudHealthBonusPulse" );
-
-					m_iAnimState = HUD_HEALTH_BONUS_ANIM;
-				}
-
-				m_pHealthBonusImage->SetDrawColor( Color( 255, 255, 255, 255 ) );
-
-				// scale the flashing image based on how much health bonus we currently have
-				float flBoostMaxAmount = ( iMaxBuffedHealth ) - m_nMaxHealth;
-				float flPercent = MIN( ( m_nHealth - m_nMaxHealth ) / flBoostMaxAmount, 1.0f );
-
-				int nPosAdj = RoundFloatToInt( flPercent * m_nHealthBonusPosAdj );
-				int nSizeAdj = 2 * nPosAdj;
-
-				m_pHealthBonusImage->SetBounds( m_nBonusHealthOrigX - nPosAdj, 
-					m_nBonusHealthOrigY - nPosAdj, 
-					m_nBonusHealthOrigW + nSizeAdj,
-					m_nBonusHealthOrigH + nSizeAdj );
+			if ( m_pPlayerHealthLabel && m_pPlayerHealthLabel->IsVisible() )
+			{
+				m_pPlayerHealthLabel->SetVisible( false );
+			}
+			if ( m_pPlayerMaxHealthLabel && m_pPlayerMaxHealthLabel->IsVisible() )
+			{
+				m_pPlayerMaxHealthLabel->SetVisible( false );
 			}
 		}
-		// are we close to dying?
-		else if ( m_nHealth < m_nMaxHealth * m_flHealthDeathWarning )
-		{
-			if ( m_pHealthBonusImage && m_nBonusHealthOrigW != -1 )
-			{
-				if ( !m_pHealthBonusImage->IsVisible() )
-				{
-					m_pHealthBonusImage->SetVisible( true );
-				}
-
-				if ( m_bAnimate && m_iAnimState != HUD_HEALTH_DYING_ANIM )
-				{
-					g_pClientMode->GetViewportAnimationController()->StartAnimationSequence( this, "HudHealthBonusPulseStop" );
-					g_pClientMode->GetViewportAnimationController()->StartAnimationSequence( this, "HudHealthDyingPulse" );
-
-					m_iAnimState = HUD_HEALTH_DYING_ANIM;
-				}
-
-				m_pHealthBonusImage->SetDrawColor( m_clrHealthDeathWarningColor );
-
-				// scale the flashing image based on how much health bonus we currently have
-				float flBoostMaxAmount = m_nMaxHealth * m_flHealthDeathWarning;
-				float flPercent = ( flBoostMaxAmount - m_nHealth ) / flBoostMaxAmount;
-
-				int nPosAdj = RoundFloatToInt( flPercent * m_nHealthBonusPosAdj );
-				int nSizeAdj = 2 * nPosAdj;
-
-				m_pHealthBonusImage->SetBounds( m_nBonusHealthOrigX - nPosAdj, 
-					m_nBonusHealthOrigY - nPosAdj, 
-					m_nBonusHealthOrigW + nSizeAdj,
-					m_nBonusHealthOrigH + nSizeAdj );
-			}
-
-			if ( m_pHealthImage )
-			{
-				m_pHealthImage->SetFgColor( m_clrHealthDeathWarningColor );
-			}
-		}
-		// turn it off
 		else
 		{
-			HideHealthBonusImage();
-		}
-	}
+			if ( !m_pHealthImageBG->IsVisible() )
+			{
+				m_pHealthImageBG->SetVisible( true );
+			}
+			m_pBuildingHealthImageBG->SetVisible( m_bBuilding );
 
-	// set our health display value
-	if ( m_nHealth > 0 )
-	{
+			// are we getting a health bonus?
+			if ( m_nHealth > m_nMaxHealth )
+			{
+				if ( m_pHealthBonusImage && m_nBonusHealthOrigW != -1 )
+				{
+					if ( !m_pHealthBonusImage->IsVisible() )
+					{
+						m_pHealthBonusImage->SetVisible( true );
+					}
+
+					if ( m_bAnimate && m_iAnimState != HUD_HEALTH_BONUS_ANIM )
+					{
+						g_pClientMode->GetViewportAnimationController()->StartAnimationSequence( this, "HudHealthDyingPulseStop" );
+						g_pClientMode->GetViewportAnimationController()->StartAnimationSequence( this, "HudHealthBonusPulse" );
+
+						m_iAnimState = HUD_HEALTH_BONUS_ANIM;
+					}
+
+					m_pHealthBonusImage->SetDrawColor( Color( 255, 255, 255, 255 ) );
+
+					// scale the flashing image based on how much health bonus we currently have
+					float flBoostMaxAmount = ( m_nMaxBuffedHealth ) - m_nMaxHealth;
+					float flPercent = MIN( ( m_nHealth - m_nMaxHealth ) / flBoostMaxAmount, 1.0f );
+
+					int nPosAdj = RoundFloatToInt( flPercent * m_nHealthBonusPosAdj );
+					int nSizeAdj = 2 * nPosAdj;
+
+					m_pHealthBonusImage->SetBounds( m_nBonusHealthOrigX - nPosAdj,
+						m_nBonusHealthOrigY - nPosAdj,
+						m_nBonusHealthOrigW + nSizeAdj,
+						m_nBonusHealthOrigH + nSizeAdj );
+				}
+			}
+			// are we close to dying?
+			else if ( m_nHealth < m_nMaxHealth * m_flHealthDeathWarning )
+			{
+				if ( m_pHealthBonusImage && m_nBonusHealthOrigW != -1 )
+				{
+					if ( !m_pHealthBonusImage->IsVisible() )
+					{
+						m_pHealthBonusImage->SetVisible( true );
+					}
+
+					if ( m_bAnimate && m_iAnimState != HUD_HEALTH_DYING_ANIM )
+					{
+						g_pClientMode->GetViewportAnimationController()->StartAnimationSequence( this, "HudHealthBonusPulseStop" );
+						g_pClientMode->GetViewportAnimationController()->StartAnimationSequence( this, "HudHealthDyingPulse" );
+
+						m_iAnimState = HUD_HEALTH_DYING_ANIM;
+					}
+
+					m_pHealthBonusImage->SetDrawColor( m_clrHealthDeathWarningColor );
+
+					// scale the flashing image based on how much health bonus we currently have
+					float flBoostMaxAmount = m_nMaxHealth * m_flHealthDeathWarning;
+					float flPercent = ( flBoostMaxAmount - m_nHealth ) / flBoostMaxAmount;
+
+					int nPosAdj = RoundFloatToInt( flPercent * m_nHealthBonusPosAdj );
+					int nSizeAdj = 2 * nPosAdj;
+
+					m_pHealthBonusImage->SetBounds( m_nBonusHealthOrigX - nPosAdj,
+						m_nBonusHealthOrigY - nPosAdj,
+						m_nBonusHealthOrigW + nSizeAdj,
+						m_nBonusHealthOrigH + nSizeAdj );
+				}
+
+				m_pHealthImage->SetFgColor( m_clrHealthDeathWarningColor );
+			}
+			// turn it off
+			else
+			{
+				HideHealthBonusImage();
+			}
+			if ( m_pPlayerHealthLabel && !m_pPlayerHealthLabel->IsVisible() )
+			{
+				m_pPlayerHealthLabel->SetVisible( true );
+			}
+
+			if ( m_pPlayerMaxHealthLabel )
+			{
+				bool bVisible = ( m_nMaxHealth - m_nHealth >= 5 ) ? true : false;
+				if ( m_pPlayerMaxHealthLabel->IsVisible() != bVisible )
+				{
+					m_pPlayerMaxHealthLabel->SetVisible( bVisible );
+				}
+			}
+		}
+
+		// set our health display value
 		SetDialogVariable( "Health", m_nHealth );
 		SetDialogVariable( "MaxHealth", m_nMaxHealth );
-
-		bool bVisible = (m_nMaxHealth - m_nHealth >= 5) ? true : false;
-
-		if (m_pPlayerMaxHealthLabel->IsVisible() != bVisible)
-		{
-			m_pPlayerMaxHealthLabel->SetVisible( bVisible );
-		}
+		SetDialogVariable( "MaxBuffedHealth", m_nMaxBuffedHealth );
 	}
-	else
-	{
-		SetDialogVariable( "Health", "" );
-		SetDialogVariable( "MaxHealth", "" );
-	}	
 }
 
 //-----------------------------------------------------------------------------

--- a/src/game/client/tf/tf_hud_playerstatus.h
+++ b/src/game/client/tf/tf_hud_playerstatus.h
@@ -196,12 +196,14 @@ private:
 	vgui::ImagePanel	*m_pWheelOfDoomImage;
 	vgui::ImagePanel	*m_pSlowedImage;
 	CExLabel			*m_pPlayerLevelLabel;
+	CExLabel			*m_pPlayerHealthLabel;
 	CExLabel			*m_pPlayerMaxHealthLabel;
 
 	CUtlVector<CTFBuffInfo*> m_vecBuffInfo;
 
 	int					m_nHealth;
 	int					m_nMaxHealth;
+	int					m_nMaxBuffedHealth;
 
 	int					m_nBonusHealthOrigX;
 	int					m_nBonusHealthOrigY;

--- a/src/game/client/tf/tf_hud_target_id.cpp
+++ b/src/game/client/tf/tf_hud_target_id.cpp
@@ -1385,7 +1385,6 @@ void CSpectatorTargetID::PerformLayout( void )
 //-----------------------------------------------------------------------------
 CFloatingHealthIcon::CFloatingHealthIcon( vgui::Panel *parent, const char *name ) : EditablePanel( parent, name )
 {
-	m_flPrevHealth = -1.f;
 	m_nPrevLevel = 0;
 
 	SetVisible( false );
@@ -1485,12 +1484,8 @@ void CFloatingHealthIcon::OnTick( void )
 		flMaxHealth = (float)pTargetPlayer->m_Shared.GetDisguiseMaxHealth();
 		iMaxBuffedHealth = pTargetPlayer->m_Shared.GetDisguiseMaxBuffedHealth();
 	}
-		
-	if ( flHealth != m_flPrevHealth )
- 	{
-		m_pTargetHealth->SetHealth( flHealth, flMaxHealth, iMaxBuffedHealth );
-		m_flPrevHealth = flHealth;
-	}
+
+	m_pTargetHealth->SetHealth( flHealth, flMaxHealth, iMaxBuffedHealth );
 
 }
 

--- a/src/game/client/tf/tf_hud_target_id.h
+++ b/src/game/client/tf/tf_hud_target_id.h
@@ -170,7 +170,6 @@ public:
 private:
 	CTFSpectatorGUIHealth	*m_pTargetHealth;
 	CHandle< C_BaseEntity >	m_hEntity;
-	float					m_flPrevHealth;
 	int						m_nPrevLevel;
 };
 


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
This is a minor restructuring of the `CTFHudPlayerHealth::SetHealth` function (which is used to update the health UI panels), to improve speed, add new features, and fix a bug or two.
the diff on github looks rather odd, but for the most part the code in `SetHealth` has mostly just moved around rather than changed.

I had hoped this would be a smaller PR, but the changes work best as one larger one.

## Changes
<details><summary>Only run `SetHealth` if the input health is different from prior cached values</summary>
<p>
This is something that the revive dialog and the floating health icon for target ID already did, but merged into the main function and expanded. This change takes the function from taking on average ~0.025ms per call down to being so fast that vprof says it takes 0.000ms average per call.

Even in an absolute worst case scenario of having 102 healthbars (1 from your health bar, 1 from targetID, and 100 from the matchhud if for some reason you have 100 players on your team), the average time spent per frame is still 0.00ms. In my tests, I was averaging around 1000 calls every 10 seconds, and this totaled out to about 0.12ms.

Additionally, I've removed the checks from the revive dialog and floating health icon, as they are now unnecessary with this change and actually seemed to cause issues with sometimes causing the new check to fail and as such not ever running the function, I'm not sure entirely why.
This does mean that `SetHealth` is being run more often since the check is happening inside the function, which appeared to be ~200 times every 10 seconds, but due to the speed improvements this doesn't seem to be an issue.
</p>
</details>
<details><summary>Hide health and max health label panels instead of emptying their dialog variables (Fixes ValveSoftware/Source-1-Games/issues/3815)</summary>
<p>
This is done mostly for hud editors, with current behavior the `%MaxHealth%` variable is completely blank unless the player is missing 5 or more health.

Because some hud editors (myself included) want to have huds which always show max health, I've changed it so that it gets the default panels which use these variables and toggles their visibility instead. This keeps behavior with the default hud the same, while allowing hud editors to simply make their own panel to read the variable without worrying about having it hidden.
</p>
</details> 
<details><summary>Add new dialog variable `%MaxBuffedHealth%` to display max overheal</summary>
<p>
This is debatable as being necessary, but I needed a cached variable anyway for it to make sure `SetHealth` wouldn't early out if `iMaxBuffedHealth` had changed but the other 2 health values had hadn't, so I thought it would be fun :)

I think its pretty unlikely that `iMaxBuffedHealth` would change without health or max health also being changed because the `GetMaxBuffedHealth` function used in most of the calls of `SetHealth` doesn't take into account the overheal multiplier attributes on the client, although if it did, then the health cross would scale oddly when medics start and stop healing you.

The only other instance I can think of in gameplay where this value would ever change is with Gloves of Running Urgently and the Eviction Notice, which do seem to show the modified overheal max properly with this change.
</p>
</details> 
<details><summary>Remove 2 unnecessary `if ( m_pHealthImage )` checks</summary>
<p>
m_pHealthImage is initialized in the constructor, and there are many _many_ other places where the game would crash if this caused access violation errors, such as 2 lines above the first one I removed, where a function is called on it.

I suppose in theory this is kind of bad code but there are so SO many other places where an uninitialized variable could cause crashes (see below) but doesn't that I think its safe to remove this for speed.
</p>
</details> 
<details><summary>Initialize player level label and new health/maxhealth labels to NULL</summary>
<p>
This is partially just to fix an issue I came across with my added label pointers causing access violation errors with the spectator UI, due to uninitialized memory being used and passing checks to see if the labels existed.

The level label is (re)used for the respawn timer on targetID for revive markers, but I've never heard of it breaking, so there may simply be some deeper issue that I was running into with the other labels that I have missed.

There are still other variables that are uninitialized in the constructor, but do not seem to cause issues.
</p>
</details>