### PR TITLE
Fix class select animation playback

### DIFF
--- a/src/game/client/tf/vgui/tf_playermodelpanel.cpp
+++ b/src/game/client/tf/vgui/tf_playermodelpanel.cpp
@@ -2295,6 +2295,7 @@ void CTFPlayerModelPanel::SetupFlexWeights( void )
 		}
 
 		m_flSceneTime += (m_RootMDL.m_MDL.m_flTime - m_flLastTickTime);
+		m_flSceneTime = Max( m_flSceneTime, -0.1f );
 		m_flLastTickTime = m_RootMDL.m_MDL.m_flTime;
 
 		if ( m_flSceneEndTime > FLT_EPSILON && m_flSceneTime > m_flSceneEndTime )

--- a/src/game/client/tf/vgui/tf_playermodelpanel.cpp
+++ b/src/game/client/tf/vgui/tf_playermodelpanel.cpp
@@ -34,6 +34,8 @@
 
 DECLARE_BUILD_FACTORY( CTFPlayerModelPanel );
 
+#define SCENE_LERP_TIME 0.1f
+
 char g_szSceneTmpName[256];
 
 static bool IsTauntItem( GameItemDefinition_t *pItemDef, const int iTeam, const int iClass, const char **ppSequence = NULL, const char **ppRequiredItem = NULL, const char **ppScene = NULL )
@@ -466,7 +468,7 @@ CChoreoScene *LoadSceneForModel( const char *filename, IChoreoEventCallback *pCa
 
 		if ( bSetEndTime )
 		{
-			*flSceneEndTime += 0.1f; // give time for lerp to idle pose
+			*flSceneEndTime += SCENE_LERP_TIME; // give time for lerp to idle pose
 		}
 	}
 
@@ -2291,11 +2293,11 @@ void CTFPlayerModelPanel::SetupFlexWeights( void )
 		// Advance time
 		if ( m_flLastTickTime < FLT_EPSILON )
 		{
-			m_flLastTickTime = m_RootMDL.m_MDL.m_flTime - 0.1;
+			m_flLastTickTime = m_RootMDL.m_MDL.m_flTime - SCENE_LERP_TIME;
 		}
 
 		m_flSceneTime += (m_RootMDL.m_MDL.m_flTime - m_flLastTickTime);
-		m_flSceneTime = Max( m_flSceneTime, -0.1f );
+		m_flSceneTime = Max( m_flSceneTime, -SCENE_LERP_TIME );
 		m_flLastTickTime = m_RootMDL.m_MDL.m_flTime;
 
 		if ( m_flSceneEndTime > FLT_EPSILON && m_flSceneTime > m_flSceneEndTime )


### PR DESCRIPTION
Hi. This fixes a bug where class select animations will freeze if you go back and forth in the menu.

## Before:

https://github.com/user-attachments/assets/2a1c625e-ba25-4048-bf60-08cc4140d0f0

## After

https://github.com/user-attachments/assets/da9ab140-d697-4ad5-bdff-888d0d6e86db

## Details:

When reusing the shared CTFPlayerModelPanel in the class select screen, `SetupFlexWeights` would incorrectly calculate a large negative `m_flSceneTime`. This would result in class select animations freezing when going back and forth in the class select menu.

-0.1s start times are allowed to give the system time to lerp to the looping animation. This constant is already used in neighboring code.

The 2nd commit just replaces this `0.1f` magic number with a macro constant. This is optional, I just thought it would be a nice improvement.