### PR TITLE
[TF2] Fix Pomson 6000 projectile firing below crosshair

### DIFF
--- a/src/game/shared/tf/tf_weapon_raygun.cpp
+++ b/src/game/shared/tf/tf_weapon_raygun.cpp
@@ -241,15 +241,3 @@ void CTFDRGPomson::Precache()
 	PrecacheParticleSystem( "drg_pomson_projectile" );
 	PrecacheParticleSystem( "drg_pomson_muzzleflash" );
 }
-
-
-//-----------------------------------------------------------------------------
-// Purpose: 
-//-----------------------------------------------------------------------------
-void CTFDRGPomson::GetProjectileFireSetup( CTFPlayer *pPlayer, Vector vecOffset, Vector *vecSrc, QAngle *angForward, bool bHitTeammates, float flEndDist )
-{
-	BaseClass::GetProjectileFireSetup( pPlayer, vecOffset, vecSrc, angForward, bHitTeammates, flEndDist );
-
-	// adjust to line up with the weapon muzzle
-	vecSrc->z -= 13.0f;
-}

--- a/src/game/shared/tf/tf_weapon_raygun.h
+++ b/src/game/shared/tf/tf_weapon_raygun.h
@@ -95,8 +95,6 @@ public:
 
 	virtual const char *GetMuzzleFlashParticleEffect( void )	{ return "drg_pomson_muzzleflash"; }
 	virtual const char *GetIdleParticleEffect( void )			{ return "drg_pomson_idle"; }
-
-	virtual void GetProjectileFireSetup( CTFPlayer *pPlayer, Vector vecOffset, Vector *vecSrc, QAngle *angForward, bool bHitTeammates = true, float flEndDist = 2000.f );
 };
 
 


### PR DESCRIPTION
# Description
The Pomson 6000 currently fires projectiles below the crosshair to align with the muzzle. This leads to shots hitting below their target and sometimes being blocked by ledges which can feel unintuitive and frustrating for the user. The preferred behavior is that the projectile fires straight from the crosshair's location.

Mentioned in Uncle Dane's video https://youtu.be/-iYUMyXLZoo?si=M_k6G6vxJo-TEhGo&t=668

Mentioned in https://github.com/ValveSoftware/Source-1-Games/issues/2592

> The shots fired by the weapon are fired slightly below the reticule.

# Changes
- Fixed the Pomson 6000 projectile firing below the crosshair.

https://github.com/user-attachments/assets/61923d92-908f-4f8b-a494-5e9e20459b13

https://github.com/user-attachments/assets/ad7bc8ad-c5d3-4879-9017-cd7c51c87e10

Unlike the Pomson 6000, the Rescue Ranger's bolt does not share this offset. It looks odd in third-person, but this is rarely noticed in gameplay and is preferred.

https://github.com/user-attachments/assets/d0b45e03-853e-41ce-9259-d8e9873fa98a

