### PR TITLE
[VBSP] add %CompileNoBumpLight

### DIFF
--- a/src/utils/vbsp/textures.cpp
+++ b/src/utils/vbsp/textures.cpp
@@ -180,7 +180,13 @@ int	FindMiptex (const char *name)
 
 		if( g_BumpAll || GetMaterialShaderPropertyBool( matID, UTILMATLIB_NEEDS_BUMPED_LIGHTMAPS ) )
 		{
-			textureref[i].flags |= SURF_BUMPLIGHT;
+			// $nodiffusebumpedlighting doesn't work properly in vanilla shaders unless using SSBump.
+			// Leaving out SURF_BUMPLIGHT bypasses the issue. This breaks custom shaders that fix
+			// bumped overlays, however (since those require bumped lightmaps), so a separate matvar is used.
+			if (!( ( propVal = GetMaterialVar( matID, "%compileNoBumpLight" ) ) && StringIsTrue( propVal ) ))
+			{
+				textureref[i].flags |= SURF_BUMPLIGHT;
+			}
 		}
 		
 		if( GetMaterialShaderPropertyBool( matID, UTILMATLIB_NEEDS_LIGHTMAP ) )


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

## Description
New VMT flag that disables SURF_BUMPLIGHT even if a material would have it normally.
Bypasses issues with $nodiffusebumplighting on vanilla shaders, but causes custom shaders that add bumped overlays to not work (see https://github.com/ValveSoftware/source-sdk-2013/issues/1124 for explanation on bumped overlays), so a separate command is used. That command was intended to be used to have bumpy reflections on flat surfaces.

## Legal
I have read the contribution rules, and can affirm that the contents of this PR are based entirely upon existing SDK code and does not contain any code from third parties or other developers. Valve, any Valve game modders, and and any licensors of Valve-developed software are free to use the contents of this PR as they see fit.