### PR TITLE
[ALL] Refactor how kills with VPhysics objects are handled.

### DIFF
--- a/src/game/server/basecombatcharacter.cpp
+++ b/src/game/server/basecombatcharacter.cpp
@@ -3194,11 +3194,11 @@ void CBaseCombatCharacter::VPhysicsShadowCollision( int index, gamevcollisioneve
 	CTakeDamageInfo dmgInfo( pOther, pAttacker, damageForce, damagePos, damage, damageType );
 
 	// FIXME: is there a better way for physics objects to keep track of what root entity responsible for them moving?
-	CBasePlayer *pPlayer = pOther->HasPhysicsAttacker( 1.0 );
+	/*CBasePlayer *pPlayer = pOther->HasPhysicsAttacker( 1.0 );
 	if (pPlayer)
 	{
 		dmgInfo.SetAttacker( pPlayer );
-	}
+	}*/
 
 	// UNDONE: Find one near damagePos?
 	m_nForceBone = 0;

--- a/src/game/server/basecombatcharacter.cpp
+++ b/src/game/server/basecombatcharacter.cpp
@@ -3184,7 +3184,14 @@ void CBaseCombatCharacter::VPhysicsShadowCollision( int index, gamevcollisioneve
 
 	Vector damagePos;
 	pEvent->pInternalData->GetContactPoint( damagePos );
-	CTakeDamageInfo dmgInfo( pOther, pOther, damageForce, damagePos, damage, damageType );
+	CBaseEntity* pAttacker = pOther;
+
+	if (pOther->GetOwnerEntity() != NULL)
+	{
+		pAttacker = pOther->GetOwnerEntity();
+	}
+
+	CTakeDamageInfo dmgInfo( pOther, pAttacker, damageForce, damagePos, damage, damageType );
 
 	// FIXME: is there a better way for physics objects to keep track of what root entity responsible for them moving?
 	CBasePlayer *pPlayer = pOther->HasPhysicsAttacker( 1.0 );


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
For whatever reason, VPhysicsShadowCollision in CBaseCombatCharacter doesn't set the owner entity properly when calculating collision damage between entities. This results in rare instances where entities aren't credited for the kill, and is presumably the reason why this block of code was written:

```
// FIXME: is there a better way for physics objects to keep track of what root entity responsible for them moving?
CBasePlayer* pPlayer = pOther->HasPhysicsAttacker(1.0);
if (pPlayer)
{
	dmgInfo.SetAttacker( pPlayer );
}
```

This PR correctly sets it so any VPhysics kills (mainly with the combine ball, but could effect other instances) will always mark the owner entity as the attacker, rather than the entity that attacked. This addresses the FIXME comment above, while also addressing other more rare instances (such as NPCs that fire insta-kill energy balls in some mods).