### PR TITLE
[TF2] Improve meter consistency and 

### DIFF
--- a/game/mod_tf/resource/ui/huditemeffectmeter_flaregun.res
+++ b/game/mod_tf/resource/ui/huditemeffectmeter_flaregun.res
@@ -1,0 +1,102 @@
+"Resource/UI/HUDItemEffectMeter_Flaregun.res"
+{
+	HudItemEffectMeter
+	{
+		"fieldName"		"HudItemEffectMeter"
+		"visible"		"1"
+		"enabled"		"1"
+		"xpos"			"r162"	[$WIN32]
+		"ypos"			"r92"	[$WIN32]
+		"xpos_minmode"	"r70"	[$WIN32]
+		"ypos_minmode"	"r74"	[$WIN32]
+		"xpos"			"r194"	[$X360]
+		"ypos"			"r74"	[$X360]
+		"wide"			"100"
+		"tall"			"50"
+		"MeterFG"		"White"
+		"MeterBG"		"Gray"
+	}
+	
+	"ItemEffectMeterBG"
+	{
+		"ControlName"	"CTFImagePanel"
+		"fieldName"		"ItemEffectMeterBG"
+		"xpos"			"12"
+		"ypos"			"0"
+		"zpos"			"0"
+		"wide"			"76"
+		"tall"			"44"
+		"visible"		"1"
+		"visible_minmode"	"0"
+		"enabled"		"1"
+		"image"			"../hud/misc_ammo_area_blue"
+		"scaleImage"	"1"	
+		"teambg_2"		"../hud/misc_ammo_area_red"
+		"teambg_2_lodef"	"../hud/misc_ammo_area_red_lodef"
+		"teambg_3"		"../hud/misc_ammo_area_blue"
+		"teambg_3_lodef"	"../hud/misc_ammo_area_blue_lodef"				
+	}
+	
+	"ItemEffectMeterLabel"
+	{
+		"ControlName"			"CExLabel"
+		"fieldName"				"ItemEffectMeterLabel"
+		"xpos"					"25"
+		"ypos"					"27"
+		"zpos"					"2"
+		"wide"					"41"
+		"tall"					"15"
+		"autoResize"			"1"
+		"pinCorner"				"2"
+		"visible"				"1"
+		"enabled"				"1"
+		"tabPosition"			"0"
+		"labelText"				"#TF_Ball"
+		"textAlignment"			"center"
+		"dulltext"				"0"
+		"brighttext"			"0"
+		"font"					"TFFontSmall"
+	}
+
+	"ItemEffectMeter"
+	{	
+		"ControlName"			"ContinuousProgressBar"
+		"fieldName"				"ItemEffectMeter"
+		"font"					"Default"
+		"xpos"					"25"
+		"ypos"					"23"
+		"ypos_minmode"			"0"
+		"xpos_minmode"			"0"
+		"zpos"					"2"
+		"wide"					"40"
+		"wide_minmode"			"50"
+		"tall"					"6"				
+		"autoResize"			"0"
+		"pinCorner"				"0"
+		"visible"				"0"
+		"enabled"				"0"
+		"textAlignment"			"Left"
+		"dulltext"				"0"
+		"brighttext"			"0"
+	}					
+	
+	"ItemEffectMeterCount"
+	{
+		"ControlName"			"CExLabel"
+		"fieldName"				"ItemEffectMeterCount"
+		"xpos"					"25"
+		"ypos"					"10"
+		"zpos"					"2"
+		"wide"					"40"
+		"tall"					"20"	
+		"pinCorner"				"2"
+		"visible"				"1"
+		"enabled"				"1"
+		"tabPosition"			"0"
+		"labelText"				"%progresscount%"
+		"textAlignment"			"north"
+		"dulltext"				"0"
+		"brighttext"			"0"
+		"font"					"HudFontMedium"
+	}
+}

--- a/game/mod_tf/resource/ui/huditemeffectmeter_medic.res
+++ b/game/mod_tf/resource/ui/huditemeffectmeter_medic.res
@@ -1,0 +1,88 @@
+"Resource/UI/HudItemEffectMeter_Medic.res"
+{
+	HudItemEffectMeter
+	{
+		"fieldName"		"HudItemEffectMeter"
+		"visible"		"1"
+		"enabled"		"1"
+		"x_offset"		"40"
+		"xpos"			"r174"	[$WIN32]
+		"ypos"			"r57"	[$WIN32]
+		"xpos_minmode"	"r52"	[$WIN32]
+		"ypos_minmode"	"r68"	[$WIN32]
+		"x_offset_minmode"		"0"	[$WIN32]
+		"xpos"			"r194"	[$X360]
+		"ypos"			"r124"	[$X360]
+		"wide"			"100"
+		"tall"			"50"
+		"MeterFG"		"White"
+		"MeterBG"		"Gray"
+	}
+	
+	"ItemEffectMeterBG"
+	{
+		"ControlName"	"CTFImagePanel"
+		"fieldName"		"ItemEffectMeterBG"
+		"xpos"			"12"
+		"ypos"			"0"
+		"zpos"			"0"
+		"wide"			"100"
+		"tall"			"50"
+		"visible"		"1"
+		"visible_minmode"	"0"
+		"enabled"		"1"
+		"image"			"../hud/misc_ammo_area_horiz2_blue"
+		"scaleImage"	"1"	
+		"teambg_2"		"../hud/misc_ammo_area_horiz2_red"
+		"teambg_2_lodef"	"../hud/misc_ammo_area_red_lodef"
+		"teambg_3"		"../hud/misc_ammo_area_horiz2_blue"
+		"teambg_3_lodef"	"../hud/misc_ammo_area_blue_lodef"				
+	}
+	
+	"ItemEffectMeterLabel"
+	{
+		"ControlName"			"CExLabel"
+		"fieldName"				"ItemEffectMeterLabel"
+		"xpos"					"40"
+		"ypos"					"25"
+		"zpos"					"2"
+		"wide"					"41"
+		"tall"					"15"
+		"autoResize"			"1"
+		"pinCorner"				"2"
+		"visible"				"1"
+		"visible_minmode"		"1"
+		"ypos_minmode"			"1"
+		"xpos_minmode"			"0"
+		"textAlignment_minmode"			"west"
+		"enabled"				"1"
+		"tabPosition"			"0"
+		"labelText"				"#TF_ENERGYDRINK"
+		"textAlignment"			"center"
+		"dulltext"				"0"
+		"brighttext"			"0"
+		"font"					"TFFontSmall"
+	}
+
+	"ItemEffectMeter"
+	{	
+		"ControlName"			"ContinuousProgressBar"
+		"fieldName"				"ItemEffectMeter"
+		"font"					"Default"
+		"xpos"					"45"
+		"ypos"					"23"
+		"ypos_minmode"			"0"
+		"xpos_minmode"			"0"
+		"zpos"					"2"
+		"wide"					"30"
+		"wide_minmode"			"50"
+		"tall"					"5"				
+		"autoResize"			"0"
+		"pinCorner"				"0"
+		"visible"				"1"
+		"enabled"				"1"
+		"textAlignment"			"Left"
+		"dulltext"				"0"
+		"brighttext"			"0"
+	}					
+}

--- a/game/mod_tf/resource/ui/huditemeffectmeter_soldier.res
+++ b/game/mod_tf/resource/ui/huditemeffectmeter_soldier.res
@@ -1,0 +1,102 @@
+"Resource/UI/HUDItemEffectMeter_Soldier.res"
+{
+	HudItemEffectMeter
+	{
+		"fieldName"		"HudItemEffectMeter"
+		"visible"		"1"
+		"enabled"		"1"
+		"xpos"			"r162"	[$WIN32]
+		"ypos"			"r92"	[$WIN32]
+		"xpos_minmode"	"r70"	[$WIN32]
+		"ypos_minmode"	"r74"	[$WIN32]
+		"xpos"			"r194"	[$X360]
+		"ypos"			"r74"	[$X360]
+		"wide"			"100"
+		"tall"			"50"
+		"MeterFG"		"White"
+		"MeterBG"		"Gray"
+	}
+	
+	"ItemEffectMeterBG"
+	{
+		"ControlName"	"CTFImagePanel"
+		"fieldName"		"ItemEffectMeterBG"
+		"xpos"			"12"
+		"ypos"			"0"
+		"zpos"			"0"
+		"wide"			"76"
+		"tall"			"44"
+		"visible"		"1"
+		"visible_minmode"	"0"
+		"enabled"		"1"
+		"image"			"../hud/misc_ammo_area_blue"
+		"scaleImage"	"1"	
+		"teambg_2"		"../hud/misc_ammo_area_red"
+		"teambg_2_lodef"	"../hud/misc_ammo_area_red_lodef"
+		"teambg_3"		"../hud/misc_ammo_area_blue"
+		"teambg_3_lodef"	"../hud/misc_ammo_area_blue_lodef"				
+	}
+	
+	"ItemEffectMeterLabel"
+	{
+		"ControlName"			"CExLabel"
+		"fieldName"				"ItemEffectMeterLabel"
+		"xpos"					"25"
+		"ypos"					"27"
+		"zpos"					"2"
+		"wide"					"41"
+		"tall"					"15"
+		"autoResize"			"1"
+		"pinCorner"				"2"
+		"visible"				"1"
+		"enabled"				"1"
+		"tabPosition"			"0"
+		"labelText"				"#TF_Ball"
+		"textAlignment"			"center"
+		"dulltext"				"0"
+		"brighttext"			"0"
+		"font"					"TFFontSmall"
+	}
+
+	"ItemEffectMeter"
+	{	
+		"ControlName"			"ContinuousProgressBar"
+		"fieldName"				"ItemEffectMeter"
+		"font"					"Default"
+		"xpos"					"25"
+		"ypos"					"23"
+		"ypos_minmode"			"0"
+		"xpos_minmode"			"0"
+		"zpos"					"2"
+		"wide"					"40"
+		"wide_minmode"			"50"
+		"tall"					"6"				
+		"autoResize"			"0"
+		"pinCorner"				"0"
+		"visible"				"0"
+		"enabled"				"0"
+		"textAlignment"			"Left"
+		"dulltext"				"0"
+		"brighttext"			"0"
+	}					
+	
+	"ItemEffectMeterCount"
+	{
+		"ControlName"			"CExLabel"
+		"fieldName"				"ItemEffectMeterCount"
+		"xpos"					"25"
+		"ypos"					"10"
+		"zpos"					"2"
+		"wide"					"40"
+		"tall"					"20"	
+		"pinCorner"				"2"
+		"visible"				"1"
+		"enabled"				"1"
+		"tabPosition"			"0"
+		"labelText"				"%progresscount%"
+		"textAlignment"			"north"
+		"dulltext"				"0"
+		"brighttext"			"0"
+		"font"					"HudFontMedium"
+	}
+}

--- a/src/game/client/tf/tf_hud_itemeffectmeter.cpp
+++ b/src/game/client/tf/tf_hud_itemeffectmeter.cpp
@@ -21,6 +21,7 @@
 #include "tf_weapon_flaregun.h"
 #include "tf_weapon_revolver.h"
 #include "tf_weapon_flamethrower.h"
+#include "tf_weapon_dragons_fury.h"
 #include "tf_weapon_knife.h"
 #include "tf_item_powerup_bottle.h"
 #include "tf_imagepanel.h"
@@ -304,7 +305,7 @@ void CHudItemEffectMeter::CreateHudElementsForClass( C_TFPlayer* pPlayer, CUtlVe
 		DECLARE_ITEM_EFFECT_METER( CTFBuffItem, TF_WEAPON_BUFF_ITEM, true, NULL );
 		DECLARE_ITEM_EFFECT_METER( CTFParticleCannon, TF_WEAPON_PARTICLE_CANNON, false, "resource/UI/HUDItemEffectMeter_ParticleCannon.res" );
 		DECLARE_ITEM_EFFECT_METER( CTFRaygun, TF_WEAPON_RAYGUN, false, "resource/UI/HUDItemEffectMeter_Raygun.res" );
-		DECLARE_ITEM_EFFECT_METER( CTFRocketLauncher_AirStrike, TF_WEAPON_ROCKETLAUNCHER, false, "resource/UI/HudItemEffectMeter_Demoman.res" );
+		DECLARE_ITEM_EFFECT_METER( CTFRocketLauncher_AirStrike, TF_WEAPON_ROCKETLAUNCHER, false, "resource/UI/HUDItemEffectMeter_Soldier.res" ); // respect shared meter language
 		break;
 
 	case TF_CLASS_SPY:
@@ -326,20 +327,20 @@ void CHudItemEffectMeter::CreateHudElementsForClass( C_TFPlayer* pPlayer, CUtlVe
 	case TF_CLASS_ENGINEER:
 		DECLARE_ITEM_EFFECT_METER( CTFShotgun_Revenge, TF_WEAPON_SENTRY_REVENGE, false, "resource/UI/HUDItemEffectMeter_Engineer.res" );
 		DECLARE_ITEM_EFFECT_METER( CTFDRGPomson, TF_WEAPON_DRG_POMSON, false, "resource/UI/HUDItemEffectMeter_Pomson.res" );
-		DECLARE_ITEM_EFFECT_METER( CTFRevolver, TF_WEAPON_REVOLVER, false, "resource/UI/HUDItemEffectMeter_Spy.res" );
+		DECLARE_ITEM_EFFECT_METER( CTFRevolver, TF_WEAPON_REVOLVER, false, "resource/UI/HUDItemEffectMeter_Engineer.res" ); // respect shared meter language
 		break;
 
 	case TF_CLASS_PYRO:
 	{
 		DECLARE_ITEM_EFFECT_METER( CTFFlameThrower, TF_WEAPON_FLAMETHROWER, true, "resource/UI/HudItemEffectMeter_Pyro.res" );
-		DECLARE_ITEM_EFFECT_METER( CTFFlareGun_Revenge, TF_WEAPON_FLAREGUN_REVENGE, false, "resource/UI/HUDItemEffectMeter_Engineer.res" );
+		DECLARE_ITEM_EFFECT_METER( CTFFlareGun_Revenge, TF_WEAPON_FLAREGUN_REVENGE, false, "resource/UI/HUDItemEffectMeter_Flaregun.res" ); // respect shared meter language
 		DECLARE_ITEM_EFFECT_METER( CTFRocketPack, TF_WEAPON_ROCKETPACK, false, "resource/UI/HudRocketPack.res" );
+		DECLARE_ITEM_EFFECT_METER( CTFWeaponFlameBall, TF_WEAPON_FLAME_BALL, false, "resource/UI/HudItemEffectMeter_Pyro.res" );
 		lambdaAddItemEffectMeter( "tf_weapon_jar_gas", true );
-		lambdaAddItemEffectMeter( "tf_weapon_rocketlauncher_fireball", false );
 		break;
 	}
 	case TF_CLASS_MEDIC:
-		DECLARE_ITEM_EFFECT_METER( CWeaponMedigun, TF_WEAPON_MEDIGUN, true, "resource/UI/HudItemEffectMeter_Scout.res" );
+		DECLARE_ITEM_EFFECT_METER( CWeaponMedigun, TF_WEAPON_MEDIGUN, true, "resource/UI/HudItemEffectMeter_Medic.res" ); // respect shared meter language
 		DECLARE_ITEM_EFFECT_METER( CTFBonesaw, TF_WEAPON_BONESAW, false, "resource/UI/HUDItemEffectMeter_Organs.res" );
 		break;
 	}
@@ -871,6 +872,20 @@ bool CHudItemEffectMeter_Weapon<CTFFlameThrower>::ShouldFlash( void )
 }
 
 //-----------------------------------------------------------------------------
+template <>
+bool CHudItemEffectMeter_Weapon<CTFWeaponFlameBall>::IsEnabled( void )
+{
+	if ( !m_pPlayer )
+		return false;
+
+	CTFWeaponFlameBall *pWeapon = GetWeapon();
+	if ( !pWeapon )
+		return false;
+
+	return pWeapon->ShouldDrawMeter();
+}
+
+//-----------------------------------------------------------------------------
 // Soda Popper Flash
 //-----------------------------------------------------------------------------
 template <>
@@ -1018,16 +1033,6 @@ int CHudItemEffectMeter_Weapon<CTFShotgun_Revenge>::GetCount( void )
 	{
 		return 0.f;
 	}
-}
-
-template <>
-bool CHudItemEffectMeter_Weapon<CTFFlareGun_Revenge>::IsEnabled( void )
-{
-	if ( !m_pPlayer )
-		return false;
-
-	CTFFlareGun_Revenge *pWeapon = GetWeapon();
-	return pWeapon && pWeapon->IsActiveByLocalPlayer();
 }
 
 template <>

--- a/src/game/shared/tf/tf_weapon_dragons_fury.cpp
+++ b/src/game/shared/tf/tf_weapon_dragons_fury.cpp
@@ -57,6 +57,10 @@ END_DATADESC()
 ConVar tf_fireball_airblast_recharge_penalty( "tf_fireball_airblast_recharge_penalty", "0.5", FCVAR_REPLICATED | FCVAR_CHEAT );
 ConVar tf_fireball_hit_recharge_boost( "tf_fireball_hit_recharge_boost", "1.5", FCVAR_REPLICATED | FCVAR_CHEAT );
 
+#ifdef CLIENT_DLL
+ConVar tf_fireball_show_pressure( "tf_fireball_show_pressure", "0", FCVAR_ARCHIVE );
+#endif
+
 CTFWeaponFlameBall::CTFWeaponFlameBall()
 {
 	m_flRechargeScale = 1.f;
@@ -280,6 +284,15 @@ void CTFWeaponFlameBall::ItemPostFrame( void )
 	}
 }
 
+float CTFWeaponFlameBall::GetProgress( void )
+{
+	CTFPlayer *pPlayer = GetTFPlayerOwner();
+	if ( !pPlayer )
+		return 0.f;
+
+	return pPlayer->m_Shared.GetItemChargeMeter( LOADOUT_POSITION_PRIMARY ) / 100.0f;
+}
+
 void CTFWeaponFlameBall::OnResourceMeterFilled()
 {
 	m_flRechargeScale = 1.f;
@@ -349,7 +362,7 @@ void CTFWeaponFlameBall::OnDataChanged( DataUpdateType_t updateType )
 bool CTFWeaponFlameBall::ShouldDrawMeter() const
 {
 	// There's a meter on the gun, so don't draw the meter
-	return false;	
+	return tf_fireball_show_pressure.GetBool();
 }
 
 void CTFWeaponFlameBall::UpdatePoseParams()

--- a/src/game/shared/tf/tf_weapon_dragons_fury.h
+++ b/src/game/shared/tf/tf_weapon_dragons_fury.h
@@ -52,8 +52,10 @@ public:
 
 	bool HasFullCharge() const;
 
+	float			GetProgress( void );
 	virtual void	OnResourceMeterFilled() OVERRIDE;
 	virtual float	GetMeterMultiplier() const OVERRIDE;
+	const char*		GetEffectLabelText( void ) { return "#TF_PRESSURE"; }
 
 #ifdef GAME_DLL
 	virtual float GetInitialAfterburnDuration() const OVERRIDE { return 0.f; }


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
This PR does a few things with weapon meters/counters
1. Makes the organization/naming scheme more consistent, enabling flexibility for HUD developers
2. Makes the Manmelter Crit counter always present
3. Adds the unfinished pressure meter for the Dragon's Fury with a convar 

