### PR TITLE
[TF2] 2 MvM Wavebar Changes

### DIFF
--- a/src/game/client/tf/c_tf_objective_resource.cpp
+++ b/src/game/client/tf/c_tf_objective_resource.cpp
@@ -15,6 +15,7 @@ IMPLEMENT_CLIENTCLASS_DT( C_TFObjectiveResource, DT_TFObjectiveResource, CTFObje
 	RecvPropInt( RECVINFO(m_nMannVsMachineMaxWaveCount) ),
 	RecvPropInt( RECVINFO(m_nMannVsMachineWaveCount) ),
 	RecvPropInt( RECVINFO(m_nMannVsMachineWaveEnemyCount) ),
+	RecvPropBool( RECVINFO(m_nMannVsMachineWaveHasTanks) ),
 	RecvPropInt( RECVINFO(m_nMvMWorldMoney) ),
 	RecvPropFloat( RECVINFO( m_flMannVsMachineNextWaveTime ) ),
 	RecvPropBool( RECVINFO( m_bMannVsMachineBetweenWaves ) ),

--- a/src/game/client/tf/c_tf_objective_resource.h
+++ b/src/game/client/tf/c_tf_objective_resource.h
@@ -34,6 +34,7 @@ public:
 	int				GetMannVsMachineMaxWaveCount( void ) { return m_nMannVsMachineMaxWaveCount; }
 	int				GetMannVsMachineWaveCount( void ) { return m_nMannVsMachineWaveCount; }
 	int				GetMannVsMachineWaveEnemyCount( void ) { return m_nMannVsMachineWaveEnemyCount; }
+	bool			GetMannVsMachineWaveHasTanks( void ) { return m_nMannVsMachineWaveHasTanks;  }
 	int				GetMvMInWorldMoney( void ) { return m_nMvMWorldMoney; }
 
 	float			GetMannVsMachineNextWaveTime( void ) { return m_flMannVsMachineNextWaveTime; }
@@ -56,6 +57,7 @@ private:
 	int		m_nMannVsMachineMaxWaveCount;
 	int		m_nMannVsMachineWaveCount;
 	int		m_nMannVsMachineWaveEnemyCount;
+	bool	m_nMannVsMachineWaveHasTanks;
 	
 	int		m_nMvMWorldMoney;
 

--- a/src/game/client/tf/player_vs_environment/c_tf_tank_boss.cpp
+++ b/src/game/client/tf/player_vs_environment/c_tf_tank_boss.cpp
@@ -8,6 +8,7 @@
 
 IMPLEMENT_CLIENTCLASS_DT(C_TFTankBoss, DT_TFTankBoss, CTFTankBoss)
 	//RecvPropVector(RECVINFO(m_shadowDirection)),
+	RecvPropString( RECVINFO(m_iszClassIcon) ),
 END_RECV_TABLE()
 
 LINK_ENTITY_TO_CLASS( tank_boss, C_TFTankBoss );
@@ -22,3 +23,12 @@ void C_TFTankBoss::GetGlowEffectColor( float *r, float *g, float *b )
 	TeamplayRoundBasedRules()->GetTeamGlowColor( GetTeamNumber(), *r, *g, *b );
 }
 
+const char* C_TFTankBoss::GetBossProgressImageName() const
+{
+	//DevMsg("Icon: %s\n", m_iszClassIcon);
+	if (m_iszClassIcon[0] == '\0')
+	{
+		return "tank";
+	}
+	return m_iszClassIcon;
+}

--- a/src/game/client/tf/player_vs_environment/c_tf_tank_boss.cpp
+++ b/src/game/client/tf/player_vs_environment/c_tf_tank_boss.cpp
@@ -25,7 +25,6 @@ void C_TFTankBoss::GetGlowEffectColor( float *r, float *g, float *b )
 
 const char* C_TFTankBoss::GetBossProgressImageName() const
 {
-	//DevMsg("Icon: %s\n", m_iszClassIcon);
 	if (m_iszClassIcon[0] == '\0')
 	{
 		return "tank";

--- a/src/game/client/tf/player_vs_environment/c_tf_tank_boss.h
+++ b/src/game/client/tf/player_vs_environment/c_tf_tank_boss.h
@@ -8,15 +8,17 @@
 class C_TFTankBoss : public C_TFBaseBoss
 {
 public:
-	DECLARE_CLASS( C_TFTankBoss, C_TFBaseBoss );
+	DECLARE_CLASS(C_TFTankBoss, C_TFBaseBoss);
 	DECLARE_CLIENTCLASS();
 
 	C_TFTankBoss();
 
-	virtual void GetGlowEffectColor( float *r, float *g, float *b );
+	virtual void GetGlowEffectColor(float* r, float* g, float* b);
 
 	// ITFMvMBossProgressUser
-	virtual const char* GetBossProgressImageName() const OVERRIDE { return "tank"; }
+	virtual const char* GetBossProgressImageName() const OVERRIDE;
+private:
+	char m_iszClassIcon[MAX_PATH];
 };
 
 #endif // C_TF_TANK_BOSS_H

--- a/src/game/client/tf/player_vs_environment/c_tf_tank_boss.h
+++ b/src/game/client/tf/player_vs_environment/c_tf_tank_boss.h
@@ -8,12 +8,12 @@
 class C_TFTankBoss : public C_TFBaseBoss
 {
 public:
-	DECLARE_CLASS(C_TFTankBoss, C_TFBaseBoss);
+	DECLARE_CLASS( C_TFTankBoss, C_TFBaseBoss );
 	DECLARE_CLIENTCLASS();
 
 	C_TFTankBoss();
 
-	virtual void GetGlowEffectColor(float* r, float* g, float* b);
+	virtual void GetGlowEffectColor(float *r, float *g, float *b);
 
 	// ITFMvMBossProgressUser
 	virtual const char* GetBossProgressImageName() const OVERRIDE;

--- a/src/game/client/tf/tf_hud_mann_vs_machine_status.cpp
+++ b/src/game/client/tf/tf_hud_mann_vs_machine_status.cpp
@@ -918,7 +918,14 @@ void CWaveStatusPanel::UpdateEnemyCounts( void )
 				{
 					if ( pPanel->m_pEnemyCountImageBG )
 					{
-						pPanel->m_pEnemyCountImageBG->SetBgColor( m_clrNormal );
+						if ( mission[i].iFlags & MVM_CLASS_FLAG_MINIBOSS )
+						{
+							pPanel->m_pEnemyCountImageBG->SetBgColor( m_clrMiniBoss );
+						}
+						else
+						{
+							pPanel->m_pEnemyCountImageBG->SetBgColor( m_clrNormal );
+						}
 					}
 					if ( pPanel->m_pEnemyCountCritBG )
 					{

--- a/src/game/client/tf/tf_hud_tournament.cpp
+++ b/src/game/client/tf/tf_hud_tournament.cpp
@@ -196,21 +196,11 @@ void CHudTournament::PlaySounds( int nTime )
 			{
 				int nMaxWaves = TFObjectiveResource()->GetMannVsMachineMaxWaveCount();
 				int nCurWave = TFObjectiveResource()->GetMannVsMachineWaveCount();
-				bool bHasTank = false;
-				for ( int i = 0; i < MVM_CLASS_TYPES_PER_WAVE_MAX_NEW; ++i )
-				{
-	// 				int nClassCount = TFObjectiveResource()->GetMannVsMachineWaveClassCount( i );
- 					const char *pchClassIconName = TFObjectiveResource()->GetMannVsMachineWaveClassName( i );
-					if( V_stristr( pchClassIconName, "tank" ))
-					{
-						bHasTank = true;
-					}
-				}
 				if( nCurWave == nMaxWaves )
 				{
 					pLocalPlayer->EmitSound( "music.mvm_start_last_wave" );	
 				}
-				else if( bHasTank )
+				else if( TFObjectiveResource()->GetMannVsMachineWaveHasTanks() )
 				{
 					pLocalPlayer->EmitSound( "music.mvm_start_tank_wave" );
 				}

--- a/src/game/server/tf/player_vs_environment/tf_population_manager.cpp
+++ b/src/game/server/tf/player_vs_environment/tf_population_manager.cpp
@@ -783,6 +783,7 @@ void CPopulationManager::UpdateObjectiveResource( void )
 	{
 		TFObjectiveResource()->SetMannVsMachineWaveEnemyCount( wave->GetEnemyCount() );
 		TFObjectiveResource()->ClearMannVsMachineWaveClassFlags();
+		TFObjectiveResource()->SetMannVsMachineWaveHasTanks( wave->HasTanks() );
 
 		int i = 0;
 		bool bHasEngineer = false;

--- a/src/game/server/tf/player_vs_environment/tf_populator_spawners.cpp
+++ b/src/game/server/tf/player_vs_environment/tf_populator_spawners.cpp
@@ -1376,6 +1376,7 @@ CTankSpawner::CTankSpawner( IPopulator *populator ) : IPopulationSpawner( popula
 	m_startingPathTrackNodeName = NULL;
 	m_onKilledOutput = NULL;
 	m_onBombDroppedOutput = NULL;
+	m_iszClassIcon = NULL_STRING;
 }
 
 
@@ -1385,7 +1386,6 @@ bool CTankSpawner::Parse( KeyValues *values )
 	for ( KeyValues *data = values->GetFirstSubKey(); data != NULL; data = data->GetNextKey() )
 	{
 		const char *name = data->GetName();
-		const char* value = data->GetString();
 
 		if ( Q_strlen( name ) <= 0 )
 		{
@@ -1396,9 +1396,9 @@ bool CTankSpawner::Parse( KeyValues *values )
 		{
 			m_health = data->GetInt();
 		}
-		else if ( !Q_stricmp(name, "ClassIcon") )
+		else if (!Q_stricmp(name, "ClassIcon"))
 		{
-			m_iszClassIcon = AllocPooledString(value);
+			m_iszClassIcon = AllocPooledString(data->GetString());
 		}
 		else if ( !Q_stricmp( name, "Speed" ) )
 		{
@@ -1406,7 +1406,7 @@ bool CTankSpawner::Parse( KeyValues *values )
 		}
 		else if ( !Q_stricmp( name, "Name" ) )
 		{
-			m_name = value;
+			m_name = data->GetString();
 		}
 		else if ( !Q_stricmp( name, "Skin" ) )
 		{
@@ -1414,7 +1414,7 @@ bool CTankSpawner::Parse( KeyValues *values )
 		}
 		else if ( !Q_stricmp( name, "StartingPathTrackNode" ) )
 		{
-			m_startingPathTrackNodeName = value;
+			m_startingPathTrackNodeName = data->GetString();
 		}
 		else if ( !Q_stricmp( name, "OnKilledOutput" ) )
 		{
@@ -1457,7 +1457,6 @@ bool CTankSpawner::Spawn( const Vector &here, EntityHandleVector_t *result )
 		tank->DefineOnKilledOutput( m_onKilledOutput );
 		tank->DefineOnBombDroppedOutput( m_onBombDroppedOutput );
 		tank->SetClassIconName( GetClassIcon() );
-		DevMsg("Icon: %s", tank->GetClassIconName().ToCStr());
 
 		if ( result )
 		{
@@ -1474,7 +1473,7 @@ bool CTankSpawner::Spawn( const Vector &here, EntityHandleVector_t *result )
 	return false;
 }
 
-string_t CTankSpawner::GetClassIcon(int nSpawnNum /*= -1*/)
+string_t CTankSpawner::GetClassIcon(int nSpawnNum)
 {
 	if (m_iszClassIcon != NULL_STRING)
 	{

--- a/src/game/server/tf/player_vs_environment/tf_populator_spawners.cpp
+++ b/src/game/server/tf/player_vs_environment/tf_populator_spawners.cpp
@@ -1385,6 +1385,7 @@ bool CTankSpawner::Parse( KeyValues *values )
 	for ( KeyValues *data = values->GetFirstSubKey(); data != NULL; data = data->GetNextKey() )
 	{
 		const char *name = data->GetName();
+		const char* value = data->GetString();
 
 		if ( Q_strlen( name ) <= 0 )
 		{
@@ -1395,13 +1396,17 @@ bool CTankSpawner::Parse( KeyValues *values )
 		{
 			m_health = data->GetInt();
 		}
+		else if ( !Q_stricmp(name, "ClassIcon") )
+		{
+			m_iszClassIcon = AllocPooledString(value);
+		}
 		else if ( !Q_stricmp( name, "Speed" ) )
 		{
 			m_speed = data->GetFloat();
 		}
 		else if ( !Q_stricmp( name, "Name" ) )
 		{
-			m_name = data->GetString();
+			m_name = value;
 		}
 		else if ( !Q_stricmp( name, "Skin" ) )
 		{
@@ -1409,7 +1414,7 @@ bool CTankSpawner::Parse( KeyValues *values )
 		}
 		else if ( !Q_stricmp( name, "StartingPathTrackNode" ) )
 		{
-			m_startingPathTrackNodeName = data->GetString();
+			m_startingPathTrackNodeName = value;
 		}
 		else if ( !Q_stricmp( name, "OnKilledOutput" ) )
 		{
@@ -1451,6 +1456,8 @@ bool CTankSpawner::Spawn( const Vector &here, EntityHandleVector_t *result )
 
 		tank->DefineOnKilledOutput( m_onKilledOutput );
 		tank->DefineOnBombDroppedOutput( m_onBombDroppedOutput );
+		tank->SetClassIconName( GetClassIcon() );
+		DevMsg("Icon: %s", tank->GetClassIconName().ToCStr());
 
 		if ( result )
 		{
@@ -1467,6 +1474,15 @@ bool CTankSpawner::Spawn( const Vector &here, EntityHandleVector_t *result )
 	return false;
 }
 
+string_t CTankSpawner::GetClassIcon(int nSpawnNum /*= -1*/)
+{
+	if (m_iszClassIcon != NULL_STRING)
+	{
+		return m_iszClassIcon;
+	}
+
+	return MAKE_STRING( "tank" );
+}
 
 //-----------------------------------------------------------------------
 //-----------------------------------------------------------------------

--- a/src/game/server/tf/player_vs_environment/tf_populator_spawners.h
+++ b/src/game/server/tf/player_vs_environment/tf_populator_spawners.h
@@ -195,7 +195,7 @@ class CTankSpawner : public IPopulationSpawner
 public:
 	CTankSpawner( IPopulator *populator );
 
-	virtual string_t GetClassIcon( int nSpawnNum = -1 ) { return MAKE_STRING( "tank" ); }
+	virtual string_t GetClassIcon( int nSpawnNum = -1 );
 	virtual int GetHealth( int nSpawnNum = -1  ){ return m_health; }
 
 	virtual bool Parse( KeyValues *data );
@@ -218,6 +218,7 @@ public:
 	int m_skin;
 	EventInfo *m_onKilledOutput;
 	EventInfo *m_onBombDroppedOutput;
+	string_t m_iszClassIcon;
 };
 
 //-----------------------------------------------------------------------

--- a/src/game/server/tf/player_vs_environment/tf_populators.cpp
+++ b/src/game/server/tf/player_vs_environment/tf_populators.cpp
@@ -1745,6 +1745,7 @@ void CWaveSpawnPopulator::Update( void )
 CWave::CWave( CPopulationManager *manager ) : IPopulator( manager )
 {
 	m_iEnemyCount = 0;
+	m_bHasTanks = false;
 	m_nTanksSpawned = 0;
 	m_nSentryBustersSpawned = 0;
 	m_nNumEngineersTeleportSpawned = 0;
@@ -1779,6 +1780,7 @@ CWave::~CWave()
 bool CWave::Parse( KeyValues *data )
 {
 	m_iEnemyCount = 0;
+	m_bHasTanks = false;
 	m_nWaveClassCounts.RemoveAll();
 	m_totalCurrency = 0;
 
@@ -1801,12 +1803,18 @@ bool CWave::Parse( KeyValues *data )
 				// this is a total of all enemies we have to fight that are NOT support enemies
 				m_iEnemyCount += wavePopulator->m_totalCount;
 			}
+			
 			m_totalCurrency += wavePopulator->m_totalCurrency;
 
 			wavePopulator->SetParent( this );
 
 			if ( wavePopulator->m_spawner )
 			{
+				CTankSpawner* tankSpawner = dynamic_cast<CTankSpawner*>(wavePopulator->m_spawner);
+				if (tankSpawner)
+				{
+					m_bHasTanks = true;
+				}
 				if ( wavePopulator->m_spawner->IsVarious() )
 				{
 					for ( int i = 0; i < wavePopulator->m_totalCount; ++i )

--- a/src/game/server/tf/player_vs_environment/tf_populators.h
+++ b/src/game/server/tf/player_vs_environment/tf_populators.h
@@ -334,6 +334,7 @@ public:
 	string_t GetClassIconName( int nIndex ) const;
 	unsigned int GetClassFlags( int nIndex ) const;
 
+	bool HasTanks( void ) const;
 	int NumTanksSpawned( void ) const;
 	void IncrementTanksSpawned( void );
 
@@ -358,6 +359,7 @@ private:
 	bool m_isStarted;
 	bool m_bFiredInitWaveOutput;
 	int m_iEnemyCount;
+	bool m_bHasTanks;
 	int m_nTanksSpawned;
 	int m_nSentryBustersSpawned;
 	int m_nNumEngineersTeleportSpawned;
@@ -416,6 +418,11 @@ inline string_t CWave::GetClassIconName( int nIndex ) const
 inline unsigned int CWave::GetClassFlags( int nIndex ) const
 {
 	return m_nWaveClassCounts[ nIndex ].iFlags;
+}
+
+inline bool CWave::HasTanks( void ) const
+{
+	return m_bHasTanks;
 }
 
 inline int CWave::NumTanksSpawned( void ) const

--- a/src/game/server/tf/player_vs_environment/tf_tank_boss.cpp
+++ b/src/game/server/tf/player_vs_environment/tf_tank_boss.cpp
@@ -176,6 +176,7 @@ PRECACHE_REGISTER( tank_boss );
 
 IMPLEMENT_SERVERCLASS_ST( CTFTankBoss, DT_TFTankBoss)
 	//SendPropVector(SENDINFO(m_StartColor), 8, 0, 0, 1),
+	SendPropStringT(SENDINFO(m_iszClassIcon))
 END_SEND_TABLE()
 
 
@@ -521,7 +522,7 @@ void CTFTankBoss::UpdateOnRemove( void )
 
 	if ( TFObjectiveResource() )
 	{
-		TFObjectiveResource()->DecrementMannVsMachineWaveClassCount( MAKE_STRING( "tank" ), MVM_CLASS_FLAG_NORMAL | MVM_CLASS_FLAG_MINIBOSS );
+		TFObjectiveResource()->DecrementMannVsMachineWaveClassCount( GetClassIconName(), MVM_CLASS_FLAG_NORMAL | MVM_CLASS_FLAG_MINIBOSS);
 	}
 
 	BaseClass::UpdateOnRemove();

--- a/src/game/server/tf/player_vs_environment/tf_tank_boss.h
+++ b/src/game/server/tf/player_vs_environment/tf_tank_boss.h
@@ -49,6 +49,9 @@ public:
 
 	void UpdatePingSound( void );
 
+	string_t	GetClassIconName( void ) const { return m_iszClassIcon.Get(); }
+	void		SetClassIconName( string_t iszClassIcon ) { m_iszClassIcon = iszClassIcon; }
+
 protected:
 	virtual void ModifyDamage( CTakeDamageInfo *info ) const;
 
@@ -107,6 +110,7 @@ private:
 	static float m_flLastTankAlert;
 
 	CHistoryVector< EntityHistory_t, CEntityHistoryLess, 12 > m_vecDamagers;
+	CNetworkVar( string_t, m_iszClassIcon);
 };
 
 

--- a/src/game/server/tf/tf_objective_resource.cpp
+++ b/src/game/server/tf/tf_objective_resource.cpp
@@ -20,6 +20,7 @@ IMPLEMENT_SERVERCLASS_ST( CTFObjectiveResource, DT_TFObjectiveResource )
 	SendPropInt( SENDINFO(m_nMannVsMachineMaxWaveCount), 9, SPROP_UNSIGNED ),
 	SendPropInt( SENDINFO(m_nMannVsMachineWaveCount), 9, SPROP_UNSIGNED ),
 	SendPropInt( SENDINFO(m_nMannVsMachineWaveEnemyCount), 16, SPROP_UNSIGNED ),
+	SendPropBool( SENDINFO(m_nMannVsMachineWaveHasTanks) ),
 	SendPropInt( SENDINFO(m_nMvMWorldMoney), 16, SPROP_UNSIGNED ),
 	SendPropFloat( SENDINFO( m_flMannVsMachineNextWaveTime ) ),
 	SendPropBool( SENDINFO( m_bMannVsMachineBetweenWaves ) ),
@@ -47,6 +48,7 @@ BEGIN_DATADESC( CTFObjectiveResource )
 	DEFINE_FIELD( m_nMannVsMachineMaxWaveCount, FIELD_INTEGER ),
 	DEFINE_FIELD( m_nMannVsMachineWaveCount, FIELD_INTEGER ),
 	DEFINE_FIELD( m_nMannVsMachineWaveEnemyCount, FIELD_INTEGER ),
+	DEFINE_FIELD( m_nMannVsMachineWaveHasTanks, FIELD_BOOLEAN),
 	DEFINE_FIELD( m_nMvMWorldMoney, FIELD_INTEGER ),
 	DEFINE_FIELD( m_flMannVsMachineNextWaveTime, FIELD_TIME ),
 	DEFINE_FIELD( m_bMannVsMachineBetweenWaves, FIELD_BOOLEAN ),
@@ -74,6 +76,7 @@ CTFObjectiveResource::CTFObjectiveResource()
 	m_nMannVsMachineMaxWaveCount = 0;
 	m_nMannVsMachineWaveCount = 0;
 	m_nMannVsMachineWaveEnemyCount = 0;
+	m_nMannVsMachineWaveHasTanks = false;
 	m_nMvMWorldMoney = 0;
 	m_flMannVsMachineNextWaveTime = 0;
 	m_bMannVsMachineBetweenWaves = false;

--- a/src/game/server/tf/tf_objective_resource.h
+++ b/src/game/server/tf/tf_objective_resource.h
@@ -34,6 +34,9 @@ public:
 	void SetMannVsMachineWaveEnemyCount( int nCount ) { m_nMannVsMachineWaveEnemyCount = nCount; }
 	int	 GetMannVsMachineWaveEnemyCount( void ) { return m_nMannVsMachineWaveEnemyCount.Get(); }
 
+	void SetMannVsMachineWaveHasTanks( bool bTanks ) { m_nMannVsMachineWaveHasTanks = bTanks; }
+	bool GetMannVsMachineWaveHasTanks( void ) { return m_nMannVsMachineWaveHasTanks.Get(); }
+
 	void AddMvMWorldMoney( int nCurrency ) { m_nMvMWorldMoney += nCurrency; }
 
 	void SetMannVsMachineNextWaveTime( float flTime ) { m_flMannVsMachineNextWaveTime = flTime; }
@@ -74,6 +77,7 @@ private:
 	CNetworkVar( int, m_nMannVsMachineMaxWaveCount );
 	CNetworkVar( int, m_nMannVsMachineWaveCount );
 	CNetworkVar( int, m_nMannVsMachineWaveEnemyCount );
+	CNetworkVar( bool, m_nMannVsMachineWaveHasTanks );
 
 	CNetworkVar( int, m_nMvMWorldMoney );
 

--- a/src/game/shared/econ/econ_item.cpp
+++ b/src/game/shared/econ/econ_item.cpp
@@ -480,7 +480,7 @@ void CEconItem::UnequipFromClass( equipped_class_t unClass )
 	Assert( GetItemSchema()->IsValidClass( unClass ) );
 
 	// If we only have a single equipped class...
-	if ( m_dirtyBits.m_bHasEquipSingleton )
+ 	if ( m_dirtyBits.m_bHasEquipSingleton )
 	{
 		// ...and that's the class we're trying to remove from...
 		if ( m_EquipInstanceSingleton.m_unEquippedClass == unClass )

--- a/src/game/shared/econ/econ_item.cpp
+++ b/src/game/shared/econ/econ_item.cpp
@@ -480,7 +480,7 @@ void CEconItem::UnequipFromClass( equipped_class_t unClass )
 	Assert( GetItemSchema()->IsValidClass( unClass ) );
 
 	// If we only have a single equipped class...
- 	if ( m_dirtyBits.m_bHasEquipSingleton )
+	if ( m_dirtyBits.m_bHasEquipSingleton )
 	{
 		// ...and that's the class we're trying to remove from...
 		if ( m_EquipInstanceSingleton.m_unEquippedClass == unClass )


### PR DESCRIPTION
This PR has two changes relating to the MvM wavebars.

The first change addresses issue #1226 where the change relating to red icon backgrounds didn't carry over to mission supports even though they were added for regular support bots.

![image](https://github.com/user-attachments/assets/5585f120-4e43-4a16-bfa2-dc438b5408b5)

The second change allows MvM mission creators to utilize their own tank icons, removing the hardcoded bits that forced the default tank icon, previously you needed an extension to get custom tank icons working and it wouldn't work for the boss bars. This also fixes a bug where if a wave uses the tank icon but doesn't have a tank would play the tank wave music on wave start, now it just checks if the wave has any tank spawns.

![image (1)](https://github.com/user-attachments/assets/be445db7-b198-47c4-8f29-f7de0cfe5050)
