### PR TITLE
[TF2] Fix various CYOAPDA/ConTracker animation bugs ("iPad cancelling")

### DIFF
--- a/src/game/client/tf/c_tf_player.cpp
+++ b/src/game/client/tf/c_tf_player.cpp
@@ -5605,6 +5605,7 @@ void C_TFPlayer::HandleTaunting( void )
 	// Clear the taunt slot.
 	if (	!m_bWasTaunting &&
 			(	
+				IsInCYOAPDAAnimation() ||
 				m_Shared.InCond( TF_COND_TAUNTING ) ||
 				m_Shared.IsControlStunned() ||
 				m_Shared.IsLoser() ||
@@ -5632,7 +5633,7 @@ void C_TFPlayer::HandleTaunting( void )
 
 	if (	( !IsAlive() && m_nForceTauntCam < 2 ) || 
 			(
-				m_bWasTaunting && !m_Shared.InCond( TF_COND_TAUNTING ) && !m_Shared.IsControlStunned() && 
+				m_bWasTaunting && !IsInCYOAPDAAnimation() && !m_Shared.InCond( TF_COND_TAUNTING ) && !m_Shared.IsControlStunned() && 
 				!m_Shared.InCond( TF_COND_PHASE ) && !m_Shared.IsLoser() && !m_bIsReadyToHighFive &&
 				!m_nForceTauntCam && !m_Shared.InCond( TF_COND_HALLOWEEN_BOMB_HEAD ) &&
 				!m_Shared.InCond( TF_COND_HALLOWEEN_THRILLER ) &&
@@ -6515,6 +6516,15 @@ bool C_TFPlayer::CreateMove( float flInputSampleTime, CUserCmd *pCmd )
 	{
 		m_Shared.CreateVehicleMove( flInputSampleTime, pCmd );
 	}
+	else if ( IsInCYOAPDAAnimation() )
+	{
+		// Not allowed to move while the ConTracker is open.
+		pCmd->forwardmove = 0.0f;
+		pCmd->sidemove = 0.0f;
+		pCmd->upmove = 0.0f;
+
+		pCmd->weaponselect = 0;
+	}
 	else if ( bInTaunt )
 	{
 		if ( tf_allow_taunt_switch.GetInt() <= 1 )
@@ -6700,6 +6710,9 @@ void C_TFPlayer::CleanUpAnimationOnSpawn()
 	{
 		m_PlayerAnimState->ClearAnimationState();
 	}
+
+	// Close the ConTracker
+	StopViewingCYOAPDA();
 }
 
 

--- a/src/game/client/tf/c_tf_player.h
+++ b/src/game/client/tf/c_tf_player.h
@@ -191,6 +191,9 @@ public:
 	bool			IsTaunting( void ) const { return m_Shared.InCond( TF_COND_TAUNTING ); }
 
 	bool			IsViewingCYOAPDA( void ) const { return m_bViewingCYOAPDA; }
+	bool			IsInCYOAPDAAnimation( void ) const;
+	void			StopViewingCYOAPDA( void );
+
 	bool			IsRegenerating( void ) const { return m_bRegenerating; }
 
 	virtual void	InitPhonemeMappings();
@@ -244,6 +247,7 @@ public:
 	CNetworkVar( int, m_iKartState );
 
 	bool IsAllowedToTaunt( void );
+	bool IsAllowedToViewCYOAPDA( void );
 	
 	virtual bool	IsOverridingViewmodel( void );
 	virtual int		DrawOverriddenViewmodel( C_BaseViewModel *pViewmodel, int flags );

--- a/src/game/client/tf/vgui/tf_quest_map_panel.cpp
+++ b/src/game/client/tf/vgui/tf_quest_map_panel.cpp
@@ -1236,16 +1236,8 @@ CON_COMMAND( show_quest_log, "Show the quest map panel" )
 	}
 	else
 	{
-		CTFPlayer *pTFLocalPlayer = CTFPlayer::GetLocalTFPlayer();
-		if ( pTFLocalPlayer && ( pTFLocalPlayer->IsTaunting() || pTFLocalPlayer->ShouldShowHudMenuTauntSelection() ) )
-		{
-			internalCenterPrint->Print( "#TF_CYOA_PDA_Taunting" );
-		}
-		else
-		{
-			engine->ClientCmd_Unrestricted( "gameui_activate" );
-			GetQuestMapPanel()->SetVisible( true );
-			GetQuestMapPanel()->GoToCurrentQuest();
-		}
+		engine->ClientCmd_Unrestricted( "gameui_activate" );
+		GetQuestMapPanel()->SetVisible( true );
+		GetQuestMapPanel()->GoToCurrentQuest();
 	}
 }

--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -585,7 +585,10 @@ BEGIN_ENT_SCRIPTDESC( CTFPlayer, CBaseMultiplayerPlayer , "Team Fortress 2 Playe
 	DEFINE_SCRIPTFUNC( SetUseBossHealthBar, "" )
 	DEFINE_SCRIPTFUNC( IsFireproof, "" )
 	DEFINE_SCRIPTFUNC( IsAllowedToTaunt, "" )
-	DEFINE_SCRIPTFUNC( IsViewingCYOAPDA, "" )
+	DEFINE_SCRIPTFUNC( IsAllowedToViewCYOAPDA, "" )
+	DEFINE_SCRIPTFUNC( IsViewingCYOAPDA, "Returns true if this player has indicated that they are viewing the ConTracker" )
+	DEFINE_SCRIPTFUNC( IsInCYOAPDAAnimation, "Returns true if this player is viewing or playing any ConTracker animations" )
+	DEFINE_SCRIPTFUNC( StopViewingCYOAPDA, "Causes the player to immediately stop viewing the ConTracker" )
 	DEFINE_SCRIPTFUNC( IsRegenerating, "" )
 	DEFINE_SCRIPTFUNC( GetCurrentTauntMoveSpeed, "" )
 	DEFINE_SCRIPTFUNC( SetCurrentTauntMoveSpeed, "" )
@@ -3159,6 +3162,16 @@ void CTFPlayer::PlayerRunCommand( CUserCmd *ucmd, IMoveHelper *moveHelper )
 	if ( m_Shared.InCond( TF_COND_HALLOWEEN_KART ) )
 	{
 		m_Shared.CreateVehicleMove( gpGlobals->frametime, ucmd );
+	}
+	else if ( IsInCYOAPDAAnimation() )
+	{
+		// Not allowed to move while the ConTracker is open.
+		ucmd->forwardmove = 0.0f;
+		ucmd->sidemove = 0.0f;
+		ucmd->upmove = 0.0f;
+
+		ucmd->viewangles = pl.v_angle;
+		ucmd->weaponselect = 0;
 	}
 	else if ( IsTaunting() || m_Shared.InCond( TF_COND_HALLOWEEN_THRILLER ) )
 	{
@@ -8039,16 +8052,14 @@ bool CTFPlayer::ClientCommand( const CCommand &args )
 	else if ( FStrEq( "cyoa_pda_open", pcmd ) )
 	{
 		bool bOpen = atoi( args[1] ) != 0;
+		
+		if ( bOpen && !IsAllowedToViewCYOAPDA() )
+		{
+			bOpen = false;
+		}
 
-		if ( bOpen && IsTaunting() )
-		{
-			ClientPrint( this, HUD_PRINTCENTER, "#TF_CYOA_PDA_Taunting" );
-		}
-		else
-		{
-			m_bViewingCYOAPDA.Set( bOpen );
-			TeamFortress_SetSpeed();
-		}
+		m_bViewingCYOAPDA.Set( bOpen );
+
 		return true;
 	}
 

--- a/src/game/server/tf/tf_player.h
+++ b/src/game/server/tf/tf_player.h
@@ -748,6 +748,7 @@ public:
 	bool				IsTaunting( void ) const { return m_Shared.InCond( TF_COND_TAUNTING ); }
 	void				DoTauntAttack( void );
 	bool				IsAllowedToTaunt( void );
+	bool                IsAllowedToViewCYOAPDA( void );
 	bool				FindOpenTauntPartnerPosition( const CEconItemView *pEconItemView, Vector &position, float *flTolerance );
 	bool				IsAllowedToInitiateTauntWithPartner( const CEconItemView *pEconItemView, char *pszErrorMessage = NULL, int cubErrorMessage = 0 );
 	void				CancelTaunt( void );
@@ -774,6 +775,8 @@ public:
 	void				SetVehicleReverseTime( float flTime ) { m_flVehicleReverseTime = flTime; }
 
 	bool				IsViewingCYOAPDA( void ) const { return m_bViewingCYOAPDA; }
+	bool				IsInCYOAPDAAnimation( void ) const;
+	void				StopViewingCYOAPDA( void );
 	bool				IsRegenerating( void ) const { return m_bRegenerating; }
 
 	HSCRIPT				ScriptGetActiveWeapon( void ) { return ToHScript( GetActiveTFWeapon() ); }

--- a/src/game/shared/tf/tf_gamemovement.cpp
+++ b/src/game/shared/tf/tf_gamemovement.cpp
@@ -614,7 +614,7 @@ bool CTFGameMovement::StunMove()
 	// No one can move when in a final countdown transition or with the ConTracker open.
 	// Do this here to avoid the inevitable hack that prevents players 
 	// from receiving a flag or condition by stalling thinks, etc.
-	if ( m_pTFPlayer->IsViewingCYOAPDA() || ( TFGameRules() && TFGameRules()->BInMatchStartCountdown() ) )
+	if ( m_pTFPlayer->IsInCYOAPDAAnimation() || ( TFGameRules() && TFGameRules()->BInMatchStartCountdown() ) )
 	{
 		mv->m_flForwardMove = 0.f;
 		mv->m_flSideMove = 0.f;

--- a/src/game/shared/tf/tf_player_shared.cpp
+++ b/src/game/shared/tf/tf_player_shared.cpp
@@ -127,6 +127,8 @@ ConVar tf_always_loser( "tf_always_loser", "0", FCVAR_CHEAT | FCVAR_REPLICATED, 
 
 ConVar tf_mvm_bot_flag_carrier_movement_penalty( "tf_mvm_bot_flag_carrier_movement_penalty", "0.5", FCVAR_REPLICATED | FCVAR_CHEAT );
 
+ConVar tf_cyoa_pda_animations( "tf_cyoa_pda_animations", "1", FCVAR_CHEAT | FCVAR_REPLICATED, "Controls whether ConTracker animations are enabled.\n  0: Animations disabled\n  1: Animations enabled (default)\n" );
+
 //ConVar tf_scout_dodge_move_penalty_duration( "tf_scout_dodge_move_penalty_duration", "3.0", FCVAR_DEVELOPMENTONLY | FCVAR_REPLICATED );
 //ConVar tf_scout_dodge_move_penalty( "tf_scout_dodge_move_penalty", "0.5", FCVAR_DEVELOPMENTONLY | FCVAR_REPLICATED );
 
@@ -762,6 +764,71 @@ bool CTFPlayer::IsAllowedToTaunt( void )
 	return true;
 }
 
+//-----------------------------------------------------------------------------
+// Purpose: Check if a player is allowed to view the ConTracker. Mostly borrowed from IsAllowedToTaunt
+//-----------------------------------------------------------------------------
+bool CTFPlayer::IsAllowedToViewCYOAPDA( void )
+{
+	if ( tf_cyoa_pda_animations.GetInt() == 0 )
+		return false;
+
+	if ( !IsAlive() )
+		return false;
+
+	if ( m_Shared.InCond( TF_COND_TAUNTING ) )
+		return false;
+
+	if ( m_Shared.InCond( TF_COND_HALLOWEEN_KART ) )
+		return false;
+
+	if ( m_Shared.InCond( TF_COND_HALLOWEEN_GHOST_MODE ) )
+		return false;
+
+	// Can't taunt while charging.
+	if ( m_Shared.InCond( TF_COND_SHIELD_CHARGE ) )
+		return false;
+
+	if ( m_Shared.InCond( TF_COND_COMPETITIVE_LOSER ) )
+		return false;
+
+	if ( IsLerpingFOV() )
+		return false;
+
+	// Check to see if we are on the ground.
+	if ( !( GetFlags() & FL_ONGROUND ) )
+		return false;
+
+	CTFWeaponBase *pActiveWeapon = m_Shared.GetActiveTFWeapon();
+	if ( pActiveWeapon )
+	{
+		if ( !pActiveWeapon->OwnerCanTaunt() )
+			return false;
+
+		if ( pActiveWeapon->GetWeaponID() == TF_WEAPON_PDA_ENGINEER_BUILD 
+			 ||	pActiveWeapon->GetWeaponID() == TF_WEAPON_PDA_ENGINEER_DESTROY )
+			return false;
+	}
+
+	// can't view ConTracker while carrying an object
+	if ( m_Shared.IsCarryingObject() )
+		return false;
+
+	// Can't view ConTracker if hooked into a player
+	if ( m_Shared.InCond( TF_COND_GRAPPLED_TO_PLAYER ) )
+		return false;
+
+	if ( IsPlayerClass( TF_CLASS_SPY ) )
+	{
+		if ( m_Shared.IsStealthed() || m_Shared.InCond( TF_COND_STEALTHED_BLINK ) || 
+			 m_Shared.InCond( TF_COND_DISGUISED ) || m_Shared.InCond( TF_COND_DISGUISING ) )
+		{
+			return false;
+		}
+	}
+
+	return true;
+}
+
 
 // --------------------------------------------------------------------------------------------------- //
 // CTFPlayerShared implementation.
@@ -1021,6 +1088,8 @@ void CTFPlayerShared::Spawn( void )
 #endif
 	m_iStunIndex = -1;
 	m_bKingRuneBuffActive = false;
+
+	m_pOuter->StopViewingCYOAPDA();
 
 	// Reset our assist here incase something happens before we get killed
 	// again that checks this (getting slapped with a fish)
@@ -1536,6 +1605,8 @@ void CTFPlayerShared::RemoveAllCond()
 	m_nPlayerCondEx2 = 0;
 	m_nPlayerCondEx3 = 0;
 	m_nPlayerCondEx4 = 0;
+	
+	m_pOuter->StopViewingCYOAPDA();
 }
 
 
@@ -10694,7 +10765,7 @@ bool CTFPlayer::CanPlayerMove() const
 	if ( TFGameRules() && TFGameRules()->BInMatchStartCountdown() )
 		return false;
 
-	if ( IsViewingCYOAPDA() )
+	if ( IsInCYOAPDAAnimation() )
 		return false;
 
 	bool bFreezeOnRestart = tf_player_movement_restart_freeze.GetBool();
@@ -12114,7 +12185,7 @@ bool CTFPlayer::CanAttack( int iCanAttackFlags )
 
 	Assert( pRules );
 
-	if ( IsViewingCYOAPDA() )
+	if ( IsInCYOAPDAAnimation() )
 		return false;
 
 	if ( m_Shared.HasPasstimeBall() ) 
@@ -13030,7 +13101,7 @@ bool CTFPlayer::ShouldStopTaunting()
 	if ( GetWaterLevel() > WL_Waist )
 		return true;
 
-	if ( IsViewingCYOAPDA() )
+	if ( IsInCYOAPDAAnimation() )
 		return true;
 
 	return false;
@@ -14679,3 +14750,27 @@ bool CTFPlayer::IsHelpmeButtonPressed() const
 	return m_flHelpmeButtonPressTime != 0.f;
 }
 
+//-----------------------------------------------------------------------------
+// Purpose: Returns true if this player is viewing or playing any ConTracker animations
+//-----------------------------------------------------------------------------
+bool CTFPlayer::IsInCYOAPDAAnimation( void ) const
+{
+	return IsViewingCYOAPDA() || m_Shared.m_iCYOAPDAAnimState != CYOA_PDA_ANIM_NONE;
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: Causes the player to immediately stop viewing the ConTracker
+//-----------------------------------------------------------------------------
+void CTFPlayer::StopViewingCYOAPDA()
+{
+	if ( m_PlayerAnimState && IsInCYOAPDAAnimation() )
+	{
+		// Make sure the outro anim events still go out (weapon unhide).
+		m_PlayerAnimState->RestartGesture( GESTURE_SLOT_CUSTOM, ACT_MP_CYOA_PDA_OUTRO );
+		m_PlayerAnimState->ResetGestureSlot( GESTURE_SLOT_CUSTOM );
+	}
+
+	m_Shared.m_flCYOAPDAAnimStateTime = 0.f;
+	m_Shared.m_iCYOAPDAAnimState = CYOA_PDA_ANIM_NONE;
+	m_bViewingCYOAPDA = false;
+}

--- a/src/game/shared/tf/tf_playeranimstate.cpp
+++ b/src/game/shared/tf/tf_playeranimstate.cpp
@@ -385,7 +385,8 @@ void CTFPlayerAnimState::Update( float eyeYaw, float eyePitch )
 	Vector vPositionToFace = ( pTauntPartner ? pTauntPartner->GetAbsOrigin() : vec3_origin );
 	bool bInTaunt = pTFPlayer->m_Shared.InCond( TF_COND_TAUNTING );
 	bool bInKart = pTFPlayer->m_Shared.InCond( TF_COND_HALLOWEEN_KART );
-	bool bIsImmobilized = bInTaunt || pTFPlayer->m_Shared.IsControlStunned();
+	bool bInCYOAPDAAnim = pTFPlayer->IsInCYOAPDAAnimation();
+	bool bIsImmobilized = bInTaunt || bInCYOAPDAAnim || pTFPlayer->m_Shared.IsControlStunned();
 
 	if ( SetupPoseParameters( pStudioHdr ) )
 	{
@@ -489,6 +490,11 @@ void CTFPlayerAnimState::Update( float eyeYaw, float eyePitch )
 			m_bForceAimYaw = true;
 			m_flEyeYaw = pTFPlayer->GetTauntYaw();
 		}
+		else if ( bInCYOAPDAAnim )
+		{
+			m_bForceAimYaw = true;
+			m_flEyeYaw = pTFPlayer->GetTauntYaw();
+		}
 		
 		if ( !bIsImmobilized || bInTaunt || bInKart )
 		{
@@ -571,7 +577,6 @@ void CTFPlayerAnimState::CheckPasstimeThrowAnimation()
 }
 
 
-
 extern bool IsInPrediction();
 
 //-----------------------------------------------------------------------------
@@ -583,15 +588,17 @@ void CTFPlayerAnimState::CheckCYOAPDAAnimtion()
 	if ( !pPlayer )
 		return;
 
+#ifdef CLIENT_DLL
 	if ( IsInPrediction() )
 		return;
+#endif
 
-	// do not play anims if in kart
-	if ( pPlayer->m_Shared.InCond( TF_COND_HALLOWEEN_KART ) )
+	if ( !pPlayer->IsAllowedToViewCYOAPDA() )
+	{
+		// Skip animating out if something changes and we shouldn't be playing ConTracker animations.
+		pPlayer->StopViewingCYOAPDA();
 		return;
-
-	if ( pPlayer->IsTaunting() )
-		return;
+	}
 
 	bool isViewingCYOAPDA = pPlayer->IsViewingCYOAPDA();
 
@@ -610,7 +617,10 @@ void CTFPlayerAnimState::CheckCYOAPDAAnimtion()
 	}
 #endif
 	item_definition_index_t contractTrackerDefIndex = 5869;
-	if ( pItem && pItem->GetItemDefIndex() != contractTrackerDefIndex )
+
+	// We need to check pItem->IsValid() because GetItemInLoadoutForClass() can return a non-null invalid item in some cases.
+	// (maybe disallow ConTracker animations if pItem is invalid?)
+	if ( pItem && pItem->IsValid() && pItem->GetItemDefIndex() != contractTrackerDefIndex )
 	{
 		// If we don't have the contracker equipped, we can't be looking at it.
 		// We may have been looking at it and only just now removed it,
@@ -627,6 +637,8 @@ void CTFPlayerAnimState::CheckCYOAPDAAnimtion()
 	{
 		if ( state == CYOA_PDA_ANIM_NONE )
 		{
+			pPlayer->SetTauntYaw( pPlayer->GetAbsAngles()[YAW] );
+
 			int iSeq = pPlayer->SelectWeightedSequence( ACT_MP_CYOA_PDA_INTRO );
 			pPlayer->m_Shared.m_flCYOAPDAAnimStateTime = gpGlobals->curtime + pPlayer->SequenceDuration( iSeq );
 			pPlayer->DoAnimationEvent( PLAYERANIMEVENT_CYOAPDA_BEGIN );


### PR DESCRIPTION
This patch fixes a bug in `CTFPlayerAnimState::CheckCYOAPDAAnimtion()` that prevented the server from ever playing ConTracker animations which caused desync between client and server hitboxes.

Here's a video showing some silly effects of the bug: https://youtu.be/Qgl0uRBl9_E

Before patch (server hitbox does not match client's):
![image](https://github.com/user-attachments/assets/b757cbae-aef2-4895-ab01-7beaee6fee3b)

After patch:
![image](https://github.com/user-attachments/assets/ec131a2e-ff68-4994-a686-69b11eccba55)

Additional changes:

- Update checks that prevented certain player actions while viewing the ConTracker to instead check for actively playing ConTracker animations. This fixes wonky behavior like players being able to move/shoot while viewing the ConTracker.

- Add new checks to prevent player input while viewing the ConTracker.

- Remove client check preventing the quest panel from being opened while taunting.

- Players are now put in third person to make it obvious when ConTracker animations are playing (and thus are unable to move/shoot).

- Add ConVar `tf_cyoa_pda_animations` to control ConTracker animations.

- Add `IsAllowedToViewCYOAPDA()` and `IsInCYOAPDAAnimation()` script functions.


