### PR TITLE
Fix MvM victory screen player animations

### DIFF
--- a/src/game/client/tf/tf_hud_mann_vs_machine_victory.cpp
+++ b/src/game/client/tf/tf_hud_mann_vs_machine_victory.cpp
@@ -52,7 +52,6 @@ extern const ConVar *sv_cheats;
 
 
 extern const char *g_szItemBorders[AE_MAX_TYPES][5];
-extern int g_iLegacyClassSelectWeaponSlots[TF_LAST_NORMAL_CLASS];
 
 class CShowMannUpLootNotification : public CEconNotification
 {
@@ -876,11 +875,6 @@ void CMvMVictoryMannUpEntry::SetLootAnimationPause( float flPause )
 void CMvMVictoryMannUpEntry::SetActive( bool bActive )
 {
 	SetVisible( bActive );
-
-	if ( bActive )
-	{
-		PlayVCD( "class_select" );
-	}
 }
 
 void CMvMVictoryMannUpEntry::PerformLayout()
@@ -1290,19 +1284,6 @@ void CMvMVictoryMannUpEntry::ClearEconItems()
 	SetLootAnimationPause( 2.f ); // + 2 gives us a pause of 2 seconds when the panel first opens
 }
 
-
-void CMvMVictoryMannUpEntry::PlayVCD( const char * pszVCDName )
-{
-	if (m_pPlayerModelPanel)
-	{
-		const int iClass = m_pPlayerModelPanel->GetPlayerClass();
-		m_pPlayerModelPanel->PlayVCD(pszVCDName, NULL, false);
-		// This causes the VCD to be played.  Yep.
-		m_pPlayerModelPanel->HoldItemInSlot(g_iLegacyClassSelectWeaponSlots[iClass]);
-	}
-}
-
-
 bool CMvMVictoryMannUpEntry::SetModelPanelInfo( C_TFPlayer* pPlayer )
 {
 	if ( !pPlayer )
@@ -1324,38 +1305,11 @@ bool CMvMVictoryMannUpEntry::SetModelPanelInfo( C_TFPlayer* pPlayer )
 
 	int nClass = pPlayer->GetPlayerClass()->GetClassIndex();
 	int nTeam = pPlayer->GetTeamNumber();
-	int nLoadoutSlot = g_iLegacyClassSelectWeaponSlots[nClass];	// We want to mirror the class select panel
-	CEconItemView *pWeapon = TFInventoryManager()->GetItemInLoadoutForClass( nClass, nLoadoutSlot, &steamID );
 
 	m_pPlayerModelPanel->ClearCarriedItems();
 	m_pPlayerModelPanel->SetToPlayerClass( nClass, true );
 	m_pPlayerModelPanel->SetTeam( nTeam );
-
-	for ( int wbl = pPlayer->GetNumWearables()-1; wbl >= 0; wbl-- )
-	{
-		C_TFWearable *pItem = dynamic_cast<C_TFWearable*>( pPlayer->GetWearable( wbl ) );
-		if ( !pItem )
-			continue;
-
-		if ( pItem->IsViewModelWearable() )
-			continue;
-
-		CAttributeContainer *pCont		   = pItem->GetAttributeContainer();
-		CEconItemView		*pEconItemView = pCont ? pCont->GetItem() : NULL;
-
-		if ( pEconItemView && pEconItemView->IsValid() )
-		{
-			m_pPlayerModelPanel->AddCarriedItem( pEconItemView );
-		}
-	}
-
-	if ( pWeapon )
-	{
-		m_pPlayerModelPanel->AddCarriedItem( pWeapon );
-	}
-
-	m_pPlayerModelPanel->HoldItemInSlot( nLoadoutSlot );
-	m_pPlayerModelPanel->SetVisible( true );
+	m_pPlayerModelPanel->PlayClassSelectAnimation( pPlayer );
 
 	return true;
 }

--- a/src/game/client/tf/tf_hud_mann_vs_machine_victory.h
+++ b/src/game/client/tf/tf_hud_mann_vs_machine_victory.h
@@ -145,7 +145,6 @@ public:
 	void ForceFinishAllAnimation();
 	void SetLootAnimationPause( float flPause );
 private:
-	void PlayVCD( const char * pszVCDName );
 	bool SetModelPanelInfo( C_TFPlayer* pPlayer );
 	void SetBadgeProgressBarProgress( float flPercent );
 #ifdef USE_MVM_TOUR

--- a/src/game/client/tf/vgui/tf_classmenu.cpp
+++ b/src/game/client/tf/vgui/tf_classmenu.cpp
@@ -681,34 +681,6 @@ void CTFClassMenu::ShowPanel( bool bShow )
 	}
 }
 
-const char *g_pszLegacyClassSelectVCDWeapons[TF_LAST_NORMAL_CLASS] =
-{
-	"",										// TF_CLASS_UNDEFINED = 0,
-	"",										// TF_CLASS_SCOUT,				// weapons handled individually
-	"",										// TF_CLASS_SNIPER,				// weapons handled individually
-	"",										// TF_CLASS_SOLDIER,			// weapons handled individually
-	"tf_weapon_grenadelauncher",			// TF_CLASS_DEMOMAN,
-	"tf_weapon_medigun",					// TF_CLASS_MEDIC,
-	"tf_weapon_minigun",					// TF_CLASS_HEAVYWEAPONS,
-	"tf_weapon_flamethrower",				// TF_CLASS_PYRO,
-	"",										// TF_CLASS_SPY,				// weapons handled individually
-	"tf_weapon_wrench",						// TF_CLASS_ENGINEER,		
-};
-
-int g_iLegacyClassSelectWeaponSlots[TF_LAST_NORMAL_CLASS] =
-{
-	LOADOUT_POSITION_PRIMARY,		// TF_CLASS_UNDEFINED = 0,
-	LOADOUT_POSITION_PRIMARY,		// TF_CLASS_SCOUT,			// TF_FIRST_NORMAL_CLASS
-	LOADOUT_POSITION_PRIMARY,		// TF_CLASS_SNIPER,
-	LOADOUT_POSITION_PRIMARY,		// TF_CLASS_SOLDIER,
-	LOADOUT_POSITION_PRIMARY,		// TF_CLASS_DEMOMAN,
-	LOADOUT_POSITION_SECONDARY,		// TF_CLASS_MEDIC,
-	LOADOUT_POSITION_PRIMARY,		// TF_CLASS_HEAVYWEAPONS,
-	LOADOUT_POSITION_PRIMARY,		// TF_CLASS_PYRO,
-	LOADOUT_POSITION_MELEE,			// TF_CLASS_SPY,
-	LOADOUT_POSITION_MELEE,			// TF_CLASS_ENGINEER,		
-};
-
 //-----------------------------------------------------------------------------
 // Purpose: 
 //-----------------------------------------------------------------------------
@@ -829,43 +801,7 @@ void CTFClassMenu::SelectClass( int iClass )
 //-----------------------------------------------------------------------------
 void CTFClassMenu::LoadItems()
 {
-	const int iClass = m_pTFPlayerModelPanel->GetPlayerClass();
-
-	m_pTFPlayerModelPanel->ClearCarriedItems();
-
-	static CSchemaAttributeDefHandle pAttrDef_DisableFancyLoadoutAnim( "disable fancy class select anim" );
-	bool bCanUseFancyClassSelectAnimation = true;
-
-	static CSchemaAttributeDefHandle pAttrDef_ClassSelectOverrideVCD( "class select override vcd" );
-	CAttribute_String attrClassSelectOverrideVCD;
-
-	const char *pszVCD = "class_select";
-
-	for ( int i = 0; i < CLASS_LOADOUT_POSITION_COUNT; i++ )
-	{
-		CEconItemView *pItemData = TFInventoryManager()->GetItemInLoadoutForClass( iClass, i );
-		if ( pItemData && pItemData->IsValid() )
-		{
-			m_pTFPlayerModelPanel->AddCarriedItem( pItemData );
-
-			// Certain items have different shapes and would interfere with our class select animations.
-			bCanUseFancyClassSelectAnimation = bCanUseFancyClassSelectAnimation
-											&& !pItemData->FindAttribute( pAttrDef_DisableFancyLoadoutAnim );
-
-			// Some items want to override the class select VCD
-			if ( pItemData->FindAttribute( pAttrDef_ClassSelectOverrideVCD, &attrClassSelectOverrideVCD ) )
-			{
-				const char *pszClassSelectOverrideVCD = attrClassSelectOverrideVCD.value().c_str();
-				if ( pszClassSelectOverrideVCD && *pszClassSelectOverrideVCD )
-				{
-					pszVCD = pszClassSelectOverrideVCD;
-				}
-			}
-		}
-	}
-
-	m_pTFPlayerModelPanel->PlayVCD( bCanUseFancyClassSelectAnimation ? pszVCD : NULL, g_pszLegacyClassSelectVCDWeapons[iClass] );
-	m_pTFPlayerModelPanel->HoldItemInSlot( g_iLegacyClassSelectWeaponSlots[iClass] );
+	m_pTFPlayerModelPanel->PlayClassSelectAnimation( C_TFPlayer::GetLocalTFPlayer() );
 }
 
 //-----------------------------------------------------------------------------

--- a/src/game/client/tf/vgui/tf_playermodelpanel.cpp
+++ b/src/game/client/tf/vgui/tf_playermodelpanel.cpp
@@ -487,6 +487,85 @@ void CTFPlayerModelPanel::PlayVCD( const char *pszVCD, const char *pszWeaponEnti
 //-----------------------------------------------------------------------------
 // Purpose: 
 //-----------------------------------------------------------------------------
+void CTFPlayerModelPanel::PlayClassSelectAnimation( C_TFPlayer *pPlayer )
+{
+	if ( !pPlayer )
+		return;
+
+	const int iClass = GetPlayerClass();
+
+	CSteamID playerSteamID = CSteamID();
+	if ( !pPlayer->IsLocalPlayer() )
+		pPlayer->GetSteamID( &playerSteamID );
+
+	static CSchemaAttributeDefHandle pAttrDef_DisableFancyLoadoutAnim( "disable fancy class select anim" );
+	bool bCanUseFancyClassSelectAnimation = true;
+
+	static CSchemaAttributeDefHandle pAttrDef_ClassSelectOverrideVCD( "class select override vcd" );
+	CAttribute_String attrClassSelectOverrideVCD;
+
+	const char *pszVCD = "class_select";
+
+	ClearCarriedItems();
+
+	for ( int i = 0; i < CLASS_LOADOUT_POSITION_COUNT; i++ )
+	{
+		CEconItemView *pItemData = TFInventoryManager()->GetItemInLoadoutForClass( iClass, i, playerSteamID.IsValid() ? &playerSteamID : NULL );
+		if ( pItemData && pItemData->IsValid() )
+		{
+			AddCarriedItem( pItemData );
+
+			// Certain items have different shapes and would interfere with our class select animations.
+			bCanUseFancyClassSelectAnimation = bCanUseFancyClassSelectAnimation
+				&& !pItemData->FindAttribute( pAttrDef_DisableFancyLoadoutAnim );
+
+			// Some items want to override the class select VCD
+			if ( pItemData->FindAttribute( pAttrDef_ClassSelectOverrideVCD, &attrClassSelectOverrideVCD ) )
+			{
+				const char *pszClassSelectOverrideVCD = attrClassSelectOverrideVCD.value().c_str();
+				if ( pszClassSelectOverrideVCD && *pszClassSelectOverrideVCD )
+				{
+					pszVCD = pszClassSelectOverrideVCD;
+				}
+			}
+		}
+	}
+
+	static const char *s_pszLegacyClassSelectVCDWeapons[TF_LAST_NORMAL_CLASS] =
+	{
+		"",										// TF_CLASS_UNDEFINED = 0,
+		"",										// TF_CLASS_SCOUT,				// weapons handled individually
+		"",										// TF_CLASS_SNIPER,				// weapons handled individually
+		"",										// TF_CLASS_SOLDIER,			// weapons handled individually
+		"tf_weapon_grenadelauncher",			// TF_CLASS_DEMOMAN,
+		"tf_weapon_medigun",					// TF_CLASS_MEDIC,
+		"tf_weapon_minigun",					// TF_CLASS_HEAVYWEAPONS,
+		"tf_weapon_flamethrower",				// TF_CLASS_PYRO,
+		"",										// TF_CLASS_SPY,				// weapons handled individually
+		"tf_weapon_wrench",						// TF_CLASS_ENGINEER,
+	};
+
+	static int s_iLegacyClassSelectWeaponSlots[TF_LAST_NORMAL_CLASS] =
+	{
+		LOADOUT_POSITION_PRIMARY,		// TF_CLASS_UNDEFINED = 0,
+		LOADOUT_POSITION_PRIMARY,		// TF_CLASS_SCOUT,			// TF_FIRST_NORMAL_CLASS
+		LOADOUT_POSITION_PRIMARY,		// TF_CLASS_SNIPER,
+		LOADOUT_POSITION_PRIMARY,		// TF_CLASS_SOLDIER,
+		LOADOUT_POSITION_PRIMARY,		// TF_CLASS_DEMOMAN,
+		LOADOUT_POSITION_SECONDARY,		// TF_CLASS_MEDIC,
+		LOADOUT_POSITION_PRIMARY,		// TF_CLASS_HEAVYWEAPONS,
+		LOADOUT_POSITION_PRIMARY,		// TF_CLASS_PYRO,
+		LOADOUT_POSITION_MELEE,			// TF_CLASS_SPY,
+		LOADOUT_POSITION_MELEE,			// TF_CLASS_ENGINEER,
+	};
+
+	PlayVCD( bCanUseFancyClassSelectAnimation ? pszVCD : NULL, s_pszLegacyClassSelectVCDWeapons[iClass] );
+	HoldItemInSlot( s_iLegacyClassSelectWeaponSlots[iClass] );
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
 void CTFPlayerModelPanel::FireEvent( const char *pszEventName, const char *pszEventOptions )
 {
 	//Plat_DebugString( CFmtStr( "********* ANIM EVENT: %s\n", pszEventName ) );

--- a/src/game/client/tf/vgui/tf_playermodelpanel.h
+++ b/src/game/client/tf/vgui/tf_playermodelpanel.h
@@ -14,6 +14,7 @@
 #include "basemodel_panel.h"
 #include "ichoreoeventcallback.h"
 
+class C_TFPlayer;
 class CChoreoScene;
 
 extern CMouthInfo g_ClientUIMouth;
@@ -39,6 +40,7 @@ public:
 	void	ClearCarriedItems( void );
 
 	void	PlayVCD( const char *pszVCD, const char *pszWeaponEntityRequired = NULL, bool bLoopVCD = true, bool bFileNameOnly = true );
+	void	PlayClassSelectAnimation( C_TFPlayer *pPlayer );
 
 	// Handle animation events
 	virtual void FireEvent( const char *pszEventName, const char *pszEventOptions );


### PR DESCRIPTION
Hi. This fixes several visual bugs relating to player animations on the Mann Up victory screen.

## Before/After

<details>

<summary>Demoman with The Bootlegger equipped</summary>

![image](https://github.com/user-attachments/assets/6859dbef-287a-4a5d-8961-8dab50d258c3)

![image](https://github.com/user-attachments/assets/04cc3fc5-3d77-46da-8c7d-ebca9b386b2c)

</details>

<details>

<summary>Sniper with The Huntsman equipped</summary>

![image](https://github.com/user-attachments/assets/33aa0ad2-23a3-4167-ae83-038b447056b2)

![image](https://github.com/user-attachments/assets/c59b7068-acbd-4c2a-adc2-329f72da9cf3)

</details>

## Details

This PR essentially just moves the class select animation logic from `CTFClassMenu::LoadItems()` to a new function  `CTFPlayerModelPanel::PlayClassSelectAnimation()`, which can be used by both the class select menu and the MvM loot screen menu. This allows both menus to reuse the same animation logic, eliminating duplicated and potentially inconsistent code.

Note: As of the current master 39f6dde8fbc238727c020d13b05ecadd31bda4c0, this is affected by the class select animation playback bug. This could be resolved by merging my previous PR before merging this one: 
* https://github.com/ValveSoftware/source-sdk-2013/pull/1285

## Testing

To force the loot screen to show on a listen server, change this check to always be true:

https://github.com/ValveSoftware/source-sdk-2013/blob/39f6dde8fbc238727c020d13b05ecadd31bda4c0/src/game/client/tf/tf_hud_mann_vs_machine_victory.cpp#L1924

and add this ConCommand:

```c++
CON_COMMAND( test_show_mvm_victory_screen, "" )
{
	CTFHudMannVsMachineStatus *pMannVsMachineStatus = GET_HUDELEMENT( CTFHudMannVsMachineStatus );
	if ( pMannVsMachineStatus && TFObjectiveResource() )
	{
		pMannVsMachineStatus->ReopenVictoryPanel();

		CMsgMvMVictoryInfo victoryInfo = CMsgMvMVictoryInfo::default_instance();

		C_BasePlayer *pMe = C_BasePlayer::GetLocalPlayer();
		CSteamID mySteamId = { }; pMe->GetSteamID( &mySteamId );

		CEconItem testItem = CEconItem();
		testItem.SetDefinitionIndex( 169 );
		testItem.SetQuality( AE_SELFMADE );

		CSOEconItem testItemSO = { };
		testItem.SerializeToProtoBufItem( testItemSO );
		std::string test_item_bytes = { };
		testItemSO.SerializeToString( &test_item_bytes );

		for ( int i = 0; i < MVM_PLAYER_COUNT; ++i )
		{
			CMsgMvMVictoryInfo_Player *pVictoryPlayer = victoryInfo.add_players();
			pVictoryPlayer->set_steam_id( mySteamId.ConvertToUint64() );
			pVictoryPlayer->set_badge_level( 12345 );

			for ( int j = 0; j < 5; ++j )
			{
				CMsgMvMVictoryInfo_Item *pItem = pVictoryPlayer->add_items();
				pItem->set_item_data( test_item_bytes );
				pItem->set_grant_reason( j == 0 ? CMsgMvMVictoryInfo_GrantReason_BADGE_LEVELED : CMsgMvMVictoryInfo_GrantReason_MANN_UP );
			}
		}

		pMannVsMachineStatus->MVMVictoryGCResponse( victoryInfo );
	}
};
```