### PR TITLE
[ANY] Remove m_vecViewOffset compression

### DIFF
--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -8120,9 +8120,9 @@ void CMovementSpeedMod::InputSpeedMod(inputdata_t &data)
 		
 // If HL2_DLL is defined, then baseflex.cpp already sends these.
 #ifndef HL2_DLL
-		SendPropFloat		( SENDINFO_VECTORELEM(m_vecViewOffset, 0), 8, SPROP_ROUNDDOWN, -32.0, 32.0f),
-		SendPropFloat		( SENDINFO_VECTORELEM(m_vecViewOffset, 1), 8, SPROP_ROUNDDOWN, -32.0, 32.0f),
-		SendPropFloat		( SENDINFO_VECTORELEM(m_vecViewOffset, 2), 20, SPROP_CHANGES_OFTEN,	0.0f, 256.0f),
+		SendPropFloat		( SENDINFO_VECTORELEM(m_vecViewOffset, 0), 32, SPROP_NOSCALE),
+		SendPropFloat		( SENDINFO_VECTORELEM(m_vecViewOffset, 1), 32, SPROP_NOSCALE),
+		SendPropFloat		( SENDINFO_VECTORELEM(m_vecViewOffset, 2), 32, SPROP_NOSCALE|SPROP_CHANGES_OFTEN),
 #endif
 
 		SendPropFloat		( SENDINFO(m_flFriction),		8,	SPROP_ROUNDDOWN,	0.0f,	4.0f),


### PR DESCRIPTION
Although a bunch of prediction required variables have had their values uncompressed recently, m_vecViewOffset is still compressed for some reason? I doubt players are missing their shots due to it being compressed down to 20 bits but it would still be nice to have all needed data uncompressed