### PR TITLE
Fix mount path in sdk_container

### DIFF
--- a/src/sdk_container
+++ b/src/sdk_container
@@ -29,8 +29,8 @@ function run_in_sniper() {
             --env "CCACHE_DIR=${CCACHE_DIR:-$HOME/.ccache}" \
             --userns=keep-id \
             --rm -it \
-            --mount type=bind,\"source="${CCACHE_DIR:-$HOME/.ccache}"\",\"target="${CCACHE_DIR:-$HOME/.ccache}"\" \
-            --mount type=bind,\"source="$mod_base_dir"\",target=/my_mod/ \
+            --mount type=bind,source="${CCACHE_DIR:-$HOME/.ccache}",target="${CCACHE_DIR:-$HOME/.ccache}" \
+            --mount type=bind,source="$mod_base_dir",target=/my_mod/ \
             "$image" \
             /my_mod/"$mod_src_dir_name"/"$script_file" \
             "$@"


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
Current script throws an error on Ubuntu 22.04 LTS: `Error: "source: invalid mount option`. This PR fixes that.