### PR TITLE
add func_detail_nonsolid

### DIFF
--- a/src/utils/common/map_shared.cpp
+++ b/src/utils/common/map_shared.cpp
@@ -29,7 +29,7 @@ ChunkFileResult_t LoadEntityKeyCallback(const char *szKey, const char *szValue, 
 		{
 			pLoadEntity->nBaseContents = CONTENTS_DETAIL;
 		}
-		else if (!stricmp( szValue, "func_detail_nosolid"))
+		else if (!stricmp( szValue, "func_detail_nonsolid"))
 		{
 			pLoadEntity->nBaseContents = CONTENTS_DETAIL | CONTENTS_OPAQUE;
 		}

--- a/src/utils/vbsp/map.cpp
+++ b/src/utils/vbsp/map.cpp
@@ -1579,7 +1579,7 @@ ChunkFileResult_t CMapFile::LoadEntityCallback(CChunkFile *pFile, int nParam)
 		//
 		const char *pClassName = ValueForKey( mapent, "classname" );
 
-		if ( !strcmp( "func_detail", pClassName ) || !strcmp( "func_detail_nosolid", pClassName ) )
+		if ( !strcmp( "func_detail", pClassName ) || !strcmp( "func_detail_nonsolid", pClassName ) )
 		{
 			MoveBrushesToWorld (mapent);
 			mapent->numbrushes = 0;
@@ -2645,8 +2645,8 @@ bool LoadMapFile( const char *pszFileName )
 		}
 
 		// CONTENTS_OPAQUE makes a brush not solid, but CONTENTS_WINDOW breaks its non-solidity
-		// CONTENTS_OPAQUE only gets applied via %compilenonsolid VMT property and func_detail_nosolid entity
-		// %compilenonsolid prevents CONTENTS_WINDOW from being applied, func_detail_nosolid does not, so we remove it here
+		// CONTENTS_OPAQUE only gets applied via %compilenonsolid VMT property and func_detail_nonsolid entity
+		// %compilenonsolid prevents CONTENTS_WINDOW from being applied, func_detail_nonsolid does not, so we remove it here
 		for ( int i = 0; i < g_LoadingMap->entities[0].numbrushes; i++ )
 		{
 			mapbrush_t* brush = &g_LoadingMap->mapbrushes[i];


### PR DESCRIPTION
Currently, if you want to add a non-solid brush to your map, your only option is to use a brush entity, such as func_illusionary or func_brush. Brush entities take up valuable edicts, and are generally overkill when all you want is a brush you don't collide with.

This PR adds func_detail_nonsolid, which, just like func_detail, gets turned into a world brush on compile, thus not consuming any edicts. It basically acts like the %compilenonsolid VMT property.

Just like func_detail, func_detail_nonsolid has no keyvalues.

![image](https://github.com/user-attachments/assets/5907b21f-b55b-4247-8579-59c9d600f391)

Here's the entity in action:

https://github.com/user-attachments/assets/4d6b0cf8-9eba-49c0-8db6-515af67ef741

Huge thanks to @gidi30 and @flurbury for helping me with stopping windows from breaking the entity.