### PR TITLE
Fix Sync/Reset loadout commands being restricted

### DIFF
--- a/src/game/client/tf/vgui/character_info_panel.cpp
+++ b/src/game/client/tf/vgui/character_info_panel.cpp
@@ -320,7 +320,7 @@ void CCharacterInfoPanel::OnCommand( const char *command )
 	}
 	else
 	{
-		engine->ClientCmd( const_cast<char *>( command ) );
+		engine->ClientCmd_Unrestricted( command );
 	}
 
 	BaseClass::OnCommand( command );


### PR DESCRIPTION
In mods that restrict client commands (via `engine->SetRestrictClientCommands`), the loadout sync and reset buttons don't work as they get blocked by this restriction:

```
FCVAR_CLIENTCMD_CAN_EXECUTE prevented running command: reset_loadout_ui
Unknown command: reset_loadout_ui
FCVAR_CLIENTCMD_CAN_EXECUTE prevented running command: clear_loadout_ui
Unknown command: clear_loadout_ui
```

The fix simply runs these commands as unrestricted