### PR TITLE
[TF2] Fix TFBots joining the server after the SourceTV or Replay bot does with tf_bot_join_after_player 1

### DIFF
--- a/src/game/server/tf/bot/tf_bot_manager.cpp
+++ b/src/game/server/tf/bot/tf_bot_manager.cpp
@@ -400,6 +400,9 @@ void CTFBotManager::MaintainBotQuota()
 		if ( !pPlayer->IsConnected() )
 			continue;
 
+		if ( pPlayer->IsHLTV() || pPlayer->IsReplay() )
+			continue;
+
 		CTFBot* pBot = dynamic_cast<CTFBot*>( pPlayer );
 		if ( pBot && pBot->HasAttribute( CTFBot::QUOTA_MANANGED ) )
 		{


### PR DESCRIPTION
# Description
Closes https://github.com/ValveSoftware/Source-1-Games/issues/5330

This fixes an issue with `tf_bot_join_after_player` causing bots to join the server after the SourceTV or Replay bot joins. The issue is that `CTFBotManager::MaintainBotQuota` does not check for the SourceTV or Replay bots when counting the number of players in the server, the fix being to just exclude them from the counting.