### PR TITLE
[ALL] net_graph: Fix a bug where net_graphproportionalfont and net_graphheight is non-functional after changing resolutions.

### DIFF
--- a/src/game/client/vgui_netgraphpanel.cpp
+++ b/src/game/client/vgui_netgraphpanel.cpp
@@ -328,6 +328,7 @@ void CNetGraphPanel::OnFontChanged()
 void CNetGraphPanel::ApplySchemeSettings(IScheme *pScheme)
 {
 	BaseClass::ApplySchemeSettings(pScheme);
+	g_pNetGraphPanel = this;
 
 	m_hFont = pScheme->GetFont( "DefaultFixedOutline", false );
 	m_hFontProportional = pScheme->GetFont( "DefaultFixedOutline", true );


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
After changing resolutions when net_graph is enabled, net_graphproportionalfont/net_graphheight doesn't work as g_pNetGraphPanel is set to NULL even if the panel is currently available. As g_pNetGraphPanel is null, that means it won't call OnFontChanged(), which is important when adjusting both ConVars.

To fix this, g_pNetGraphPanel should be set to the panel when ApplySchemeSettings is called. Switching resolutions calls this function, so it makes sense to initialize g_pNetGraphPanel here.

This fix was done as a result of researching a way to enable proportional text for #1261.