### PR TITLE
hl2mp: Fix phantom weapon fire when throwing an object with `hl2mp_allow_pickup`

### DIFF
--- a/src/game/client/hl2/c_basehlplayer.h
+++ b/src/game/client/hl2/c_basehlplayer.h
@@ -52,6 +52,8 @@ public:
 
 	bool				IsWeaponLowered( void ) { return m_HL2Local.m_bWeaponLowered; }
 
+	bool				IsHoldingAnyEntity( void ) { return m_HL2Local.m_bHoldingObject; }
+
 	virtual void	HandleSpeedChanges( CMoveData *mv ){}
 	virtual void	ReduceTimers( CMoveData *mv ){}
 

--- a/src/game/client/hl2/c_hl2_playerlocaldata.cpp
+++ b/src/game/client/hl2/c_hl2_playerlocaldata.cpp
@@ -22,6 +22,7 @@ BEGIN_RECV_TABLE_NOBASE( C_HL2PlayerLocalData, DT_HL2Local )
 	RecvPropInt( RECVINFO(m_iSquadMedicCount) ),
 	RecvPropBool( RECVINFO(m_fSquadInFollowMode) ),
 	RecvPropBool( RECVINFO(m_bWeaponLowered) ),
+	RecvPropBool( RECVINFO(m_bHoldingObject) ),
 	RecvPropEHandle( RECVINFO(m_hAutoAimTarget) ),
 	RecvPropVector( RECVINFO(m_vecAutoAimPoint) ),
 	RecvPropEHandle( RECVINFO(m_hLadder) ),
@@ -58,6 +59,7 @@ C_HL2PlayerLocalData::C_HL2PlayerLocalData()
 	m_iSquadMedicCount = 0;
 	m_fSquadInFollowMode = false;
 	m_bWeaponLowered = false;
+	m_bHoldingObject = false;
 	m_hLadder = NULL;
 #ifdef HL2_EPISODIC
 	m_flFlashBattery = 0.0f;

--- a/src/game/client/hl2/c_hl2_playerlocaldata.h
+++ b/src/game/client/hl2/c_hl2_playerlocaldata.h
@@ -39,6 +39,7 @@ public:
 	int		m_iSquadMedicCount;
 	bool	m_fSquadInFollowMode;
 	bool	m_bWeaponLowered;
+	bool	m_bHoldingObject;
 	EHANDLE m_hAutoAimTarget;
 	Vector	m_vecAutoAimPoint;
 	bool	m_bDisplayReticle;

--- a/src/game/server/hl2/hl2_player.cpp
+++ b/src/game/server/hl2/hl2_player.cpp
@@ -3151,6 +3151,16 @@ bool CHL2_Player::Weapon_CanSwitchTo( CBaseCombatWeapon *pWeapon )
 	return true;
 }
 
+void CHL2_Player::OnPickupObject( void )
+{
+	m_HL2Local.m_bHoldingObject = true;
+}
+
+void CHL2_Player::OnDropObject( void )
+{
+	m_HL2Local.m_bHoldingObject = false;
+}
+
 void CHL2_Player::PickupObject( CBaseEntity *pObject, bool bLimitMassAndSize )
 {
 	// can't pick up what you're standing on

--- a/src/game/server/hl2/hl2_player.h
+++ b/src/game/server/hl2/hl2_player.h
@@ -238,7 +238,10 @@ public:
 	virtual bool		CanBreatheUnderwater() const { return m_HL2Local.m_flSuitPower > 0.0f; }
 
 	// physics interactions
+	virtual void		OnPickupObject( void );
+	virtual void		OnDropObject( void );
 	virtual void		PickupObject( CBaseEntity *pObject, bool bLimitMassAndSize );
+	virtual bool		IsHoldingAnyEntity( void ) { return m_HL2Local.m_bHoldingObject; }
 	virtual	bool		IsHoldingEntity( CBaseEntity *pEnt );
 	virtual void		ForceDropOfCarriedPhysObjects( CBaseEntity *pOnlyIfHoldindThis );
 	virtual float		GetHeldObjectMass( IPhysicsObject *pHeldObject );

--- a/src/game/server/hl2/hl2_playerlocaldata.cpp
+++ b/src/game/server/hl2/hl2_playerlocaldata.cpp
@@ -28,6 +28,7 @@ BEGIN_SEND_TABLE_NOBASE( CHL2PlayerLocalData, DT_HL2Local )
 	SendPropInt( SENDINFO(m_iSquadMedicCount) ),
 	SendPropBool( SENDINFO(m_fSquadInFollowMode) ),
 	SendPropBool( SENDINFO(m_bWeaponLowered) ),
+	SendPropBool( SENDINFO(m_bHoldingObject) ),
 	SendPropEHandle( SENDINFO(m_hAutoAimTarget) ),
 	SendPropVector( SENDINFO(m_vecAutoAimPoint) ),
 	SendPropEHandle( SENDINFO(m_hLadder) ),
@@ -71,6 +72,7 @@ CHL2PlayerLocalData::CHL2PlayerLocalData()
 	m_bZooming = false;
 	m_bNewSprinting = false;
 	m_bWeaponLowered = false;
+	m_bHoldingObject = false;
 	m_hAutoAimTarget.Set(NULL);
 	m_hLadder.Set(NULL);
 	m_vecAutoAimPoint.GetForModify().Init();

--- a/src/game/server/hl2/hl2_playerlocaldata.h
+++ b/src/game/server/hl2/hl2_playerlocaldata.h
@@ -38,6 +38,7 @@ public:
 	CNetworkVar( int,	m_iSquadMedicCount );
 	CNetworkVar( bool,	m_fSquadInFollowMode );
 	CNetworkVar( bool,	m_bWeaponLowered );
+	CNetworkVar( bool,  m_bHoldingObject );
 	CNetworkVar( EHANDLE, m_hAutoAimTarget );
 	CNetworkVar( Vector, m_vecAutoAimPoint );
 	CNetworkVar( bool,	m_bDisplayReticle );

--- a/src/game/shared/hl2mp/weapon_hl2mpbase.cpp
+++ b/src/game/shared/hl2mp/weapon_hl2mpbase.cpp
@@ -136,6 +136,16 @@ CHL2MP_Player* CWeaponHL2MPBase::GetHL2MPPlayerOwner() const
 	return dynamic_cast< CHL2MP_Player* >( GetOwner() );
 }
 
+void CWeaponHL2MPBase::ItemPostFrame( void )
+{
+#ifdef CLIENT_DLL
+	// prevent phantom weapon fire occuring on the client when throwing a prop
+	if( GetHL2MPPlayerOwner() && GetHL2MPPlayerOwner()->IsHoldingAnyEntity() )
+		return;
+#endif
+	BaseClass::ItemPostFrame();
+}
+
 #ifdef CLIENT_DLL
 	
 void CWeaponHL2MPBase::OnDataChanged( DataUpdateType_t type )

--- a/src/game/shared/hl2mp/weapon_hl2mpbase.h
+++ b/src/game/shared/hl2mp/weapon_hl2mpbase.h
@@ -53,6 +53,8 @@ public:
 	CBasePlayer* GetPlayerOwner() const;
 	CHL2MP_Player* GetHL2MPPlayerOwner() const;
 
+	virtual void ItemPostFrame( void );
+
 	void WeaponSound( WeaponSound_t sound_type, float soundtime = 0.0f );
 	
 	CHL2MPSWeaponInfo const	&GetHL2MPWpnData() const;

--- a/src/game/shared/hl2mp/weapon_physcannon.cpp
+++ b/src/game/shared/hl2mp/weapon_physcannon.cpp
@@ -700,6 +700,7 @@ void CPlayerPickupController::Init( CBasePlayer *pPlayer, CBaseEntity *pObject )
 	if ( pOwner )
 	{
 		pOwner->EnableSprint( false );
+		pOwner->OnPickupObject();
 	}
 
 	// If the target is debris, convert it to non-debris
@@ -753,6 +754,7 @@ void CPlayerPickupController::Shutdown( bool bThrown )
 		if ( pOwner )
 		{
 			pOwner->EnableSprint( true );
+			pOwner->OnDropObject();
 		}
 
 		m_pPlayer->SetUseEntity( NULL );


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
With `hl2mp_allow_pickup` ConVar enabled, when a player picks up a prop and tries to throw it, a fake weapon fire on that client will be triggered. This PR fixes this issue by adding an early return in `CWeaponHL2MPBase::ItemPostFrame( void )` that gets run when the player is holding an object. 

In order to let the client know that it is holding an object a networked boolean was also added to HL2 local data that tracks if the player is holding an object or not.

https://github.com/user-attachments/assets/ed901653-40d9-45e2-9ec5-5bd07e5d9f37

##### ^ before

https://github.com/user-attachments/assets/6a35573e-644b-4220-bc8b-06d387320192

##### ^ after