### PR TITLE
[ANY] feat: Allow mp_disable_respawn_times to work with specific team numbers

### DIFF
--- a/src/game/shared/teamplayroundbased_gamerules.cpp
+++ b/src/game/shared/teamplayroundbased_gamerules.cpp
@@ -3464,7 +3464,9 @@ float CTeamplayRoundBasedRules::GetRespawnWaveMaxLength( int iTeam, bool bScaleW
 	if ( State_Get() != GR_STATE_RND_RUNNING )
 		return 0;
 
-	if ( mp_disable_respawn_times.GetBool() == true )
+	if ( mp_disable_respawn_times.GetInt() == 1 )
+		return 0.0f;
+	else if ( mp_disable_respawn_times.GetInt() >= FIRST_GAME_TEAM && mp_disable_respawn_times.GetInt() == iTeam )
 		return 0.0f;
 
 	//Let's just turn off respawn times while players are messing around waiting for the tournament to start


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
Makes `mp_disable_respawn_times` work with the team number, for TF2 for example `mp_disable_respawn_times 2` would disable respawn times for RED team only.