### PR TITLE
all games: Add ConVars for changing the Steam overlay notification toasts position

### DIFF
--- a/src/game/client/cdll_client_int.cpp
+++ b/src/game/client/cdll_client_int.cpp
@@ -293,6 +293,36 @@ extern CViewRender g_DefaultViewRender;
 
 extern void StopAllRumbleEffects( void );
 
+#if !defined( _X360 ) && !defined( NO_STEAM )
+void OnSteamToastConVarChanged( IConVar *pCVar, const char *pszOldValue, float flOldValue );
+ConVar cl_steam_overlay_toast_position( "cl_steam_overlay_toast_position", "0", FCVAR_ARCHIVE, "Which corner the Steam overlay notification toast should display itself in. 0 = k_EPositionTopLeft, 1 = k_EPositionTopRight, 2 = k_EPositionBottomLeft, 3 = k_EPositionBottomRight", OnSteamToastConVarChanged );
+ConVar cl_steam_overlay_toast_inset_horizontal( "cl_steam_overlay_toast_inset_horizontal", "0", FCVAR_ARCHIVE, "Steam overlay notification toast horizontal inset", true, 0.0f, true, 1.0f, OnSteamToastConVarChanged );
+ConVar cl_steam_overlay_toast_inset_vertical( "cl_steam_overlay_toast_inset_vertical", "0", FCVAR_ARCHIVE, "Steam overlay notification toast vertical inset", true, 0.0f, true, 1.0f, OnSteamToastConVarChanged );
+
+void SetSteamOverlayToastPosition( void )
+{
+	if ( !SteamUtils() )
+		return;
+
+	const float k_flMaxRatio = .25f;
+
+	SteamUtils()->SetOverlayNotificationPosition( static_cast< ENotificationPosition >( cl_steam_overlay_toast_position.GetInt() ) );
+
+	int nWidth, nHeight;
+	engine->GetScreenSize( nWidth, nHeight );
+
+	int nHorizontalInset = ( int )( nWidth * ( k_flMaxRatio * cl_steam_overlay_toast_inset_horizontal.GetFloat() ) );
+	int nVerticalInset = ( int )( nHeight * ( k_flMaxRatio * cl_steam_overlay_toast_inset_vertical.GetFloat() ) );
+
+	SteamUtils()->SetOverlayNotificationInset( nHorizontalInset, nVerticalInset );
+}
+
+void OnSteamToastConVarChanged( IConVar *pCVar, const char *pszOldValue, float flOldValue )
+{
+	SetSteamOverlayToastPosition();
+}
+#endif
+
 static C_BaseEntityClassList *s_pClassLists = NULL;
 C_BaseEntityClassList::C_BaseEntityClassList()
 {
@@ -1184,12 +1214,6 @@ void CHLClient::PostInit()
 	}
 #endif
 
-#if !defined( _X360 ) && !defined( NO_STEAM )
-	// This needs to be called every time the game is launched since Steam doesn't save the updated position
-	extern void SetSteamOverlayToastPosition( void ); // from clientmode_shared.cpp
-	SetSteamOverlayToastPosition();
-#endif
-
 	if ( !r_lightmap_bicubic_set.GetBool() && materials )
 	{
 		MaterialAdapterInfo_t info{};
@@ -1280,6 +1304,10 @@ int CHLClient::HudVidInit( void )
 	gHUD.VidInit();
 
 	GetClientVoiceMgr()->VidInit();
+
+#if !defined( _X360 ) && !defined( NO_STEAM )
+	SetSteamOverlayToastPosition();
+#endif
 
 	return 1;
 }

--- a/src/game/client/clientmode_shared.cpp
+++ b/src/game/client/clientmode_shared.cpp
@@ -78,19 +78,10 @@ class CHudVote;
 
 static vgui::HContext s_hVGuiContext = DEFAULT_VGUI_CONTEXT;
 
-#if !defined( _X360 ) && !defined( NO_STEAM )
-void OnSteamToastConVarChanged( IConVar* pCVar, const char* pszOldValue, float flOldValue );
-#endif
-
 ConVar cl_drawhud( "cl_drawhud", "1", FCVAR_CHEAT, "Enable the rendering of the hud" );
 ConVar hud_takesshots( "hud_takesshots", "0", FCVAR_CLIENTDLL | FCVAR_ARCHIVE, "Auto-save a scoreboard screenshot at the end of a map." );
 ConVar hud_freezecamhide( "hud_freezecamhide", "0", FCVAR_CLIENTDLL | FCVAR_ARCHIVE, "Hide the HUD during freeze-cam" );
 ConVar cl_show_num_particle_systems( "cl_show_num_particle_systems", "0", FCVAR_CLIENTDLL, "Display the number of active particle systems." );
-#if !defined( _X360 ) && !defined( NO_STEAM )
-ConVar cl_steam_overlay_toast_position( "cl_steam_overlay_toast_position", "0", FCVAR_ARCHIVE, "Which corner the Steam overlay notification toast should display itself in. 0 = k_EPositionTopLeft, 1 = k_EPositionTopRight, 2 = k_EPositionBottomLeft, 3 = k_EPositionBottomRight", OnSteamToastConVarChanged );
-ConVar cl_steam_overlay_toast_inset_horizontal( "cl_steam_overlay_toast_inset_horizontal", "0", FCVAR_ARCHIVE, "Steam overlay notification toast horizontal inset", true, 0.0f, true, 1.0f, OnSteamToastConVarChanged );
-ConVar cl_steam_overlay_toast_inset_vertical( "cl_steam_overlay_toast_inset_vertical", "0", FCVAR_ARCHIVE, "Steam overlay notification toast vertical inset", true, 0.0f, true, 1.0f, OnSteamToastConVarChanged );
-#endif
 
 extern ConVar v_viewmodel_fov;
 extern ConVar voice_modenable;
@@ -98,31 +89,6 @@ extern ConVar cl_enable_text_chat;
 
 extern bool IsInCommentaryMode( void );
 extern const char* GetWearLocalizationString( float flWear );
-
-#if !defined( _X360 ) && !defined( NO_STEAM )
-void SetSteamOverlayToastPosition( void )
-{
-	if( !SteamUtils() )
-		return;
-
-	const float k_flMaxRatio = .25f;
-
-	SteamUtils()->SetOverlayNotificationPosition( static_cast< ENotificationPosition >( cl_steam_overlay_toast_position.GetInt() ) );
-
-	int nWidth, nHeight;
-	engine->GetScreenSize( nWidth, nHeight );
-
-	int nHorizontalInset = ( int )( nWidth * ( k_flMaxRatio * cl_steam_overlay_toast_inset_horizontal.GetFloat() ) );
-	int nVerticalInset = ( int )( nHeight * ( k_flMaxRatio * cl_steam_overlay_toast_inset_vertical.GetFloat() ) );
-
-	SteamUtils()->SetOverlayNotificationInset( nHorizontalInset, nVerticalInset );
-}
-
-void OnSteamToastConVarChanged( IConVar* pCVar, const char* pszOldValue, float flOldValue )
-{
-	SetSteamOverlayToastPosition();
-}
-#endif
 
 CON_COMMAND( cl_reload_localization_files, "Reloads all localization files" )
 {


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
This PR adds ConVars that allow the player to customize the position of Steam overlay notification toasts, similarly to the functionality present in Counter-Strike 2. It does this by calling the Steam API functions:
- [ISteamUtils::SetOverlayNotificationInset](https://partner.steamgames.com/doc/api/ISteamUtils#SetOverlayNotificationInset)
- [ISteamUtils::SetOverlayNotificationPosition](https://partner.steamgames.com/doc/api/ISteamUtils#SetOverlayNotificationPosition)


| | Description                                                                                                                  |
|--------------------------------------------|------------------------------------------------------------------------------------------------------------------------------|
| `cl_steam_overlay_toast_position`          | Which corner the Steam overlay notification toast should display itself in. <br>0 = k_EPositionTopLeft, 1 = k_EPositionTopRight, 2 = k_EPositionBottomLeft, 3 = k_EPositionBottomRight |
| `cl_steam_overlay_toast_inset_horizontal`  | Steam overlay notification toast horizontal inset    |
| `cl_steam_overlay_toast_inset_vertical`    | Steam overlay notification toast vertical inset     |

Inset is specified as a percentage from 0.0 to 1.0. Steam clamps the inset to a maximum of 25% of the screen's width/height.
It would also be a good idea to add these vars to the advanced settings menus of the games.


https://github.com/user-attachments/assets/7ca2f5d6-5fed-46af-8021-452f3662fb61

Closes https://github.com/ValveSoftware/Source-1-Games/issues/3816
