### PR TITLE
Fix weapons wiping velocity for ragdolls

### DIFF
--- a/src/game/shared/tf/tf_weaponbase.cpp
+++ b/src/game/shared/tf/tf_weaponbase.cpp
@@ -1347,7 +1347,7 @@ void CTFWeaponBase::OnActiveStateChanged( int iOldState )
 
 	// Check for a speed mod change.
 	CTFPlayer *pPlayer = ToTFPlayer( GetOwner() );
-	if ( pPlayer )
+	if ( pPlayer && pPlayer->IsAlive() )
 	{
 		pPlayer->TeamFortress_SetSpeed();
 	}


### PR DESCRIPTION
A long-standing bug is that ragdolls don't inherit the player velocity, they only receive force from external damage. This is because of the held weapon re-calculating the player's speed on death, due to its active state changing. This leads to a max speed of 0 in `TeamFortress_SetSpeed` which resets the velocity. When the ragdoll is created, it copies the velocity from the player which is now zero. The fix adds an alive check for the player before re-calculating velocity

Before:

https://github.com/user-attachments/assets/4eaf53ad-1eb7-4e0f-a877-cbad8b2f873c

After:

https://github.com/user-attachments/assets/20bc894d-567a-465f-ad6d-473173c0df9e


