### PR TITLE
[TF2] Fix disguise_on_backstab not functioning for stab targets that become ghosts

### DIFF
--- a/src/game/shared/tf/tf_weapon_knife.cpp
+++ b/src/game/shared/tf/tf_weapon_knife.cpp
@@ -240,7 +240,7 @@ void CTFKnife::PrimaryAttack( void )
 	C_CTF_GameStats.Event_PlayerFiredWeapon( pPlayer, IsCurrentAttackACrit() );
 #endif
 
-	bool bSuccessfulBackstab = IsBackstab() && !m_hBackstabVictim->IsAlive();
+	bool bSuccessfulBackstab = IsBackstab() && ( !m_hBackstabVictim->IsAlive() || m_hBackstabVictim->m_Shared.InCond( TF_COND_HALLOWEEN_GHOST_MODE ) );
 
 	ETFFlagType ignoreTypes[] = { TF_FLAGTYPE_PLAYER_DESTRUCTION };
 	if ( ShouldDisguiseOnBackstab() && bSuccessfulBackstab && !pPlayer->HasTheFlag( ignoreTypes, ARRAYSIZE( ignoreTypes ) ) )


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
Fixes https://github.com/ValveSoftware/Source-1-Games/issues/4477

Players with cond TF_COND_HALLOWEEN_IN_HELL do not change m_lifeState when they are killed, instead gaining TF_COND_HALLOWEEN_GHOST_MODE; the IsAlive() check used in successful backstab checks solely looks at lifestate, so backstabs on these players are never considered successful despite causing their 'death'. This fixes the check to account for GHOST_MODE.

Tested that the player properly obtains GHOST_MODE in time for the check when stabbed with IN_HELL.