### PR TITLE
tf: Skip deathcam delay when `mp_disable_respawn_times` is set to higher than 1

### DIFF
--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -292,6 +292,7 @@ extern ConVar tf_tournament_classchange_allowed;
 extern ConVar tf_tournament_classchange_ready_allowed;
 extern ConVar tf_rocketpack_impact_push_min;
 extern ConVar tf_rocketpack_impact_push_max;
+extern ConVar mp_disable_respawn_times;
 #if defined( _DEBUG ) || defined( STAGING_ONLY )
 extern ConVar mp_developer;
 extern ConVar bot_mimic;
@@ -12911,6 +12912,9 @@ void CTFPlayer::Event_Killed( const CTakeDamageInfo &info )
 
 	// make sure to remove custom attributes
 	RemoveAllCustomAttributes();
+
+	if ( mp_disable_respawn_times.GetInt() > 1 )
+		ForceRespawn();
 }
 
 struct SkillRatingAttackRecord_t


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
This PR makes it so if `mp_disable_respawn_times`  is set to a value higher than `1` it will bypass the extra delay when the player is killed that is used for the deathcam.

The same can be done for Day of Defeat: Source, however because it is not part of this SDK, this PR only affects Team Fortress 2.

###### `mp_disable_respawn_times` set to 1 vs 2:

https://github.com/user-attachments/assets/61e6cae9-6f76-46fd-a99d-20ca0de40ad8
