### PR TITLE
[TF2] Fix Pomson 6000 projectile colliding with teammates

### DIFF
--- a/src/game/shared/tf/tf_projectile_energy_ring.cpp
+++ b/src/game/shared/tf/tf_projectile_energy_ring.cpp
@@ -256,9 +256,22 @@ void CTFProjectile_EnergyRing::ProjectileTouch( CBaseEntity *pOther )
 
 	if ( bCombatEntity )
 	{
-		// Bison projectiles shouldn't collide with friendly things
-		if ( ShouldPenetrate() && ( pOther->InSameTeam( this ) || ( gpGlobals->curtime - m_flLastHitTime ) < tf_bison_tick_time.GetFloat() ) )
-			return;
+		if ( ShouldPenetrate() ) // Righteous Bison
+		{
+			// Projectiles shouldn't collide with friendly things.
+			if ( pOther->InSameTeam( this ) )
+				return;
+
+			// Don't hit them too fast.
+			if ( gpGlobals->curtime - m_flLastHitTime < tf_bison_tick_time.GetFloat() )
+				return;
+		}
+		else // Pomson
+		{
+			// Projectiles shouldn't collide with friendly things except buildings.
+			if ( pOther->InSameTeam( this ) && !pOther->IsBaseObject() )
+				return;
+		}
 
 		m_flLastHitTime = gpGlobals->curtime;
 


### PR DESCRIPTION
# Description
In its current state, the Pomson 6000's projectile is blocked by teammates regardless of how close they are. The expected behavior is that they should pass through teammates. As mentioned in Uncle Dane's video: https://youtu.be/-iYUMyXLZoo?si=wTN3qbbs2MF-tPKe&t=357

# Changes
- Fixed the Pomson 6000 projectile colliding with friendly entities, with the exception of friendly buildings (base objects).