### PR TITLE
[ALL} Allow the Color class to accept hex code strings as colors.

### DIFF
--- a/src/public/Color.h
+++ b/src/public/Color.h
@@ -12,6 +12,8 @@
 #pragma once
 #endif
 
+#include "tier1/strtools.h"
+
 //-----------------------------------------------------------------------------
 // Purpose: Basic handler for an rgb set of colors
 //			This class is fully inline
@@ -31,6 +33,20 @@ public:
 	Color(int _r,int _g,int _b,int _a)
 	{
 		SetColor(_r, _g, _b, _a);
+	}
+	Color(const char *_hexCode, bool alphaHex = false)
+	{
+		int r = V_nibble(_hexCode[0]) << 4 | V_nibble(_hexCode[1]);
+		int g = V_nibble(_hexCode[2]) << 4 | V_nibble(_hexCode[3]);
+		int b = V_nibble(_hexCode[4]) << 4 | V_nibble(_hexCode[5]);
+		int a = 255;
+
+		if (alphaHex)
+		{
+			a = V_nibble(_hexCode[6]) << 4 | V_nibble(_hexCode[7]);
+		}
+
+		SetColor(r, g, b, a);
 	}
 	
 	// set the color

--- a/src/public/Color.h
+++ b/src/public/Color.h
@@ -34,19 +34,19 @@ public:
 	{
 		SetColor(_r, _g, _b, _a);
 	}
-	Color(const char *_hexCode, bool alphaHex = false)
+	Color(const char *_hexCode)
 	{
-		int r = V_nibble(_hexCode[0]) << 4 | V_nibble(_hexCode[1]);
-		int g = V_nibble(_hexCode[2]) << 4 | V_nibble(_hexCode[3]);
-		int b = V_nibble(_hexCode[4]) << 4 | V_nibble(_hexCode[5]);
-		int a = 255;
+		int r = V_nibble( _hexCode[0] ) << 4 | V_nibble( _hexCode[1] );
+		int g = V_nibble( _hexCode[2] ) << 4 | V_nibble( _hexCode[3] );
+		int b = V_nibble( _hexCode[4] ) << 4 | V_nibble( _hexCode[5] );
+		int a = 0;
 
-		if (alphaHex)
+		if ( _hexCode[6] && _hexCode[7] )
 		{
-			a = V_nibble(_hexCode[6]) << 4 | V_nibble(_hexCode[7]);
+			a = V_nibble( _hexCode[6] ) << 4 | V_nibble( _hexCode[7] );
 		}
 
-		SetColor(r, g, b, a);
+		SetColor( r, g, b, a );
 	}
 	
 	// set the color


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
This PR aims to implement a constructor to the Color class that allows users to define hex code strings for colors instead of RGB(a) values. This implementation is similar to hud_basechat's, and as such supports alpha channels.

Due to the nature of the Color class, the default alpha is set to 0, so passing in any normal hex code will result in a transparent color if whatever we put this in uses the full RGBA values.

# Usage:
This example defines a color macro named COLOR_GENUINE with a hex code of #4D7455, the TF2 Genuine color hex code provided by the TF2 Wiki (https://wiki.teamfortress.com/wiki/Item_quality). FF was added to ensure the color is opaque.
```
#define COLOR_GENUINE		Color("4D7455FF")
```

![image](https://github.com/user-attachments/assets/42c7071b-b60d-489e-a52b-bddcac8440ca)

The COLOR_GENUINE color macro, but it is transparent
```
#define COLOR_GENUINE		Color("4D745580")
```

![image](https://github.com/user-attachments/assets/d089f060-1aa8-4d39-9d4c-2e4751d5b8d0)

Shout out to @KaleiAlma for suggesting I do this 😄 
