### PR TITLE
[TF2] Fix disguise bodygroups being tied to the disguise target

### DIFF
--- a/src/game/shared/tf/tf_item_wearable.cpp
+++ b/src/game/shared/tf/tf_item_wearable.cpp
@@ -525,15 +525,13 @@ bool CTFWearable::UpdateBodygroups( CBaseCombatCharacter* pOwner, int iState )
 	if ( !pTFOwner )
 		return false;
 
-	bool bBaseUpdate = BaseClass::UpdateBodygroups( pOwner, iState );
-	if ( bBaseUpdate && m_bDisguiseWearable )
+	BaseClass::UpdateBodygroups( pOwner, iState );
+
+	CEconItemView *pItem = GetAttributeContainer() ? GetAttributeContainer()->GetItem() : NULL;
+
+#ifdef CLIENT_DLL
+	if ( pItem && m_bDisguiseWearable )
 	{
-		CEconItemView *pItem = GetAttributeContainer()->GetItem(); // Safe. Checked in base class call.
-
-		CTFPlayer *pDisguiseTarget = pTFOwner->m_Shared.GetDisguiseTarget();
-		if ( !pDisguiseTarget )
-			return false;
-
 		// Update our disguise bodygroup.
 		int iDisguiseBody = pTFOwner->m_Shared.GetDisguiseBody();
 		int iTeam = pTFOwner->m_Shared.GetDisguiseTeam();
@@ -542,18 +540,18 @@ bool CTFWearable::UpdateBodygroups( CBaseCombatCharacter* pOwner, int iState )
 		{
 			int iBody = 0;
 			const char *pszBodyGroup = pItem->GetStaticData()->GetModifiedBodyGroup( iTeam, i, iBody );
-			int iBodyGroup = pDisguiseTarget->FindBodygroupByName( pszBodyGroup );
+			int iBodyGroup = pTFOwner->FindBodygroupByName( pszBodyGroup );
 
 			if ( iBodyGroup == -1 )
 				continue;
 
-			::SetBodygroup( pDisguiseTarget->GetModelPtr(), iDisguiseBody, iBodyGroup, iState );
+			::SetBodygroup( pTFOwner->GetModelPtr(), iDisguiseBody, iBodyGroup, iState );
 		}
 
 		pTFOwner->m_Shared.SetDisguiseBody( iDisguiseBody );
 	}
+#endif // CLIENT_DLL
 
-	CEconItemView *pItem = GetAttributeContainer() ? GetAttributeContainer()->GetItem() : NULL;
 	if ( pItem )
 	{		
 		int iTeam = pTFOwner->GetTeamNumber();

--- a/src/game/shared/tf/tf_player_shared.cpp
+++ b/src/game/shared/tf/tf_player_shared.cpp
@@ -13584,6 +13584,13 @@ void CTFPlayerShared::RecalculatePlayerBodygroups( void )
 	// like if we switch to a class that uses those bits for other things.
 	m_pOuter->m_nBody = 0;
 
+#ifdef CLIENT_DLL
+	// Do the same to m_iDisguiseBody on the client. 
+	// Leaving it will make it stick between different disguises
+	m_iDisguiseBody = 0;
+#endif // CLIENT_DLL
+
+
 	// Update our weapon bodygroups that change state purely based on whether they're
 	// equipped or not.
 	CTFWeaponBase::UpdateWeaponBodyGroups( m_pOuter, false );


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description

Currently disguise wearables will set the disguise bodygroup of a disguised Spy based on the current model of the disguise target which causes the disguise to look incorrect if the disguise target changes models or disconnects.

This PR aims to fix this by making it based on the disguise players model and moving the code that does it to the client where the player has the correct model.
It will also always reset the disguise bodygroup when the bodygroup are recalculated.

# Before:

https://github.com/user-attachments/assets/f9f6d142-6348-4bc8-bbca-844328151de9

# After:


https://github.com/user-attachments/assets/0c3bda77-87ef-4e59-b0c8-4d1bd34098f7

