### PR TITLE
[TF2] Fix players sometimes getting stuck in team unassigned when joining a server

### DIFF
--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -7332,7 +7332,7 @@ bool CTFPlayer::ClientCommand( const CCommand &args )
 	if ( FStrEq( pcmd, "jointeam" ) )
 	{
 		// don't let them spam the server with changes
-		if ( GetNextChangeTeamTime() > gpGlobals->curtime )
+		if ( GetNextChangeTeamTime() > gpGlobals->curtime && GetTeamNumber() != TEAM_UNASSIGNED )
 			return true;
 
 		SetNextChangeTeamTime( gpGlobals->curtime + 2.0f );  // limit to one change every 2 secs


### PR DESCRIPTION
Fixes https://github.com/ValveSoftware/Source-1-Games/issues/3651

If a player connects to a server and tries to join a specific team right as the team becomes full (such that the client-side team balance check passes but the server-side one fails), then tries again within 2 seconds, the second `jointeam` command will be rejected by the team change rate limit without re-opening the team selection panel. This results in the player becoming permanently stuck in team unassigned unless they use console commands to manually join a team, as the team selection panel cannot be reopened.

Fixed by skipping the team change rate limit check if the player is still in team unassigned.