### PR TITLE
[TF2] Sniper Rifle hold zoom

### DIFF
--- a/src/game/client/tf/c_tf_player.cpp
+++ b/src/game/client/tf/c_tf_player.cpp
@@ -206,6 +206,7 @@ ConVar cl_autorezoom( "cl_autorezoom", "1", FCVAR_USERINFO | FCVAR_ARCHIVE, "Whe
 ConVar tf_remember_activeweapon( "tf_remember_activeweapon", "0", FCVAR_CLIENTDLL | FCVAR_ARCHIVE | FCVAR_USERINFO, "Setting this to 1 will make the active weapon persist between lives." );
 ConVar tf_remember_lastswitched( "tf_remember_lastswitched", "0", FCVAR_CLIENTDLL | FCVAR_ARCHIVE | FCVAR_USERINFO, "Setting this to 1 will make the 'last weapon' persist between lives." );
 ConVar cl_autoreload( "cl_autoreload", "1", FCVAR_USERINFO | FCVAR_ARCHIVE, "When set to 1, clip-using weapons will automatically be reloaded whenever they're not being fired." );
+ConVar cl_holdzoom( "cl_holdzoom", "0", FCVAR_USERINFO | FCVAR_ARCHIVE, "When set to 1, sniper rifle will zoom as long as you hold the zoom button." );
 
 ConVar tf_respawn_on_loadoutchanges( "tf_respawn_on_loadoutchanges", "1", FCVAR_ARCHIVE, "When set to 1, you will automatically respawn whenever you change loadouts inside a respawn zone." );
 

--- a/src/game/client/tf/c_tf_player.h
+++ b/src/game/client/tf/c_tf_player.h
@@ -43,6 +43,7 @@ class C_PasstimeAskForBallReticle;
 extern ConVar tf_medigun_autoheal;
 extern ConVar cl_autorezoom;
 extern ConVar cl_autoreload;
+extern ConVar cl_holdzoom;
 
 enum EBonusEffectFilter_t
 {
@@ -293,6 +294,7 @@ public:
 	bool			GetMedigunAutoHeal( void ){ return tf_medigun_autoheal.GetBool(); }
 	bool			ShouldAutoRezoom( void ){ return cl_autorezoom.GetBool(); }
 	bool			ShouldAutoReload( void ){ return cl_autoreload.GetBool(); }
+	bool			ShouldHoldZoom( void ){ return cl_holdzoom.GetBool(); }
 
 	void			GetTargetIDDataString( bool bIsDisguised, OUT_Z_BYTECAP(iMaxLenInBytes) wchar_t *sDataString, int iMaxLenInBytes, bool &bIsAmmoData, bool &bIsKillStreakData );
 

--- a/src/game/server/tf/tf_player.h
+++ b/src/game/server/tf/tf_player.h
@@ -497,6 +497,8 @@ public:
 	void SetAutoRezoom( bool bAutoRezoom ) { m_bAutoRezoom = bAutoRezoom; }
 	bool ShouldAutoReload( void ){ return m_bAutoReload; }
 	void SetAutoReload( bool bAutoReload ) { m_bAutoReload = bAutoReload; }
+	bool ShouldHoldZoom( void ){ return m_bHoldZoom; }
+	void SetHoldZoom( bool bHoldZoom ) { m_bHoldZoom = bHoldZoom; }
 
 	virtual void	ModifyOrAppendCriteria( AI_CriteriaSet& criteriaSet );
 
@@ -1265,6 +1267,7 @@ private:
 	bool 				m_bMedigunAutoHeal;
 	bool				m_bAutoRezoom;	// does the player want to re-zoom after each shot for sniper rifles
 	bool				m_bAutoReload;
+	bool				m_bHoldZoom;
 
 	bool				m_bForceItemRemovalOnRespawn;
 

--- a/src/game/shared/tf/tf_gamerules.cpp
+++ b/src/game/shared/tf/tf_gamerules.cpp
@@ -10231,6 +10231,7 @@ void CTFGameRules::ClientSettingsChanged( CBasePlayer *pPlayer )
 	// keep track of their cl_autorezoom value
 	pTFPlayer->SetAutoRezoom( Q_atoi( engine->GetClientConVarValue( pPlayer->entindex(), "cl_autorezoom" ) ) > 0 );
 	pTFPlayer->SetAutoReload( Q_atoi( engine->GetClientConVarValue( pPlayer->entindex(), "cl_autoreload" ) ) > 0 );
+	pTFPlayer->SetHoldZoom( Q_atoi( engine->GetClientConVarValue( pPlayer->entindex(), "cl_holdzoom" ) ) > 0 );
 
 	// keep track of their tf_remember_lastswitched value
 	pTFPlayer->SetRememberActiveWeapon( Q_atoi( engine->GetClientConVarValue( pPlayer->entindex(), "tf_remember_activeweapon" ) ) > 0 );

--- a/src/game/shared/tf/tf_weapon_sniperrifle.cpp
+++ b/src/game/shared/tf/tf_weapon_sniperrifle.cpp
@@ -307,7 +307,29 @@ void CTFSniperRifle::HandleZooms( void )
 		}
 	}
 
-	if ( ( pPlayer->m_nButtons & IN_ATTACK2 ) && ( m_flNextSecondaryAttack <= gpGlobals->curtime ) )
+	if ( pPlayer->ShouldHoldZoom() )
+	{
+		if ( m_flNextSecondaryAttack <= gpGlobals->curtime )
+		{
+			if ( pPlayer->m_nButtons & IN_ATTACK2 )
+			{
+				if ( !IsZoomed() && gpGlobals->curtime > m_flNextPrimaryAttack )
+				{
+					Zoom();
+				}
+			}
+			else
+			{
+				if ( IsZoomed() )
+				{
+					Zoom();
+				}
+			}
+		}
+
+		m_bRezoomAfterShot = false;
+	}
+	else if ( ( pPlayer->m_nButtons & IN_ATTACK2 ) && ( m_flNextSecondaryAttack <= gpGlobals->curtime ) )
 	{
 		// If we're in the process of rezooming, just cancel it
 		if ( m_flRezoomTime > 0 || m_flUnzoomTime > 0 )
@@ -1849,7 +1871,29 @@ void CTFSniperRifleClassic::HandleZooms( void )
 		}
 	}
 
-	if ( ( pPlayer->m_nButtons & IN_ATTACK2 ) && ( m_flNextSecondaryAttack <= gpGlobals->curtime ) )
+	if ( pPlayer->ShouldHoldZoom() )
+	{
+		if ( m_flNextSecondaryAttack <= gpGlobals->curtime )
+		{
+			if ( pPlayer->m_nButtons & IN_ATTACK2 )
+			{
+				if ( !IsZoomed() && gpGlobals->curtime > m_flNextPrimaryAttack )
+				{
+					Zoom();
+				}
+			}
+			else
+			{
+				if ( IsZoomed() )
+				{
+					Zoom();
+				}
+			}
+		}
+
+		m_bRezoomAfterShot = false;
+	}
+	else if ( ( pPlayer->m_nButtons & IN_ATTACK2 ) && ( m_flNextSecondaryAttack <= gpGlobals->curtime ) )
 	{
 		Zoom();
 	}


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
Adds the 'cl_holdzoom' ConVar, allowing players to click and hold to zoom the sniper rifle instead of toggling every mouse press.