### PR TITLE
[TF2] make disguised spies flinch and emit pain sounds when taking fall damage

### DIFF
--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -15139,7 +15139,7 @@ void CTFPlayer::PainSound( const CTakeDamageInfo &info )
 		// don't play sound for fall stomp event
 		if ( !( pGround && pGround->IsPlayer() && m_Shared.CanFallStomp() ) )
 		{
-			TFPlayerClassData_t* pData = GetPlayerClass()->GetData();
+			TFPlayerClassData_t *pData = GetPlayerClass()->GetData();
 			if ( pData )
 			{
 				CPASFilter filter( GetAbsOrigin() );
@@ -15154,7 +15154,7 @@ void CTFPlayer::PainSound( const CTakeDamageInfo &info )
 
 			if ( m_Shared.InCond( TF_COND_DISGUISED ) )
 			{
-				TFPlayerClassData_t* pDisguiseData = GetPlayerClassData( m_Shared.GetDisguiseClass() );
+				TFPlayerClassData_t *pDisguiseData = GetPlayerClassData( m_Shared.GetDisguiseClass() );
 				if ( pDisguiseData )
 				{
 					CPASFilter disguisedFilter( GetAbsOrigin() );

--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -9677,6 +9677,12 @@ int CTFPlayer::OnTakeDamage( const CTakeDamageInfo &inputInfo )
 		{
 			m_Shared.NoteLastDamageTime( m_lastDamageAmount );
 		}
+
+		// Set our disguise health when taking falldamage to make it more believable
+		if ( m_Shared.InCond( TF_COND_DISGUISED ) && info.GetDamageType() == DMG_FALL)
+		{
+			m_Shared.SetDisguiseHealth( Max( m_Shared.GetDisguiseHealth() - RoundFloatToInt( info.GetDamage() ), 1 ) );
+		}
 	}
 
 	if ( pWeapon ) 
@@ -15162,8 +15168,6 @@ void CTFPlayer::PainSound( const CTakeDamageInfo &info )
 					disguisedFilter.AddRecipient( this );
 					EmitSound( disguisedFilter, entindex(), pDisguiseData->GetDeathSound( DEATH_SOUND_GENERIC ) );
 				}
-
-				m_Shared.SetDisguiseHealth( Max( m_Shared.GetDisguiseHealth() - RoundFloatToInt( info.GetDamage() ), 1 ) );
 			}
 		}
 		return;


### PR DESCRIPTION
# Description

Disguised spies do not emit any pain sounds nor flinch when taking fall damage. This is a dead giveaway that the player is a disguised spy. 

This PR makes sure spies emit the correct disguise pain sound to teammates and enemies.
In addition to also flinching the disguise health is also updated when taking fall damage.