### PR TITLE
[TF2] Fix invalid Soul Gargoyle locations on Helltower

### DIFF
--- a/src/game/server/tf/halloween/halloween_gift_spawn_locations.cpp
+++ b/src/game/server/tf/halloween/halloween_gift_spawn_locations.cpp
@@ -252,8 +252,6 @@ static valid_item_pos kValidPositions_Hightower[] =
 	{ 5629.083984,  7272.486816, 186.031311f  - g_flPlayerEyeHeight },
 	{ 7569.272461,  7356.835938, 30.543331f   - g_flPlayerEyeHeight },
 	{ 7620.356445,  7806.569824, 43.632362f   - g_flPlayerEyeHeight },
-	{ 10225.334961, 7462.086914, -366.968689f - g_flPlayerEyeHeight },
-	{ 10208.725586, 7768.193848, -366.968689f - g_flPlayerEyeHeight },
 };
 
 struct halloween_map_info


### PR DESCRIPTION
Fixes https://github.com/ValveSoftware/source-1-games/issues/4456. This removes 2 coordinates spawning the Soul Gargoyle in an unplayable area on Helltower. As for the reasoning for removal instead of moving them, the castle is an unfair location for the gargoyle spawn, as the bridge appears only for 90 seconds every 145 seconds, while the gargoyle despawns after 240 seconds, making it hard to collect in time.