### PR TITLE
Tf2: Fix strange shields count kills from other weapons

### DIFF
--- a/src/game/shared/tf/tf_gamerules.cpp
+++ b/src/game/shared/tf/tf_gamerules.cpp
@@ -10534,6 +10534,9 @@ void EconItemInterface_OnOwnerKillEaterEvent( IEconItemInterface *pEconEntity, C
 		if ( !pWearableItem->GetAttributeContainer() )
 			continue;
 
+		if ( !strcmp( pWearableItem->GetAttributeContainer()->GetItem()->GetStaticData()->GetItemClass(), "tf_wearable_demoshield" ) )
+			continue;
+
 		EconEntity_ValidateAndSendStrangeMessageToGC( pWearableItem->GetAttributeContainer()->GetItem(), pOwner, pVictim, eEventType, nIncrementValue );
 
 		if ( pWearableItem->GetAttributeContainer()->GetItem() == pEconEntity )


### PR DESCRIPTION
Strange shields count shield kills, but also every other weapon kills. On wiki, mentioned as a bug.
This patch fixes this.

Fixes https://github.com/ValveSoftware/Source-1-Games/issues/5012. Detailed explanation can also be found there.

