### PR TITLE
[TF2] Fix Bombinomicon & `tf_birthday` spawning ragdoll effects incorrectly

### DIFF
--- a/src/game/client/tf/c_tf_player.cpp
+++ b/src/game/client/tf/c_tf_player.cpp
@@ -766,7 +766,7 @@ void C_TFRagdoll::CreateTFRagdoll()
 		{
 			// This is the local player, so set them in a default
 			// pose and slam their velocity, angles and origin
-			SetAbsOrigin( /* m_vecRagdollOrigin : */ pPlayer->GetRenderOrigin() );			
+			SetAbsOrigin( pPlayer->GetRenderOrigin() );			
 			SetAbsAngles( pPlayer->GetRenderAngles() );
 			SetAbsVelocity( m_vecRagdollVelocity );
 
@@ -793,13 +793,13 @@ void C_TFRagdoll::CreateTFRagdoll()
 	{
 		// Overwrite network origin so later interpolation will use this position.
 		SetNetworkOrigin( m_vecRagdollOrigin );
-		SetAbsOrigin( m_vecRagdollOrigin );
+		SetAbsOrigin( pPlayer->GetRenderOrigin() );
 		SetAbsVelocity( m_vecRagdollVelocity );
 
 		Interp_Reset( GetVarMapping() );
 	}
 
-	if ( IsCloaked() )
+	if ( m_bCloaked )
 	{
 		AddEffects( EF_NOSHADOW );
 	}
@@ -941,7 +941,7 @@ void C_TFRagdoll::CreateTFRagdoll()
 		m_flTimeToDissolve = 0.5f;
 	}
 
-	if ( pPlayer->HasBombinomiconEffectOnDeath() && !m_bGib && !m_bDissolving )
+	if ( m_bBombinomicon && !m_bGib && !m_bDissolving )
 	{
 		m_flTimeToDissolve = 1.2f;
 	}
@@ -950,7 +950,7 @@ void C_TFRagdoll::CreateTFRagdoll()
 	if ( pPlayer && TFGameRules() && TFGameRules()->IsBirthday() )
 	{
 		AngularImpulse angularImpulse( RandomFloat( 0.0f, 120.0f ), RandomFloat( 0.0f, 120.0f ), 0.0 );
-		breakablepropparams_t breakParams( m_vecRagdollOrigin, GetRenderAngles(), m_vecRagdollVelocity, angularImpulse );
+		breakablepropparams_t breakParams( pPlayer->GetRenderOrigin(), GetRenderAngles(), m_vecRagdollVelocity, angularImpulse );
 		breakParams.impactEnergyScale = 1.0f;
 		pPlayer->DropPartyHat( breakParams, m_vecRagdollVelocity.GetForModify() );
 	}
@@ -1064,12 +1064,12 @@ void C_TFRagdoll::CreateTFHeadGib( void )
 {
 	C_TFPlayer *pPlayer = GetPlayer();
 
-	if ( pPlayer && ((pPlayer->m_hFirstGib == NULL) || m_bFeignDeath) )
+	if ( pPlayer && pPlayer->m_hFirstGib == NULL )
 	{
 		Vector vecVelocity = m_vecForce + m_vecRagdollVelocity;
 		VectorNormalize( vecVelocity );
 
-		pPlayer->CreatePlayerGibs( m_vecRagdollOrigin, vecVelocity, m_vecForce.Length(), m_bBurning, false, true );
+		pPlayer->CreatePlayerGibs( pPlayer->GetRenderOrigin(), vecVelocity, m_vecForce.Length(), m_bBurning, m_bFeignDeath, false, true );
 		// Decap Death Camera is disorienting on range Decaps (aka bullets)
 		// Use normal Deathcam
 		if ( m_iDamageCustom == TF_DMG_CUSTOM_HEADSHOT_DECAPITATION )
@@ -1082,29 +1082,31 @@ void C_TFRagdoll::CreateTFHeadGib( void )
 //-----------------------------------------------------------------------------
 // Purpose:
 //-----------------------------------------------------------------------------
-void C_TFRagdoll::CreateTFGibs( bool bDestroyRagdoll, bool bCurrentPosition )
+void C_TFRagdoll::CreateTFGibs( bool bDestroyRagdoll )
 {
 	C_TFPlayer *pPlayer = GetPlayer();
 	
-	if ( pPlayer && pPlayer->HasBombinomiconEffectOnDeath() )
-	{
-		m_vecForce *= 2.0f;
-		m_vecForce.z *= 3.0f;
-
-		DispatchParticleEffect( TFGameRules()->IsHolidayActive( kHoliday_Halloween ) ? "bombinomicon_burningdebris_halloween" : "bombinomicon_burningdebris", 
-								bCurrentPosition ? GetAbsOrigin() : m_vecRagdollOrigin, GetAbsAngles() );
-		EmitSound( "Bombinomicon.Explode" );
-	}
-
-	if ( pPlayer && ((pPlayer->m_hFirstGib == NULL) || m_bFeignDeath) )
-	{
-		Vector vecVelocity = m_vecForce + m_vecRagdollVelocity;
-		VectorNormalize( vecVelocity );
-		pPlayer->CreatePlayerGibs( bCurrentPosition ? pPlayer->GetRenderOrigin() : m_vecRagdollOrigin, vecVelocity, m_vecForce.Length(), m_bBurning );
-	}
-
 	if ( pPlayer )
 	{
+		Vector vecOrigin = m_bGib ? pPlayer->GetRenderOrigin() : GetRenderOrigin();
+
+		if ( m_bBombinomicon )
+		{
+			m_vecForce *= 2.0f;
+			m_vecForce.z *= 3.0f;
+
+			DispatchParticleEffect( TFGameRules()->IsHolidayActive( kHoliday_Halloween ) ? "bombinomicon_burningdebris_halloween" : "bombinomicon_burningdebris",
+									vecOrigin, GetAbsAngles());
+			EmitSound("Bombinomicon.Explode");
+		}
+		
+		if ( pPlayer->m_hFirstGib == NULL )
+		{
+			Vector vecVelocity = m_vecForce + m_vecRagdollVelocity;
+			VectorNormalize( vecVelocity );
+			pPlayer->CreatePlayerGibs( vecOrigin, vecVelocity, m_vecForce.Length(), m_bBurning, m_bFeignDeath );
+		}
+	
 		if ( TFGameRules() && TFGameRules()->IsBirthdayOrPyroVision() )
 		{
 			DispatchParticleEffect( "bday_confetti", pPlayer->GetAbsOrigin() + Vector(0,0,32), vec3_angle );
@@ -1143,7 +1145,7 @@ void C_TFRagdoll::CreateWearableGibs( bool bDisguiseWearables )
 
 	Vector vecVelocity = m_vecForce + m_vecRagdollVelocity;
 	VectorNormalize( vecVelocity );
-	pPlayer->CreatePlayerGibs( m_vecRagdollOrigin, vecVelocity, m_vecForce.Length(), m_bBurning, true, false, bDisguiseWearables );
+	pPlayer->CreatePlayerGibs( pPlayer->GetRenderOrigin(), vecVelocity, m_vecForce.Length(), m_bBurning, m_bFeignDeath, true, false, bDisguiseWearables );
 }
 
 
@@ -1229,6 +1231,8 @@ void C_TFRagdoll::OnDataChanged( DataUpdateType_t type )
 
 		if ( bCreateRagdoll )
 		{
+			m_bBombinomicon = !m_bCloaked && pPlayer->HasBombinomiconEffectOnDeath();
+
 			if ( m_bGib )
 			{
 				CreateTFGibs( !m_bDissolving );
@@ -1396,7 +1400,6 @@ void C_TFRagdoll::ClientThink( void )
 	}
 
 	C_TFPlayer *pPlayer = GetPlayer();
-	bool bBombinomicon = ( pPlayer && pPlayer->HasBombinomiconEffectOnDeath() );
 
 	if ( !m_bGib )
 	{
@@ -1421,12 +1424,12 @@ void C_TFRagdoll::ClientThink( void )
 				}
 			}
 		}
-		else if ( bBombinomicon && ( GetFlags() & FL_DISSOLVING ) )
+		else if ( m_bBombinomicon && ( GetFlags() & FL_DISSOLVING ) )
 		{
 			m_flTimeToDissolve -= gpGlobals->frametime;
 			if ( m_flTimeToDissolve <= 0 )
 			{
-				CreateTFGibs( true, true );
+				CreateTFGibs( true );
 			}
 		}
 		else if ( m_bBecomeAsh )
@@ -1434,9 +1437,9 @@ void C_TFRagdoll::ClientThink( void )
 			m_flTimeToDissolve -= gpGlobals->frametime;
 			if ( m_flTimeToDissolve <= 0 )
 			{
-				if ( bBombinomicon )
+				if ( m_bBombinomicon )
 				{
-					CreateTFGibs( true, true );
+					CreateTFGibs( true );
 				}
 				else
 				{
@@ -1460,12 +1463,12 @@ void C_TFRagdoll::ClientThink( void )
 				return;
 			}
 		}
-		else if ( bBombinomicon )
+		else if ( m_bBombinomicon )
 		{
 			m_flTimeToDissolve -= gpGlobals->frametime;
 			if ( m_flTimeToDissolve <= 0 )
 			{
-				CreateTFGibs( true, true );
+				CreateTFGibs( true );
 				return;
 			}
 		}
@@ -1482,9 +1485,9 @@ void C_TFRagdoll::ClientThink( void )
 
 				if ( pPlayer )
 				{
-					if ( bBombinomicon )
+					if ( m_bBombinomicon )
 					{
-						CreateTFGibs( true, true );
+						CreateTFGibs( true );
 					}
 					else
 					{
@@ -7317,7 +7320,7 @@ void C_TFPlayer::CheckAndUpdateGibType( void )
 //			&vecVelocity - 
 //			&vecImpactVelocity - 
 //-----------------------------------------------------------------------------
-void C_TFPlayer::CreatePlayerGibs( const Vector &vecOrigin, const Vector &vecVelocity, float flImpactScale, bool bBurning, bool bWearableGibs, bool bOnlyHead, bool bDisguiseGibs )
+void C_TFPlayer::CreatePlayerGibs( const Vector &vecOrigin, const Vector &vecVelocity, float flImpactScale, bool bBurning, bool bFeignDeath, bool bWearableGibs, bool bOnlyHead, bool bDisguiseGibs )
 {
 	// Make sure we have Gibs to create.
 	if ( m_aGibs.Count() == 0 )
@@ -7382,11 +7385,16 @@ void C_TFPlayer::CreatePlayerGibs( const Vector &vecOrigin, const Vector &vecVel
 				}
 			}
 			
-			m_hFirstGib = CreateGibsFromList( headGib, nModelIndex, NULL, breakParams, this, -1 , false, true, &m_hSpawnedGibs, bBurning );
-			m_hHeadGib = m_hFirstGib;
-			if ( m_hFirstGib )
+			EHANDLE hGib = CreateGibsFromList( headGib, nModelIndex, NULL, breakParams, this, -1, false, true, &m_hSpawnedGibs, bBurning );
+			if ( !bFeignDeath )
 			{
-				IPhysicsObject *pPhysicsObject = m_hFirstGib->VPhysicsGetObject();
+				m_hFirstGib = hGib;
+				m_hHeadGib = hGib;
+			}
+			
+			if ( hGib )
+			{
+				IPhysicsObject *pPhysicsObject = hGib->VPhysicsGetObject();
 				if( pPhysicsObject )
 				{
 					// Give the head some rotational damping so it doesn't roll so much (for the player's view).
@@ -7400,7 +7408,12 @@ void C_TFPlayer::CreatePlayerGibs( const Vector &vecOrigin, const Vector &vecVel
 		else
 		{
 			CheckAndUpdateGibType();
-			m_hFirstGib = CreateGibsFromList( m_aGibs, nModelIndex, NULL, breakParams, this, -1 , false, true, &m_hSpawnedGibs, bBurning );
+
+			EHANDLE hGib = CreateGibsFromList( m_aGibs, nModelIndex, NULL, breakParams, this, -1, false, true, &m_hSpawnedGibs, bBurning );
+			if ( !bFeignDeath )
+			{
+				m_hFirstGib = hGib;
+			}
 		}
 		DropPartyHat( breakParams, vecBreakVelocity );
 	}

--- a/src/game/client/tf/c_tf_player.h
+++ b/src/game/client/tf/c_tf_player.h
@@ -198,7 +198,7 @@ public:
 	// Gibs.
 	void InitPlayerGibs( void );
 	void CheckAndUpdateGibType( void );
-	void CreatePlayerGibs( const Vector &vecOrigin, const Vector &vecVelocity, float flImpactScale, bool bBurning, bool bWearableGibs=false, bool bOnlyHead=false, bool bDisguiseGibs=false );
+	void CreatePlayerGibs( const Vector &vecOrigin, const Vector &vecVelocity, float flImpactScale, bool bBurning, bool bFeignDeath=false, bool bWearableGibs=false, bool bOnlyHead=false, bool bDisguiseGibs=false );
 	void DropPartyHat( breakablepropparams_t &breakParams, Vector &vecBreakVelocity );
 	void DropWearable( C_TFWearable *pItem, const breakablepropparams_t &params );
 
@@ -1073,7 +1073,7 @@ private:
 	void Interp_Copy( C_BaseAnimatingOverlay *pSourceEntity );
 
 	void CreateTFRagdoll();
-	void CreateTFGibs( bool bDestroyRagdoll = true, bool bCurrentPosition = false );
+	void CreateTFGibs( bool bDestroyRagdoll = true );
 	void CreateWearableGibs( bool bDisguiseWearables );
 	void CreateTFHeadGib();
 
@@ -1117,6 +1117,7 @@ private:
 	float m_flPercentInvisible;
 	float m_flTimeToDissolve;
 	bool  m_bCritOnHardHit;	// plays the red mist particle effect
+	bool  m_bBombinomicon;
 	float m_flHeadScale;
 	float m_flTorsoScale;
 	float m_flHandScale;


### PR DESCRIPTION
# Description
This PR fixes **many** bugs with the creation of ragdoll gibs & particles. The addition of the `tf_birthday`, the Bombinomicon, and Spy's weapons, the Dead Ringer and Your Eternal Reward, interact with each other in a way that that creates problematic gameplay scenarios for a stealthy Spy using either weapon. These bugs affect all ragdolls no matter the class, but are mainly a problem with Spy. Many fixes in this PR are also likely to fix more bugs than shown below.

**Note:** All bugs mentioned below where the bombinomicon is featured also affects client-sided birthday gibs & gibs with low violence settings turned on.

## Bugged Ragdoll Interactions
The videos below shows 3 clips in this order:
`1.` When Spy uses the Dead Ringer, the explosion from his ragdoll causes gibs and particles to spawn at his current position instead of where his feign death ragdoll is. He also isn't able to gib after his feign death ragdoll gibs.
`2.` If you explode before your feign death ragdoll does, anyone spectating you will have their camera teleported to your feign death ragdoll's gibbed head, spawned at your actual death position, rather than following your actual gibbed head.
`3.` If your previous death produced a non-gibbed ragdoll and then you equip the bombinomicon, upon respawning/resupplying your ragdoll will explode. Note that I do not have the bombinomicon on my Spy while taunting before death, it's equipped once I respawn.

**Bugged**

https://github.com/user-attachments/assets/b6058140-4309-43e0-9dda-2b4b4fd48e8c

**Fixed**

https://github.com/user-attachments/assets/344f6d87-0184-4ccb-a874-c5faec3a87bd

The video below shows 2 clips in this order:
`4.` Ragdoll gibs and particles don't respect the value given to the input `SetCustomModelOffset`.
`5.` The head gib spawned from a decapitation doesn't respect the value given to the input `SetCustomModelOffset`.
`5a.` **Note:** First feign is using `hurtme 1`, second is hurting myself with `DMG_BLAST` using `TakeDamage()` from vscript.

**Bugged**

https://github.com/user-attachments/assets/8f85404a-43e0-4a47-9727-b2bbe44aafea

**Fixed**

https://github.com/user-attachments/assets/de3fc2d0-7585-4e83-8d00-0b580ccecdb0

## Your Eternal Reward
I've added a check to prevent cloaked ragdolls from exploding by the bombinomicon to prevent victims of the Your Eternal Reward from giving the Spy away. Although people have differing opinions about whether special ragdolls as a whole should be exempt from the bombinomicon explosion, I believe cloaked ragdolls to be the only one which has a negative effect on gameplay. The "silent killer" attribute isn't so silent or inconspicuous when your victim explodes into gibs and particles 1.2 seconds later. I'm aware that most cosmetics don't properly cloak which can give the Spy away, and that an ammo box will drop too, but those are separate issues, and I think we can all agree that a gib and particle explosion is more likely to give away the Spy's disguise.

**The first clip is current, second clip is the proposed change**

https://github.com/user-attachments/assets/4ee28ea9-e754-4bd5-8556-d48f974ae9d6

# Code Changes
- `m_hFirstGib` will no longer be assigned to feign death ragdoll gibs, removing the need to check for `m_bFeignDeath` before creating gibs.
- Added the `bFeignDeath` parameter to `CreatePlayerGibs()` to be used in preventing feign death gibs from being assigned to `m_hFirstGib` or `m_hHeadGib`.
- Removed the obsolete parameter `bool bCurrentPosition` from the function `CreateTFGibs()` because checking for `m_bGib` from within the function is the only condition necessary to determine the correct spawn position.
- Replaced all instances of the network var `m_vecRagdollOrigin` with the function `GetRenderOrigin()` where it was being used as the position to create gibs & particles. This was done to respect the value of the input `SetCustomModelOffset`, and to correctly spawn gibs & particles on feign death ragdolls. Given that death ragdolls are client-sided, it makes sense that the use of `m_vecRagdollOrigin` is replaced with `GetRenderOrigin()`. This way custom client-side ragdolls and gibs are spawned in their correct positions client-side. This was actually already done for ragdolls with `m_vecRagdollOrigin` being commented out, it just needed to be done for every other place where the var was used.
- `bool m_bBombinomicon` was added to `C_TFRagdoll` to reduce the amount of calls to `pPlayer->HasBombinomiconEffectOnDeath()`. This is initialized once the ragdoll is created.
- Replaced a call to the public function `IsCloaked()` within the private function `CreateTFRagdoll()` with the private member `m_bCloaked`.