### PR TITLE
[TF2] Fix dispenser healing being briefly interrupted when touching the dispenser

### DIFF
--- a/src/game/server/tf/tf_obj_dispenser.cpp
+++ b/src/game/server/tf/tf_obj_dispenser.cpp
@@ -806,8 +806,13 @@ void CObjectDispenser::EndTouch( CBaseEntity *pOther )
 	EHANDLE hOther = pOther;
 	m_hTouchingEntities.FindAndRemove( hOther );
 
-	// remove from healing list
-	StopHealing( pOther );
+	// check if we should stop healing
+	// if pOther is touching both the dispenser and its trigger, it will be in m_hTouchingEntities twice
+	// if it's still present after one removal, it's still touching the trigger, so don't stop healing
+	if ( !m_hTouchingEntities.HasElement( hOther ) )
+	{
+		StopHealing( pOther );
+	}
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Fixes https://github.com/ValveSoftware/Source-1-Games/issues/5124

The dispenser has an `m_hTouchingEntities` vector that keeps track of which entities are near it. Entities are added to and removed from this vector both when touching the dispenser itself and its associated `m_hTouchTrigger`, meaning players will be present in the vector twice if they are touching both. `CObjectDispenser::EndTouch()` does not take this into account, and stops  healing players when they stop touching the dispenser itself, even if they're still touching the surrounding trigger, resulting in a brief interruption in healing before it's resumed by `DispenseThink()` shortly after.

Fixed by not interrupting healing in `EndTouch()` if the player is still present in the vector after being removed from it once.

There's also [another bug](https://www.youtube.com/watch?v=w4nSnumKp88) with the same cause that results in dispensers giving double the amount of metal when the engineer is touching them, but I'm not sure if that should be fixed since it noticeably affects balance.