### PR TITLE
[TF2] MvM: make miniboss icons appear before normals

### DIFF
--- a/src/game/client/tf/tf_hud_mann_vs_machine_status.h
+++ b/src/game/client/tf/tf_hud_mann_vs_machine_status.h
@@ -30,13 +30,25 @@
 #define MAX_TANK_PROGRESS_BARS 5
 
 //=========================================================
-typedef struct 
+struct hud_enemy_data_t
 {
 	int		nCount;
 	const char	*pchClassIconName;
 	int		iFlags;
 	bool	bActive;
-} hud_enemy_data_t;
+
+	friend bool operator<( const hud_enemy_data_t& lhs, const hud_enemy_data_t& rhs )
+	{
+		// True only if lhs miniboss and rhs non-miniboss
+		if ( ( lhs.iFlags & MVM_CLASS_FLAG_MINIBOSS ) &&
+			!( rhs.iFlags & MVM_CLASS_FLAG_MINIBOSS ) ) {
+			return true;
+		}
+		return false;
+	}
+};
+
+typedef struct hud_enemy_data_t hud_enemy_data_t;
 
 class CEnemyCountPanel : public vgui::EditablePanel, public CGameEventListener
 {

--- a/src/public/tier1/utlvector.h
+++ b/src/public/tier1/utlvector.h
@@ -206,6 +206,7 @@ public:
 
 	/// sort using std:: and expecting a "<" function to be defined for the type
 	void Sort( void );
+	void StableSort( void );
 
 	/// sort using std:: with a predicate. e.g. [] -> bool ( T &a, T &b ) { return a < b; }
 	template <class F> void SortPredicate( F &&predicate );
@@ -942,6 +943,13 @@ void CUtlVector<T, A>::Sort( void )
 {
 	//STACK STATS TODO: Do we care about allocation tracking precision enough to match element origins across a sort?
 	std::sort( Base(), Base() + Count() );
+}
+
+template< typename T, class A >
+void CUtlVector<T, A>::StableSort( void )
+{
+	//STACK STATS TODO: Do we care about allocation tracking precision enough to match element origins across a sort?
+	std::stable_sort( Base(), Base() + Count() );
 }
 
 template< typename T, class A >


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description

Add red miniboss icon background support to mission support. Also move minibosses before normal robots in support too. Support and mission support are ordered separately as mission support is not visible unless active, and adding icons between others would be odd.

Improvement to https://github.com/ValveSoftware/source-sdk-2013/pull/1289

Adding StableSort to CUtlVector is big-ish change and if that needs to be avoided then separate sorting function could be added.

![kuva](https://github.com/user-attachments/assets/e45f10b8-0ac6-47d8-83a2-b420610ee7bc)