### PR TITLE
[TF2] Fix engineer building damage effects and placement previews not updating correctly

### DIFF
--- a/src/game/client/tf/c_baseobject.cpp
+++ b/src/game/client/tf/c_baseobject.cpp
@@ -153,9 +153,9 @@ void C_BaseObject::UpdateOnRemove( void )
 //-----------------------------------------------------------------------------
 // Purpose: 
 //-----------------------------------------------------------------------------
-void C_BaseObject::PreDataUpdate( DataUpdateType_t updateType )
+void C_BaseObject::OnPreDataChanged( DataUpdateType_t updateType )
 {
-	BaseClass::PreDataUpdate( updateType );
+	BaseClass::OnPreDataChanged( updateType );
 
 	m_iOldHealth = m_iHealth;
 	m_hOldOwner = GetOwner();

--- a/src/game/client/tf/c_baseobject.h
+++ b/src/game/client/tf/c_baseobject.h
@@ -56,7 +56,7 @@ public:
 	void			SetObjectSequence( int sequence );
 	virtual void	ResetClientsideFrame( void );
 
-	virtual void	PreDataUpdate( DataUpdateType_t updateType );
+	virtual void	OnPreDataChanged( DataUpdateType_t updateType );
 	virtual void	OnDataChanged( DataUpdateType_t updateType );
 
 	virtual int		GetHealth() const { return m_iHealth; }


### PR DESCRIPTION
This fixes two really old, annoying visual bugs with Engineer buildings:

- Damage effects sometimes not being properly updated when a building is damaged/repaired, resulting in fully repaired buildings still emitting smoke/sparks/fire and vice-versa ([ValveSoftware/Source-1-Games#4015](https://github.com/ValveSoftware/Source-1-Games/issues/4015))
- Placement previews sometimes displaying as valid if the player begins placing a building while aiming at an invalid position (only properly updating to invalid if moved to a valid position and back to an invalid one)

And possibly more minor bugs caused by the same oversight that I'm not aware of.

The problem was an incorrect use of `PreDataUpdate` to keep track of old netprop values, that would then be compared to the current values in `OnDataChanged` to detect changes. `PreDataUpdate` is called once per packet, which means it can be called multiple times per render frame depending on network conditions (more likely with higher ping/jitter), while `OnDataChanged` is only called once per render frame. If `PreDataUpdate` was called twice or more before `OnDataChanged`, the old values would be updated to the new ones before being checked, and thus the changes would not be detected.

The solution is to simply use `OnPreDataChanged` instead of `PreDataUpdate`, which is the correct function to pair with `OnDataChanged` since it's also only called once per render frame.
