### PR TITLE
[TF2] Fix cl_flipviewmodels 1 Flamethrowers, Dragon's Fury, Short Circuit and Spellbook spawn position.

### DIFF
--- a/src/game/shared/tf/halloween/tf_weapon_spellbook.cpp
+++ b/src/game/shared/tf/halloween/tf_weapon_spellbook.cpp
@@ -939,10 +939,9 @@ void CTFSpellBook::TossJarThink( void )
 	Vector vecForward, vecRight, vecUp;
 	AngleVectors( pPlayer->EyeAngles(), &vecForward, &vecRight, &vecUp );
 
-	float fRight = 8.f;
 	if ( IsViewModelFlipped() )
 	{
-		fRight *= -1;
+		vecRight *= -1;
 	}
 	Vector vecSrc = pPlayer->Weapon_ShootPosition();
 	// Make spell toss position at the hand

--- a/src/game/shared/tf/tf_weapon_dragons_fury.cpp
+++ b/src/game/shared/tf/tf_weapon_dragons_fury.cpp
@@ -147,10 +147,9 @@ CBaseEntity* CTFWeaponFlameBall::FireProjectile( CTFPlayer *pPlayer )
 	Vector vecForward, vecRight, vecUp;
 	AngleVectors( pPlayer->EyeAngles(), &vecForward, &vecRight, &vecUp );
 
-	float fRight = 8.f;
 	if ( IsViewModelFlipped() )
 	{
-		fRight *= -1;
+		vecRight *= -1;
 	}
 	Vector vecSrc = pPlayer->Weapon_ShootPosition();
 	// Shoot from the right location

--- a/src/game/shared/tf/tf_weapon_flamethrower.cpp
+++ b/src/game/shared/tf/tf_weapon_flamethrower.cpp
@@ -724,7 +724,7 @@ void CTFFlameThrower::PrimaryAttack()
 	// Make sure the weapon can't fire in this condition by tracing a line between the eye point and the end of the muzzle.
 	trace_t trace;	
 	Vector vecEye = pOwner->EyePosition();
-	Vector vecMuzzlePos = GetVisualMuzzlePos();
+	Vector vecMuzzlePos = GetFlameOriginPos();
 	CTraceFilterIgnoreObjects traceFilter( this, COLLISION_GROUP_NONE );
 	UTIL_TraceLine( vecEye, vecMuzzlePos, MASK_SOLID, &traceFilter, &trace );
 	if ( trace.fraction < 1.0 && ( !trace.m_pEnt || trace.m_pEnt->m_takedamage == DAMAGE_NO ) )
@@ -2121,6 +2121,13 @@ Vector CTFFlameThrower::GetMuzzlePosHelper( bool bVisualPos )
 			UTIL_StringToVector( vecOffset.Base(), tf_flamethrower_new_flame_offset.GetString() );
 
 			vecOffset *= pOwner->GetModelScale();
+
+			// Inverts the horizontal offset for flipped view models.
+			if ( IsViewModelFlipped() )
+			{
+				vecOffset.y *= -1;
+			}
+
 			vecMuzzlePos = pOwner->EyePosition() + vecOffset.x * vecForward + vecOffset.y * vecRight + vecOffset.z * vecUp;
 		}
 	}

--- a/src/game/shared/tf/tf_weapon_mechanical_arm.cpp
+++ b/src/game/shared/tf/tf_weapon_mechanical_arm.cpp
@@ -250,10 +250,9 @@ void CTFMechanicalArm::SecondaryAttack( void )
 		Vector vecForward, vecRight, vecUp;
 		AngleVectors( pOwner->EyeAngles(), &vecForward, &vecRight, &vecUp );
 
-		float fRight = 8.f;
 		if ( IsViewModelFlipped() )
 		{
-			fRight *= -1;
+			vecRight *= -1;
 		}
 // 		Vector vecSrc = pOwner->Weapon_ShootPosition();
 // 		vecSrc = vecSrc + ( vecUp * -9.0f ) + ( vecRight * 7.0f ) + ( vecForward * 3.0f );


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description

This PR makes cl_flipviewmodels 1 affect the initial position of Flamethrowers, Dragon’s Fury, Short Circuit, and Spellbooks. 

The Dragon’s Fury, Short Circuit, and Spellbooks had code meant to flip the position while cl_flipviewmodels is enabled, but it was not implemented correctly. Additionally, the flamethrowers did not have code implemented for cl_flipviewmodels.

# Changes

- Fixed Flamethrowers not being affected by cl_flipviewmodels.
- Fixed Dragon's Fury not being affected by cl_flipviewmodels.
- Fixed Short Circuit not being affected by cl_flipviewmodels.
- Fixed Spellbooks not being affected by cl_flipviewmodels.

## Before Changes

https://github.com/user-attachments/assets/875890d3-38dc-4456-9fdf-dfa905cd1f14

## After Changes

https://github.com/user-attachments/assets/4b8bdc11-359f-42e8-a6ac-5eb286b452bb
