### PR TITLE
[TF2] Hotfix for PR #893; Fix for submodel not updating correctly upon Casual late-join

### DIFF
--- a/src/game/client/tf/tf_hud_match_status.cpp
+++ b/src/game/client/tf/tf_hud_match_status.cpp
@@ -580,6 +580,12 @@ void CTFHudMatchStatus::FireGameEvent( IGameEvent * event )
 		int nSubModel = 0;
 		if (pMatchDesc->BGetRoundDoorParameters(nSkin, nSubModel))
 		{
+			// Is VS doors model not initialized yet?
+			if (m_pMatchStartModelPanel->m_hModel == NULL)
+			{
+				m_pMatchStartModelPanel->UpdateModel();
+			}
+
 			m_pMatchStartModelPanel->SetBodyGroup( "logos", nSubModel );
 			m_pMatchStartModelPanel->UpdateModel();
 			m_pMatchStartModelPanel->SetSkin( nSkin );


### PR DESCRIPTION
Hotfix for recently added fix; Added check for if the versus doors haven't been initialized yet before setting skin/submodel

Current code from PR #893 does not check if the versus door model has been initialized yet. This results in the submodel not updating correctly upon the first time it is loaded in client, resulting in the bugged appearance seen below:
![image](https://github.com/user-attachments/assets/03e56899-560b-4b29-9f1c-ff2edacd06e0)


Issue currently seems to resolve itself after the first time this is triggered (as the model has since been initialized).

Repro steps:
* Join a casual game in-progress from a freshly started TF2 client
* Play match until completion

<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
