### PR TITLE
[TF2] Add thousands separators to various values

### DIFF
--- a/src/game/client/tf/player_vs_environment/c_tf_upgrades.cpp
+++ b/src/game/client/tf/player_vs_environment/c_tf_upgrades.cpp
@@ -1175,10 +1175,7 @@ void CHudUpgradePanel::UpdateUpgradeButtons( void )
 					pUpgradeBuyPanel->m_pShortDescriptionLabel->SetText( pDescription );
 				}
 
-				locchar_t wzCost[64];
-				loc_sprintf_safe( wzCost, LOCCHAR( "%d" ), pUpgradeBuyPanel->m_nPrice );
-
-				pUpgradeBuyPanel->m_pPriceLabel->SetText( wzCost );
+				pUpgradeBuyPanel->m_pPriceLabel->SetText( V_AddThousandSeparators( pUpgradeBuyPanel->m_nPrice ) );
 			}
 		}
 	}
@@ -1781,9 +1778,7 @@ void CHudUpgradePanel::UpdateButtonStates( int nCurrentMoney, int nUpgrade /*= 0
 	}
 
 	// Credits count
-	wchar_t wzCount[10];
-	_snwprintf( wzCount, ARRAYSIZE( wzCount ), L"%d", nCurrentMoney );
-	m_pSelectWeaponPanel->SetDialogVariable( "credits", wzCount );
+	m_pSelectWeaponPanel->SetDialogVariable( "credits", V_AddThousandSeparators( nCurrentMoney ) );
 }
 
 void CHudUpgradePanel::UpdateItemStatsLabel( void )

--- a/src/game/client/tf/tf_hud_mann_vs_machine_scoreboard.cpp
+++ b/src/game/client/tf/tf_hud_mann_vs_machine_scoreboard.cpp
@@ -247,28 +247,6 @@ void CTFHudMannVsMachineScoreboard::InitPlayerList ( IScheme *pScheme )
 }
 
 //-----------------------------------------------------------------------------
-char *ConvertScoreboardValueToString( int iValue )
-{
-	static char szConversion[32];
-	szConversion[0] = '\0';
-
-	if ( iValue >= 1000000 )
-	{
-		V_sprintf_safe( szConversion, "%d%s%d%d%d%s%d%d%d", iValue / 1000000, ",", ( iValue % 1000000 ) / 100000, ( iValue % 100000 ) / 10000, ( iValue % 10000 ) / 1000, ",", ( iValue % 1000 ) / 100, ( iValue % 100 ) / 10, iValue % 10 );
-	}
-	else if ( iValue >= 1000 )
-	{
-		V_sprintf_safe( szConversion, "%d%s%d%d%d", iValue / 1000, ",", ( iValue % 1000 ) / 100, ( iValue % 100 ) / 10, iValue % 10 );
-	}
-	else if ( iValue >= 0 )
-	{
-		V_sprintf_safe( szConversion, "%d", iValue  );
-	}
-
-	return szConversion;
-}
-
-//-----------------------------------------------------------------------------
 void CTFHudMannVsMachineScoreboard::UpdatePlayerList () 
 {
 	m_pPlayerList->ClearSelection();
@@ -347,7 +325,7 @@ void CTFHudMannVsMachineScoreboard::UpdatePlayerList ()
 			}
 			else
 			{
-				pKeyValues->SetString( "ping", ConvertScoreboardValueToString( g_PR->GetPing( playerIndex ) ) );
+				pKeyValues->SetString( "ping", V_AddThousandSeparators( g_PR->GetPing( playerIndex ) ) );
 			}
 		}
 
@@ -398,7 +376,7 @@ void CTFHudMannVsMachineScoreboard::UpdatePlayerList ()
 
 				if ( nTourNo > 0 )
 				{
-					pKeyValues->SetString( "tour_no", ConvertScoreboardValueToString( nTourNo ) );
+					pKeyValues->SetString( "tour_no", V_AddThousandSeparators( nTourNo ) );
 				}
 				else
 				{
@@ -421,14 +399,14 @@ void CTFHudMannVsMachineScoreboard::UpdatePlayerList ()
 						   g_TF_PR->GetDamageBlocked( playerIndex ) +
 						   ( g_TF_PR->GetBonusPoints( playerIndex ) * 25 );
 
-			pKeyValues->SetString( "score", ConvertScoreboardValueToString( g_TF_PR->GetTotalScore( playerIndex ) ) );
-			pKeyValues->SetString( "damage", ConvertScoreboardValueToString( g_TF_PR->GetDamage( playerIndex ) ) );
-			pKeyValues->SetString( "tank", ConvertScoreboardValueToString( g_TF_PR->GetDamageBoss( playerIndex ) ) );
-			pKeyValues->SetString( "healing", ConvertScoreboardValueToString( g_TF_PR->GetHealing( playerIndex ) ) );
-			pKeyValues->SetString( "support", ConvertScoreboardValueToString( nSupport ) );
-			//pKeyValues->SetString( "blocked", ConvertScoreboardValueToString( g_TF_PR->GetDamageBlocked( playerIndex ) ) );
-			//pKeyValues->SetString( "bonus", ConvertScoreboardValueToString( g_TF_PR->GetBonusPoints( playerIndex ) ) );
-			pKeyValues->SetString( "credits", ConvertScoreboardValueToString( g_TF_PR->GetCurrencyCollected( playerIndex ) ) );
+			pKeyValues->SetString( "score", V_AddThousandSeparators( g_TF_PR->GetTotalScore( playerIndex ) ) );
+			pKeyValues->SetString( "damage", V_AddThousandSeparators( g_TF_PR->GetDamage( playerIndex ) ) );
+			pKeyValues->SetString( "tank", V_AddThousandSeparators( g_TF_PR->GetDamageBoss( playerIndex ) ) );
+			pKeyValues->SetString( "healing", V_AddThousandSeparators( g_TF_PR->GetHealing( playerIndex ) ) );
+			pKeyValues->SetString( "support", V_AddThousandSeparators( nSupport ) );
+			//pKeyValues->SetString( "blocked", V_AddThousandSeparators( g_TF_PR->GetDamageBlocked( playerIndex ) ) );
+			//pKeyValues->SetString( "bonus", V_AddThousandSeparators( g_TF_PR->GetBonusPoints( playerIndex ) ) );
+			pKeyValues->SetString( "credits", V_AddThousandSeparators( g_TF_PR->GetCurrencyCollected( playerIndex ) ) );
 		}	
 
 		int itemID = m_pPlayerList->AddItem( 0, pKeyValues );
@@ -586,9 +564,9 @@ void CTFHudMannVsMachineScoreboard::UpdateCreditStats()
 //-----------------------------------------------------------------------------
 void CTFHudMannVsMachineScoreboard::UpdateCreditPanel( CCreditDisplayPanel *panel, int nAcquired, int nMissed, int nBonus )
 {
-	panel->SetDialogVariable( "creditscollected", nAcquired );
-	panel->SetDialogVariable( "creditsmissed", nMissed );
-	panel->SetDialogVariable( "creditbonus", nBonus );
+	panel->SetDialogVariable( "creditscollected", V_AddThousandSeparators( nAcquired ) );
+	panel->SetDialogVariable( "creditsmissed", V_AddThousandSeparators( nMissed ) );
+	panel->SetDialogVariable( "creditbonus", V_AddThousandSeparators( nBonus ) );
 
 	int nDropped = nAcquired + nMissed;
 
@@ -634,9 +612,9 @@ void CTFHudMannVsMachineScoreboard::UpdateCreditSpend ( CCreditSpendPanel *panel
 {
 	if ( panel )
 	{
-		panel->SetDialogVariable( "upgrades", nUpgrades );
-		panel->SetDialogVariable( "buybacks", nBuybacks );
-		panel->SetDialogVariable( "bottles", nBottles );
+		panel->SetDialogVariable( "upgrades", V_AddThousandSeparators( nUpgrades ) );
+		panel->SetDialogVariable( "buybacks", V_AddThousandSeparators( nBuybacks ) );
+		panel->SetDialogVariable( "bottles", V_AddThousandSeparators( nBottles ) );
 	}
 }
 //-----------------------------------------------------------------------------

--- a/src/game/client/tf/tf_hud_mann_vs_machine_status.cpp
+++ b/src/game/client/tf/tf_hud_mann_vs_machine_status.cpp
@@ -1080,7 +1080,7 @@ bool CCurrencyStatusPanel::UpdateHUD( void )
 	m_nCurrency += delta;
 
 	char szTmp[16];
-	Q_snprintf( szTmp, ARRAYSIZE( szTmp ), "$%d", m_nCurrency );
+	Q_snprintf( szTmp, ARRAYSIZE( szTmp ), "$%s", V_AddThousandSeparators( m_nCurrency ) );
 	SetDialogVariable( "currency", szTmp );
 	
 	return true;
@@ -1157,7 +1157,7 @@ void CInWorldCurrencyStatus::OnTick( void )
 	}
 
 	char szTmp[16];
-	Q_snprintf( szTmp, ARRAYSIZE( szTmp ), "$%d", nWorldMoney );
+	Q_snprintf( szTmp, ARRAYSIZE( szTmp ), "$%s", V_AddThousandSeparators( nWorldMoney ) );
 	SetDialogVariable( "currency", szTmp );
 }
 //-----------------------------------------------------------------------------
@@ -1397,7 +1397,7 @@ bool CWaveCompleteSummaryPanel::StateUpdateValue( vgui::EditablePanel *parent, c
 
 	if ( parent )
 	{
-		parent->SetDialogVariable( field, (int)(endValue * fPercent) );
+		parent->SetDialogVariable( field, V_AddThousandSeparators( (int)( endValue * fPercent ) ) );
 	}
 
 	// transition to next state

--- a/src/game/client/tf/vgui/tf_clientscoreboard.cpp
+++ b/src/game/client/tf/vgui/tf_clientscoreboard.cpp
@@ -1374,7 +1374,7 @@ void CTFClientScoreBoardDialog::UpdatePlayerList()
 			pKeyValues->SetInt( "playerIndex", playerIndex );
 			pKeyValues->SetString( "name", g_TF_PR->GetPlayerName( playerIndex ) );
 			pKeyValues->SetInt( "dominating", iDominationIndex );
-			pKeyValues->SetInt( "score", g_TF_PR->GetTotalScore( playerIndex ) );
+			pKeyValues->SetString( "score", V_AddThousandSeparators( g_TF_PR->GetTotalScore( playerIndex ) ) );
 			pKeyValues->SetInt( "connected", 2 );
 
 			C_TFPlayer *pTFPlayer = ToTFPlayer( UTIL_PlayerByIndex( playerIndex ) );
@@ -1426,7 +1426,7 @@ void CTFClientScoreBoardDialog::UpdatePlayerList()
 				{
 					if ( tf_scoreboard_ping_as_text.GetBool() )
 					{
-						pKeyValues->SetInt( "ping", nPing );
+						pKeyValues->SetString( "ping", V_AddThousandSeparators( nPing ) );
 					}
 					else
 					{
@@ -1880,84 +1880,84 @@ void CTFClientScoreBoardDialog::UpdatePlayerDetails()
 		Color cGreen = Color( 0, 255, 0, 255 );
 		Color cWhite = Color( 255, 255, 255, 255 );
 
-		m_pLocalPlayerStatsPanel->SetDialogVariable( "kills", g_TF_PR->GetPlayerScore( playerIndex ) );
+		m_pLocalPlayerStatsPanel->SetDialogVariable( "kills", V_AddThousandSeparators( g_TF_PR->GetPlayerScore( playerIndex ) ) );
 		if ( m_pKillsLabel )
 		{
 			m_pKillsLabel->SetFgColor( g_TF_PR->GetPlayerScore( playerIndex ) ? cGreen : cWhite );
 		}
-		m_pLocalPlayerStatsPanel->SetDialogVariable( "deaths", g_TF_PR->GetDeaths( playerIndex ) );
+		m_pLocalPlayerStatsPanel->SetDialogVariable( "deaths", V_AddThousandSeparators( g_TF_PR->GetDeaths( playerIndex ) ) );
 		if ( m_pDeathsLabel )
 		{
 			m_pDeathsLabel->SetFgColor( g_TF_PR->GetDeaths( playerIndex ) ? cGreen : cWhite );
 		}
-		m_pLocalPlayerStatsPanel->SetDialogVariable( "assists", pSelectedPlayer->m_Shared.GetKillAssists( playerIndex ) );
+		m_pLocalPlayerStatsPanel->SetDialogVariable( "assists", V_AddThousandSeparators( pSelectedPlayer->m_Shared.GetKillAssists( playerIndex ) ) );
 		if ( m_pAssistLabel )
 		{
 			m_pAssistLabel->SetFgColor( pSelectedPlayer->m_Shared.GetKillAssists( playerIndex ) ? cGreen : cWhite );
 		}
-		m_pLocalPlayerStatsPanel->SetDialogVariable( "destruction", pSelectedPlayer->m_Shared.GetBuildingsDestroyed( playerIndex ) );
+		m_pLocalPlayerStatsPanel->SetDialogVariable( "destruction", V_AddThousandSeparators( pSelectedPlayer->m_Shared.GetBuildingsDestroyed( playerIndex ) ) );
 		if ( m_pDestructionLabel )
 		{
 			m_pDestructionLabel->SetFgColor( pSelectedPlayer->m_Shared.GetBuildingsDestroyed( playerIndex ) ? cGreen : cWhite );
 		}
-		m_pLocalPlayerStatsPanel->SetDialogVariable( "captures", pSelectedPlayer->m_Shared.GetCaptures( playerIndex ) );
+		m_pLocalPlayerStatsPanel->SetDialogVariable( "captures", V_AddThousandSeparators( pSelectedPlayer->m_Shared.GetCaptures( playerIndex ) ) );
 		if ( m_pCapturesLabel )
 		{
 			m_pCapturesLabel->SetFgColor( pSelectedPlayer->m_Shared.GetCaptures( playerIndex ) ? cGreen : cWhite );
 		}
-		m_pLocalPlayerStatsPanel->SetDialogVariable( "defenses", pSelectedPlayer->m_Shared.GetDefenses( playerIndex ) );
+		m_pLocalPlayerStatsPanel->SetDialogVariable( "defenses", V_AddThousandSeparators( pSelectedPlayer->m_Shared.GetDefenses( playerIndex ) ) );
 		if ( m_pDefensesLabel )
 		{
 			m_pDefensesLabel->SetFgColor( pSelectedPlayer->m_Shared.GetDefenses( playerIndex ) ? cGreen : cWhite );
 		}
-		m_pLocalPlayerStatsPanel->SetDialogVariable( "dominations", pSelectedPlayer->m_Shared.GetDominations( playerIndex ) );
+		m_pLocalPlayerStatsPanel->SetDialogVariable( "dominations", V_AddThousandSeparators( pSelectedPlayer->m_Shared.GetDominations( playerIndex ) ) );
 		if ( m_pDominationsLabel )
 		{
 			m_pDominationsLabel->SetFgColor( pSelectedPlayer->m_Shared.GetDominations( playerIndex ) ? cGreen : cWhite );
 		}
-		m_pLocalPlayerStatsPanel->SetDialogVariable( "revenge", pSelectedPlayer->m_Shared.GetRevenge( playerIndex ) );
+		m_pLocalPlayerStatsPanel->SetDialogVariable( "revenge", V_AddThousandSeparators( pSelectedPlayer->m_Shared.GetRevenge( playerIndex ) ) );
 		if ( m_pRevengeLabel )
 		{
 			m_pRevengeLabel->SetFgColor( pSelectedPlayer->m_Shared.GetRevenge( playerIndex ) ? cGreen : cWhite );
 		}
-		m_pLocalPlayerStatsPanel->SetDialogVariable( "healing", pSelectedPlayer->m_Shared.GetHealPoints( playerIndex ) );
+		m_pLocalPlayerStatsPanel->SetDialogVariable( "healing", V_AddThousandSeparators( pSelectedPlayer->m_Shared.GetHealPoints( playerIndex ) ) );
 		if ( m_pHealingLabel )
 		{
 			m_pHealingLabel->SetFgColor( pSelectedPlayer->m_Shared.GetHealPoints( playerIndex ) ? cGreen : cWhite );
 		}
-		m_pLocalPlayerStatsPanel->SetDialogVariable( "invulns", pSelectedPlayer->m_Shared.GetInvulns( playerIndex ) );
+		m_pLocalPlayerStatsPanel->SetDialogVariable( "invulns", V_AddThousandSeparators( pSelectedPlayer->m_Shared.GetInvulns( playerIndex ) ) );
 		if ( m_pInvulnsLabel )
 		{
 			m_pInvulnsLabel->SetFgColor( pSelectedPlayer->m_Shared.GetInvulns( playerIndex ) ? cGreen : cWhite );
 		}
-		m_pLocalPlayerStatsPanel->SetDialogVariable( "teleports", pSelectedPlayer->m_Shared.GetTeleports( playerIndex ) );
+		m_pLocalPlayerStatsPanel->SetDialogVariable( "teleports", V_AddThousandSeparators( pSelectedPlayer->m_Shared.GetTeleports( playerIndex ) ) );
 		if ( m_pTeleportsLabel )
 		{
 			m_pTeleportsLabel->SetFgColor( pSelectedPlayer->m_Shared.GetTeleports( playerIndex ) ? cGreen : cWhite );
 		}
-		m_pLocalPlayerStatsPanel->SetDialogVariable( "headshots", pSelectedPlayer->m_Shared.GetHeadshots( playerIndex ) );
+		m_pLocalPlayerStatsPanel->SetDialogVariable( "headshots", V_AddThousandSeparators( pSelectedPlayer->m_Shared.GetHeadshots( playerIndex ) ) );
 		if ( m_pHeadshotsLabel )
 		{
 			m_pHeadshotsLabel->SetFgColor( pSelectedPlayer->m_Shared.GetHeadshots( playerIndex ) ? cGreen : cWhite );
 		}
-		m_pLocalPlayerStatsPanel->SetDialogVariable( "backstabs", pSelectedPlayer->m_Shared.GetBackstabs( playerIndex ) );
+		m_pLocalPlayerStatsPanel->SetDialogVariable( "backstabs", V_AddThousandSeparators( pSelectedPlayer->m_Shared.GetBackstabs( playerIndex ) ) );
 		if ( m_pBackstabsLabel )
 		{
 			m_pBackstabsLabel->SetFgColor( pSelectedPlayer->m_Shared.GetBackstabs( playerIndex ) ? cGreen : cWhite );
 		}
-		m_pLocalPlayerStatsPanel->SetDialogVariable( "bonus", pSelectedPlayer->m_Shared.GetBonusPoints( playerIndex ) );
+		m_pLocalPlayerStatsPanel->SetDialogVariable( "bonus", V_AddThousandSeparators( pSelectedPlayer->m_Shared.GetBonusPoints( playerIndex ) ) );
 		if ( m_pBonusLabel )
 		{
 			m_pBonusLabel->SetFgColor( pSelectedPlayer->m_Shared.GetBonusPoints( playerIndex ) ? cGreen : cWhite );
 		}
 
 		int nSupport = TFGameRules() ? TFGameRules()->CalcPlayerSupportScore( NULL, playerIndex ) : 0;
-		m_pLocalPlayerStatsPanel->SetDialogVariable( "support", nSupport );
+		m_pLocalPlayerStatsPanel->SetDialogVariable( "support", V_AddThousandSeparators( nSupport ) );
 		if ( m_pSupportLabel )
 		{
 			m_pSupportLabel->SetFgColor( nSupport ? cGreen : cWhite );
 		}
-		m_pLocalPlayerStatsPanel->SetDialogVariable( "damage", g_TF_PR->GetDamage( playerIndex ) );
+		m_pLocalPlayerStatsPanel->SetDialogVariable( "damage", V_AddThousandSeparators( g_TF_PR->GetDamage( playerIndex ) ) );
 		if ( m_pDamageLabel )
 		{
 			m_pDamageLabel->SetFgColor( g_TF_PR->GetDamage( playerIndex ) ? cGreen : cWhite );

--- a/src/game/client/tf/vgui/tf_controls.cpp
+++ b/src/game/client/tf/vgui/tf_controls.cpp
@@ -36,8 +36,8 @@ using namespace vgui;
 wchar_t* LocalizeNumberWithToken( const char* pszLocToken, int nValue )
 {
 	static wchar_t wszOutString[ 256 ];
-	wchar_t wszCount[ 16 ];
-	_snwprintf( wszCount, ARRAYSIZE( wszCount ), L"%d", nValue );
+	wchar_t wszCount[ 24 ];
+	_snwprintf( wszCount, ARRAYSIZE( wszCount ), L"%S", V_AddThousandSeparators( nValue ) );
 	const wchar_t *wpszFormat = g_pVGuiLocalize->Find( pszLocToken );
 	g_pVGuiLocalize->ConstructString_safe( wszOutString, wpszFormat, 1, wszCount );
 	
@@ -47,10 +47,10 @@ wchar_t* LocalizeNumberWithToken( const char* pszLocToken, int nValue )
 wchar_t* LocalizeNumberWithToken( const char* pszLocToken, int nValue1, int nValue2 )
 {
 	static wchar_t wszOutString[ 256 ];
-	wchar_t wszCount1[ 16 ];
-	wchar_t wszCount2[ 16 ];
-	_snwprintf( wszCount1, ARRAYSIZE( wszCount1 ), L"%d", nValue1 );
-	_snwprintf( wszCount2, ARRAYSIZE( wszCount2 ), L"%d", nValue2 );
+	wchar_t wszCount1[ 24 ];
+	wchar_t wszCount2[ 24 ];
+	_snwprintf( wszCount1, ARRAYSIZE( wszCount1 ), L"%S", V_AddThousandSeparators( nValue1 ) );
+	_snwprintf( wszCount2, ARRAYSIZE( wszCount2 ), L"%S", V_AddThousandSeparators( nValue2 ) );
 	const wchar_t *wpszFormat = g_pVGuiLocalize->Find( pszLocToken );
 	g_pVGuiLocalize->ConstructString_safe( wszOutString, wpszFormat, 2, wszCount1, wszCount2 );
 

--- a/src/game/client/tf/vgui/tf_pvp_rank_panel.cpp
+++ b/src/game/client/tf/vgui/tf_pvp_rank_panel.cpp
@@ -470,7 +470,7 @@ void CPvPRankPanel::UpdateRatingControls( uint32 nPreviousRating, uint32 nCurren
 		wchar_t wszRating[ 128 ];
 		auto lambdaRatingString = [ this, &wszRating ]( const char* pszToken, int nRating )
 		{
-			V_swprintf_safe( wszRating, L"%d %ls", nRating, g_pVGuiLocalize->Find( m_pProgressionDesc->GetRankUnitsLocToken() ) );
+			V_swprintf_safe( wszRating, L"%S %ls", V_AddThousandSeparators( nRating ), g_pVGuiLocalize->Find( m_pProgressionDesc->GetRankUnitsLocToken() ) );
 			return wszRating;
 		};
 

--- a/src/game/shared/econ/econ_item_description.cpp
+++ b/src/game/shared/econ/econ_item_description.cpp
@@ -1169,8 +1169,10 @@ bool CEconItemDescription::BGenerate_ItemLevelDesc_StrangeNameAndStats( const CL
 
 			const uint32 unKillEaterAltType = GetScoreTypeForKillEaterAttr( pEconItem, pKillEaterAltScoreTypeAttrDef );
 
+			wchar_t wStrangeScore[18];
+			g_pVGuiLocalize->ConvertANSIToUnicode( V_AddThousandSeparators( unKillEaterAltScore ), wStrangeScore, sizeof( wStrangeScore ) );
 			AddDescLine( CConstructLocalizedString( pLocalizationProvider->Find( "ItemTypeDescKillEaterAltv2" ),
-				unKillEaterAltScore,
+				wStrangeScore,
 				GetLocalizedStringForKillEaterTypeAttr( pLocalizationProvider, unKillEaterAltType ),
 				*CStrangeRestrictionAttrWrapper( pLocalizationProvider, GetLocalizedStringForStrangeRestrictionAttr( pLocalizationProvider, pEconItem, i ) ) ),
 				ATTRIB_COL_LEVEL,
@@ -1187,10 +1189,12 @@ bool CEconItemDescription::BGenerate_ItemLevelDesc_StrangeNameAndStats( const CL
 	static CSchemaAttributeDefHandle pAttrDef_LimitedQuantityItem( "limited quantity item" );
 	bLimitedQuantity = pEconItem->FindAttribute( pAttrDef_LimitedQuantityItem );
 
+	wchar_t wStrangeScore[18];
+	g_pVGuiLocalize->ConvertANSIToUnicode( V_AddThousandSeparators( RankGenerator.GetStrangeScore() ), wStrangeScore, sizeof( wStrangeScore ) );
 	AddDescLine( CConstructLocalizedString( pLocalizationProvider->Find( "ItemTypeDescKillEater" ),
 												RankGenerator.GetRankLocalized(),
 												locTypename ? locTypename : LOCCHAR(""),
-												RankGenerator.GetStrangeScore(),
+												wStrangeScore,
 												GetLocalizedStringForKillEaterTypeAttr( pLocalizationProvider, RankGenerator.GetStrangeType() ),
 												*CStrangeRestrictionAttrWrapper( pLocalizationProvider, GetLocalizedStringForStrangeRestrictionAttr( pLocalizationProvider, pEconItem, RankGenerator.GetUsedStrangeSlot() ) ),
 												RankGenerator.GetRankSecondaryLocalized() ? RankGenerator.GetRankSecondaryLocalized() : LOCCHAR(""), 
@@ -1222,8 +1226,10 @@ bool CEconItemDescription::BGenerate_ItemLevelDesc_StrangeNameAndStats( const CL
 		if ( unKillEaterAltType == RankGenerator.GetStrangeType() )
 			continue;
 
+		wchar_t wStrangeScore[18];
+		g_pVGuiLocalize->ConvertANSIToUnicode( V_AddThousandSeparators( unKillEaterAltScore ), wStrangeScore, sizeof( wStrangeScore ) );
 		AddDescLine( CConstructLocalizedString( pLocalizationProvider->Find( "ItemTypeDescKillEaterAlt" ),
-												unKillEaterAltScore,
+												wStrangeScore,
 												GetLocalizedStringForKillEaterTypeAttr( pLocalizationProvider, unKillEaterAltType ),
 												*CStrangeRestrictionAttrWrapper( pLocalizationProvider, GetLocalizedStringForStrangeRestrictionAttr( pLocalizationProvider, pEconItem, i ) ) ),
 					 ATTRIB_COL_LEVEL,

--- a/src/public/tier1/strtools.h
+++ b/src/public/tier1/strtools.h
@@ -633,6 +633,8 @@ char *V_pretifymem( float value, int digitsafterdecimal = 2, bool usebinaryonek 
 // Prints out a pretified integer with comma separators (eg, 7,233,270,000)
 char *V_pretifynum( int64 value );
 
+char* V_AddThousandSeparators( int value );
+
 int _V_UCS2ToUnicode( const ucs2 *pUCS2, OUT_Z_BYTECAP(cubDestSizeInBytes) wchar_t *pUnicode, int cubDestSizeInBytes );
 template< typename T > inline int V_UCS2ToUnicode( const ucs2 *pUCS2, OUT_Z_BYTECAP(cubDestSizeInBytes) wchar_t *pUnicode, T cubDestSizeInBytes )
 {

--- a/src/tier1/strtools.cpp
+++ b/src/tier1/strtools.cpp
@@ -1276,6 +1276,35 @@ char *V_pretifynum( int64 inputValue )
 
 
 //-----------------------------------------------------------------------------
+// Purpose: Returns a string representation of an integer with commas
+//			separating the 1000s (ie, 37,426,421)
+//			This is similar to V_pretifynum but faster
+// Input  : value -		Value to convert
+// Output : Pointer to a static buffer containing the output
+//-----------------------------------------------------------------------------
+char* V_AddThousandSeparators( int iValue )
+{
+	static char szConversion[32];
+	szConversion[0] = '\0';
+
+	if ( iValue >= 1000000 )
+	{
+		V_sprintf_safe( szConversion, "%d%s%d%d%d%s%d%d%d", iValue / 1000000, ",", ( iValue % 1000000 ) / 100000, ( iValue % 100000 ) / 10000, ( iValue % 10000 ) / 1000, ",", ( iValue % 1000 ) / 100, ( iValue % 100 ) / 10, iValue % 10 );
+	}
+	else if ( iValue >= 1000 )
+	{
+		V_sprintf_safe( szConversion, "%d%s%d%d%d", iValue / 1000, ",", ( iValue % 1000 ) / 100, ( iValue % 100 ) / 10, iValue % 10 );
+	}
+	else if ( iValue >= 0 )
+	{
+		V_sprintf_safe( szConversion, "%d", iValue );
+	}
+
+	return szConversion;
+}
+
+
+//-----------------------------------------------------------------------------
 // Purpose: returns true if a wide character is a "mean" space; that is,
 //			if it is technically a space or punctuation, but causes disruptive
 //			behavior when used in names, web pages, chat windows, etc.


### PR DESCRIPTION
# Description
This PR adds thousands separators to various values across the game that tend to become very large and difficult to read at first glance without separators, this previously only existed on the player list stats on the MvM scoreboard.

I moved and renamed `ConvertScoreboardValueToString` inside of `tf_hud_mann_vs_machine_scoreboard.cpp` to `V_AddThousandSeparators` inside of `strtools.cpp` to make it a more accessible function, this was to avoid using `V_pretifynum` as it's around 4x slower and results in the same desired output.

The thousands separator applies to the following values:
- Strange item counts
- All stats displayed on scoreboards
- PVP Panel stats (Casual XP, Comp MMR and unused MYM matchmaking stats)
- Competitive match history stats
- MvM Currency (Counts near the player health and the upgrade menu and upgrade cost)

# Examples:
<img src="https://github.com/user-attachments/assets/1036b637-620b-4b2a-954d-6305cbc576e1" width="550"/>
<img src="https://github.com/user-attachments/assets/fc9f14cb-8574-48f4-a3ad-b9226dbd0d76" width="550"/>
<img src="https://github.com/user-attachments/assets/523921d5-aeac-47f3-8978-8870dfc6fa0f" width="550"/>
<img src="https://github.com/user-attachments/assets/31a3fcb5-c9c3-462c-aa4a-900e1378f242" width="550"/>
