### PR TITLE
Fix Pipebomb charge sound still playing when player dies

### DIFF
--- a/src/game/shared/tf/tf_weapon_pipebomblauncher.cpp
+++ b/src/game/shared/tf/tf_weapon_pipebomblauncher.cpp
@@ -145,6 +145,8 @@ void CTFPipebombLauncher::WeaponReset( void )
 
 #ifndef CLIENT_DLL
 	DetonateRemotePipebombs( true );
+#else
+	StopSound( TF_WEAPON_PIPEBOMB_LAUNCHER_CHARGE_SOUND );
 #endif
 
 	m_flChargeBeginTime = 0.0f;


### PR DESCRIPTION
# DESCRIPTION
When Demoman dies while are charging his pipebomb launcher, and for some reason dies, this sound still plays in client. Just that...

unfixed:
https://github.com/user-attachments/assets/aa04b980-57b7-4e0d-a271-72d75a76c9ad

fixed: 
https://github.com/user-attachments/assets/6c0e48af-ce31-467d-8a8f-3968dbc0a510
