### PR TITLE
IgnitePlayerEx to let players set burn duration in vscript

### DIFF
--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -525,6 +525,7 @@ REGISTER_SEND_PROXY_NON_MODIFIED_POINTER( SendProxy_SendHealersDataTable );
 
 BEGIN_DATADESC( CTFPlayer )
 	DEFINE_INPUTFUNC( FIELD_VOID, "IgnitePlayer", InputIgnitePlayer ),
+	DEFINE_INPUTFUNC( FIELD_FLOAT, "IgnitePlayerEx", InputIgnitePlayer ),
 	DEFINE_INPUTFUNC( FIELD_STRING, "SetCustomModel", InputSetCustomModel ),
 	DEFINE_INPUTFUNC( FIELD_STRING, "SetCustomModelWithClassAnimations", InputSetCustomModelWithClassAnimations ),
 	DEFINE_INPUTFUNC( FIELD_VECTOR, "SetCustomModelOffset", InputSetCustomModelOffset ),
@@ -650,6 +651,7 @@ BEGIN_ENT_SCRIPTDESC( CTFPlayer, CBaseMultiplayerPlayer , "Team Fortress 2 Playe
 	DEFINE_SCRIPTFUNC( RemoveCurrency, "Take away money from a player for reasons such as ie. spending." )
 
 	DEFINE_SCRIPTFUNC( IgnitePlayer, "" )
+	DEFINE_SCRIPTFUNC( IgnitePlayerEx, "" )
 	DEFINE_SCRIPTFUNC( SetCustomModel, "" )
 	DEFINE_SCRIPTFUNC( SetCustomModelWithClassAnimations, "" )
 	DEFINE_SCRIPTFUNC( SetCustomModelOffset, "" )
@@ -20660,19 +20662,24 @@ void CTFPlayer::Internal_HandleMapEvent( inputdata_t &inputdata )
 	BaseClass::Internal_HandleMapEvent( inputdata );
 }
 
+void CTFPlayer::DoomsdayAchievementCheck() 
+{
+	if (FStrEq("sd_doomsday", STRING(gpGlobals->mapname)))
+	{
+		CTFPlayer* pRecentDamager = TFGameRules()->GetRecentDamager(this, 0, 5.0);
+		if (pRecentDamager && (pRecentDamager->GetTeamNumber() != GetTeamNumber()))
+		{
+			pRecentDamager->AwardAchievement(ACHIEVEMENT_TF_MAPS_DOOMSDAY_PUSH_INTO_EXHAUST);
+		}
+	}
+}
+
 //-----------------------------------------------------------------------------
 // Purpose: 
 //-----------------------------------------------------------------------------
 void CTFPlayer::IgnitePlayer()
 {
-	if ( FStrEq( "sd_doomsday", STRING( gpGlobals->mapname ) ) )
-	{
-		CTFPlayer *pRecentDamager = TFGameRules()->GetRecentDamager( this, 0, 5.0 );
-		if ( pRecentDamager && ( pRecentDamager->GetTeamNumber() != GetTeamNumber() ) )
-		{
-			pRecentDamager->AwardAchievement( ACHIEVEMENT_TF_MAPS_DOOMSDAY_PUSH_INTO_EXHAUST );
-		}
-	}
+	DoomsdayAchievementCheck();
 
 	m_Shared.Burn( this, NULL );
 }
@@ -20680,6 +20687,21 @@ void CTFPlayer::IgnitePlayer()
 void CTFPlayer::InputIgnitePlayer( inputdata_t &inputdata )
 {
 	IgnitePlayer();
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
+void CTFPlayer::IgnitePlayerEx( float fBurnTime )
+{
+	DoomsdayAchievementCheck();
+
+	m_Shared.Burn(this, NULL, fBurnTime);
+}
+
+void CTFPlayer::InputIgnitePlayerEx(inputdata_t& inputdata)
+{
+	IgnitePlayerEx(inputdata.value.Float());
 }
 
 //-----------------------------------------------------------------------------

--- a/src/game/server/tf/tf_player.h
+++ b/src/game/server/tf/tf_player.h
@@ -566,6 +566,7 @@ public:
 	void PlayerUse( void );
 
 	void IgnitePlayer();
+	void IgnitePlayerEx( float fBurnTime = 5.0f );
 	void SetCustomModel( const char *pszModel );
 	void SetCustomModelWithClassAnimations( const char *pszModel );
 	void SetCustomModelOffset( const Vector &offset );
@@ -581,6 +582,7 @@ public:
 	void ClearSpells();
 
 	void InputIgnitePlayer( inputdata_t &inputdata );
+	void InputIgnitePlayerEx( inputdata_t &inputdata );
 	void InputSetCustomModel( inputdata_t &inputdata );
 	void InputSetCustomModelWithClassAnimations( inputdata_t &inputdata );
 	void InputSetCustomModelOffset( inputdata_t &inputdata );
@@ -775,6 +777,8 @@ public:
 
 	bool				IsViewingCYOAPDA( void ) const { return m_bViewingCYOAPDA; }
 	bool				IsRegenerating( void ) const { return m_bRegenerating; }
+
+	void                DoomsdayAchievementCheck();
 
 	HSCRIPT				ScriptGetActiveWeapon( void ) { return ToHScript( GetActiveTFWeapon() ); }
 


### PR DESCRIPTION
# Description

This is a small change that fixes a bug in `IgnitePlayer`, a Vscript function that is part of `CTFPlayer`. In the original implementation the burn time is left to its default, resulting in the player to instantly start and stop burning. While this does trigger sound effects that could be useful to developers, it would also be nice to be able to directly set the duration, thus `IgnitePlayerEx` aims to fix this. It has a default burn time set of 5 seconds, but does still extinguish after a normal amount of time, should you set it long enough (This seems to be ~10-12 seconds).