### PR TITLE
[TF2] NPC damage notice fixes

### DIFF
--- a/src/game/server/tf/bot_npc/bot_npc.cpp
+++ b/src/game/server/tf/bot_npc/bot_npc.cpp
@@ -526,7 +526,7 @@ int CBotNPC::OnTakeDamage_Alive( const CTakeDamageInfo &rawInfo )
 	if ( event )
 	{
 		event->SetInt( "entindex", entindex() );
-		event->SetInt( "health", MAX( 0, GetHealth() ) );
+		event->SetInt( "health", MAX( 0, GetHealth() - info.GetDamage() ) );
 		event->SetInt( "damageamount", info.GetDamage() );
 		event->SetBool( "crit", ( info.GetDamageType() & DMG_CRITICAL ) ? true : false );
 

--- a/src/game/server/tf/bot_npc/bot_npc_minion.cpp
+++ b/src/game/server/tf/bot_npc/bot_npc_minion.cpp
@@ -201,7 +201,7 @@ int CBotNPCMinion::OnTakeDamage_Alive( const CTakeDamageInfo &rawInfo )
 	if ( event )
 	{
 		event->SetInt( "entindex", entindex() );
-		event->SetInt( "health", MAX( 0, GetHealth() ) );
+		event->SetInt( "health", MAX( 0, GetHealth() - info.GetDamage() ) );
 		event->SetInt( "damageamount", info.GetDamage() );
 		event->SetBool( "crit", ( info.GetDamageType() & DMG_CRITICAL ) ? true : false );
 

--- a/src/game/server/tf/halloween/halloween_base_boss.cpp
+++ b/src/game/server/tf/halloween/halloween_base_boss.cpp
@@ -139,7 +139,7 @@ int CHalloweenBaseBoss::OnTakeDamage_Alive( const CTakeDamageInfo &rawInfo )
 	if ( event )
 	{
 		event->SetInt( "entindex", entindex() );
-		event->SetInt( "health", MAX( 0, GetHealth() ) );
+		event->SetInt( "health", MAX( 0, GetHealth() - info.GetDamage() ) );
 		event->SetInt( "damageamount", info.GetDamage() );
 		event->SetBool( "crit", ( info.GetDamageType() & DMG_CRITICAL ) ? true : false );
 		event->SetInt( "boss", GetBossType() );

--- a/src/game/server/tf/halloween/zombie/zombie.cpp
+++ b/src/game/server/tf/halloween/zombie/zombie.cpp
@@ -269,7 +269,7 @@ int CZombie::OnTakeDamage_Alive( const CTakeDamageInfo &info )
 	if ( event )
 	{
 		event->SetInt( "entindex", entindex() );
-		event->SetInt( "health", MAX( 0, GetHealth() ) );
+		event->SetInt( "health", MAX( 0, GetHealth() - info.GetDamage() ) );
 		event->SetInt( "damageamount", info.GetDamage() );
 		event->SetBool( "crit", ( info.GetDamageType() & DMG_CRITICAL ) ? true : false );
 

--- a/src/game/server/tf/player_vs_environment/boss_alpha/boss_alpha.cpp
+++ b/src/game/server/tf/player_vs_environment/boss_alpha/boss_alpha.cpp
@@ -702,7 +702,7 @@ int CBossAlpha::OnTakeDamage_Alive( const CTakeDamageInfo &rawInfo )
 	if ( event )
 	{
 		event->SetInt( "entindex", entindex() );
-		event->SetInt( "health", MAX( 0, GetHealth() ) );
+		event->SetInt( "health", MAX( 0, GetHealth() - info.GetDamage() ) );
 		event->SetInt( "damageamount", info.GetDamage() );
 		event->SetBool( "crit", ( info.GetDamageType() & DMG_CRITICAL ) ? true : false );
 

--- a/src/game/server/tf/player_vs_environment/tf_base_boss.cpp
+++ b/src/game/server/tf/player_vs_environment/tf_base_boss.cpp
@@ -497,7 +497,7 @@ int CTFBaseBoss::OnTakeDamage_Alive( const CTakeDamageInfo &rawInfo )
 	{
 
 		event->SetInt( "entindex", entindex() );
-		event->SetInt( "health", MAX( 0, GetHealth() ) );
+		event->SetInt( "health", MAX( 0, GetHealth() - info.GetDamage() ) );
 		event->SetInt( "damageamount", info.GetDamage() );
 		event->SetBool( "crit", ( info.GetDamageType() & DMG_CRITICAL ) ? true : false );
 


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
Adds a damage event to Halloween NPCs that didn't have them, meaning they give feedback with hitsounds/killsounds.