### PR TITLE
[ALL] Fix CVoiceStatus::UpdateServerState not sending the correct vban state from the client

### DIFF
--- a/src/game/shared/voice_status.cpp
+++ b/src/game/shared/voice_status.cpp
@@ -378,7 +378,7 @@ void CVoiceStatus::UpdateServerState(bool bForce)
 
 			player_info_t pi;
 
-			if ( !engine->GetPlayerInfo( i+1, &pi ) )
+			if ( !engine->GetPlayerInfo( playerIndex+1, &pi ) )
 				continue;
 
 			if ( m_BanMgr.GetPlayerBan( pi.guid ) )


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
An oversight would cause it to fetch only the lowest 32 players' infos instead of the correct index.
This would result in something like `vban 2 2 2 2` instead of `vban 2 0 0 0` when muting player 2 (muting player 34+66+98 in the process), and would prevent muting players above index 33 correctly as those would not send any vban.

Tested with player indices >33 on live TF2 vs this patch: without the patch, muting player index 36 does nothing; with the patch the player gets muted properly. The outputs of voice_clientdebug and voice_serverdebug also print the expected (incorrect) values in live TF2 and (correct) values in patched version.