### PR TITLE
[TF2] Set the class loadout player model team based on current team if available, add setteam2/3 commands for class loadout panel for custom huds to add Team buttons

### DIFF
--- a/src/game/client/tf/vgui/character_info_panel.cpp
+++ b/src/game/client/tf/vgui/character_info_panel.cpp
@@ -173,6 +173,7 @@ void CCharacterInfoPanel::ShowPanel(bool bShow)
 		Activate();
 
 		int iClass = m_pLoadoutPanel->GetCurrentClassIndex();
+		SetDefaultTeam( GetLocalPlayerTeam() == TF_TEAM_BLUE ? TF_TEAM_BLUE : TF_TEAM_RED );
 		OpenLoadoutToClass( iClass, false );
 	}
 	else
@@ -331,9 +332,9 @@ void CCharacterInfoPanel::OnCommand( const char *command )
 //-----------------------------------------------------------------------------
 void CCharacterInfoPanel::OpenLoadoutToClass( int iClassIndex, bool bOpenClassLoadout ) 
 { 
-	Assert(iClassIndex >= TF_CLASS_UNDEFINED && iClassIndex < TF_CLASS_COUNT); 
-	m_pLoadoutPanel->SetClassIndex( iClassIndex, bOpenClassLoadout );
+	Assert(iClassIndex >= TF_CLASS_UNDEFINED && iClassIndex < TF_CLASS_COUNT);
 	m_pLoadoutPanel->SetTeamIndex( m_iDefaultTeam );
+	m_pLoadoutPanel->SetClassIndex( iClassIndex, bOpenClassLoadout );
 }
 
 //-----------------------------------------------------------------------------
@@ -470,6 +471,7 @@ IEconRootUI	*CCharacterInfoPanel::OpenEconUI( int iDirectToPage, bool bCheckForI
 	}
 	else if ( iDirectToPage < 0 )
 	{
+		SetDefaultTeam( GetLocalPlayerTeam() == TF_TEAM_BLUE ? TF_TEAM_BLUE : TF_TEAM_RED );
 		// Negative numbers go directly to the class loadout
 		OpenLoadoutToClass( -(iDirectToPage), true );
 	}
@@ -565,6 +567,11 @@ void Open_CharInfoDirect( const CCommand &args )
 	if ( args.ArgC() > 1 )
 	{
 		iClass = -atoi( args.Arg( 1 ) );
+		if ( -iClass < TF_CLASS_UNDEFINED || -iClass >= TF_CLASS_COUNT )
+		{
+			// prevent Assert-crashing if the client does something silly
+			iClass = -TF_CLASS_UNDEFINED;
+		}
 	}
 
 	EconUI()->OpenEconUI( iClass );	

--- a/src/game/client/tf/vgui/class_loadout_panel.cpp
+++ b/src/game/client/tf/vgui/class_loadout_panel.cpp
@@ -1260,6 +1260,20 @@ void CClassLoadoutPanel::OnCommand( const char *command )
 			return;
 		}
 	}
+	else if ( !V_strnicmp( command, "setteam", 7 ) )
+	{
+		const char *pszNum = command + 7;
+		if ( pszNum && pszNum[0] )
+		{
+			int iTeam = atoi( pszNum );
+			if ( IsValidTFTeam( iTeam ) )
+			{
+				SetTeam( iTeam );
+				UpdateModelPanels();
+			}
+		}
+		return;
+	}
 	BaseClass::OnCommand( command );
 }
 


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
TF2 currently defaults to RED skins in the class loadout at all times other than when selecting the "Edit Loadout" button on the bottom-right of the class selection menu. This PR allows the loadout to take on the player's current class if they are in a game.
This also allows custom HUDs to use the commands "setteam2" and "setteam3" instead of the current "sv_cheats 1; r_skin 0/1" to set the playermodel's team.