### PR TITLE
[ALL] Add a command to clear chat history.

### DIFF
--- a/src/game/client/hud_basechat.cpp
+++ b/src/game/client/hud_basechat.cpp
@@ -1870,3 +1870,12 @@ void CBaseHudChat::FireGameEvent( IGameEvent *event )
 	}
 #endif
 }
+
+CON_COMMAND( cl_clearchathistory, "Clears the chat history" )
+{
+	CBaseHudChat *pChat = ( CBaseHudChat * ) gHUD.FindElement( "CHudChat" );
+	if ( pChat )
+	{
+		pChat->GetChatHistory()->SetText( "" );
+	}
+}


### PR DESCRIPTION
# Description
Adds a console command to allow players to clear chat history.

# Reasoning
After playing on populated server with active chat for a while, the chat history gets clogged with thousands of messages. 

Due to this, when opening chat your game will freeze for a short period of time. 

This freezing scales with how much messages are stored in chat. 

So, the simplest solution is to allow the chat history to be cleared by a console command.