### PR TITLE
[TF2] Fix client desyncs with the Ullapool Caber and Gunslinger due to lack of prediction

### DIFF
--- a/src/game/shared/tf/tf_weapon_bottle.cpp
+++ b/src/game/shared/tf/tf_weapon_bottle.cpp
@@ -76,19 +76,18 @@ PRECACHE_WEAPON_REGISTER( tf_weapon_breakable_sign );
 //
 IMPLEMENT_NETWORKCLASS_ALIASED( TFStickBomb, DT_TFWeaponStickBomb )
 
-#ifdef CLIENT_DLL
-void RecvProxy_Detonated( const CRecvProxyData *pData, void *pStruct, void *pOut );
-#endif
-
 BEGIN_NETWORK_TABLE( CTFStickBomb, DT_TFWeaponStickBomb )
 #if defined( CLIENT_DLL )
-	RecvPropInt( RECVINFO( m_iDetonated ), 0, RecvProxy_Detonated )
+	RecvPropInt( RECVINFO( m_iDetonated ) )
 #else
 	SendPropInt( SENDINFO( m_iDetonated ), 1, SPROP_UNSIGNED )
 #endif
 END_NETWORK_TABLE()
 
 BEGIN_PREDICTION_DATA( CTFStickBomb )
+#ifdef CLIENT_DLL
+	DEFINE_PRED_FIELD( m_iDetonated, FIELD_INTEGER, FTYPEDESC_INSENDTABLE )
+#endif
 END_PREDICTION_DATA()
 
 LINK_ENTITY_TO_CLASS( tf_weapon_stickbomb, CTFStickBomb );
@@ -314,6 +313,7 @@ const char *CTFStickBomb::GetWorldModel( void ) const
 }
 
 #ifdef CLIENT_DLL
+
 int CTFStickBomb::GetWorldModelIndex( void )
 {
 	if ( !modelinfo )
@@ -330,19 +330,12 @@ int CTFStickBomb::GetWorldModelIndex( void )
 		return m_iWorldModelIndex;
 	}
 }
-#endif
 
-#ifdef CLIENT_DLL
-
-void RecvProxy_Detonated( const CRecvProxyData *pData, void *pStruct, void *pOut )
+void CTFStickBomb::OnDataChanged( DataUpdateType_t updateType )
 {
-	C_TFStickBomb* pBomb = (C_TFStickBomb*) pStruct;
-
-	if ( pData->m_Value.m_Int != pBomb->GetDetonated() )
-	{
-		pBomb->SetDetonated( pData->m_Value.m_Int );
-		pBomb->SwitchBodyGroups();
-	}
+	BaseClass::OnDataChanged( updateType );
+	
+	SwitchBodyGroups();
 }
 
 #endif

--- a/src/game/shared/tf/tf_weapon_bottle.h
+++ b/src/game/shared/tf/tf_weapon_bottle.h
@@ -98,6 +98,7 @@ public:
 	virtual const char*	GetWorldModel( void ) const OVERRIDE;
 #ifdef CLIENT_DLL
 	virtual int			GetWorldModelIndex( void ) OVERRIDE;
+	virtual void		OnDataChanged( DataUpdateType_t type ) OVERRIDE;
 #endif
 
 	void				SetDetonated( int iVal ) { m_iDetonated = iVal; }

--- a/src/game/shared/tf/tf_weapon_wrench.cpp
+++ b/src/game/shared/tf/tf_weapon_wrench.cpp
@@ -54,17 +54,20 @@ IMPLEMENT_NETWORKCLASS_ALIASED( TFRobotArm, DT_TFWeaponRobotArm )
 
 BEGIN_NETWORK_TABLE( CTFRobotArm, DT_TFWeaponRobotArm )
 #ifdef GAME_DLL
-SendPropEHandle(SENDINFO(m_hRobotArm)),
+	SendPropEHandle( SENDINFO( m_hRobotArm ) ),
+	SendPropInt( SENDINFO( m_iComboCount ), 4, SPROP_UNSIGNED),
+	SendPropFloat( SENDINFO( m_flLastComboHit ), 0, SPROP_NOSCALE),
 #else
-RecvPropEHandle(RECVINFO(m_hRobotArm)),
+	RecvPropEHandle( RECVINFO( m_hRobotArm ) ),
+	RecvPropInt( RECVINFO( m_iComboCount ) ),
+	RecvPropFloat( RECVINFO( m_flLastComboHit) ),
 #endif
 END_NETWORK_TABLE()
 
 #ifdef CLIENT_DLL
 BEGIN_PREDICTION_DATA( CTFRobotArm )
-// DEFINE_PRED_FIELD( name, fieldtype, flags )
-DEFINE_PRED_FIELD( m_iComboCount, FIELD_INTEGER, 0 ),
-DEFINE_PRED_FIELD( m_flLastComboHit, FIELD_FLOAT, 0 ),
+DEFINE_PRED_FIELD( m_iComboCount, FIELD_INTEGER, FTYPEDESC_INSENDTABLE ),
+DEFINE_PRED_FIELD( m_flLastComboHit, FIELD_FLOAT, FTYPEDESC_INSENDTABLE ),
 END_PREDICTION_DATA()
 #endif
 

--- a/src/game/shared/tf/tf_weapon_wrench.h
+++ b/src/game/shared/tf/tf_weapon_wrench.h
@@ -95,8 +95,8 @@ public:
 private:
 	CNetworkHandle( CTFWearable, m_hRobotArm );
 
-	int					m_iComboCount;
-	float				m_flLastComboHit;
+	CNetworkVar( int, m_iComboCount );
+	CNetworkVar( float, m_flLastComboHit );
 	bool				m_bBigIdle;
 	bool				m_bBigHit;
 };

--- a/src/game/shared/tf/tf_weaponbase_melee.cpp
+++ b/src/game/shared/tf/tf_weaponbase_melee.cpp
@@ -32,9 +32,17 @@ ConVar tf_weapon_criticals_melee( "tf_weapon_criticals_melee", "1", FCVAR_REPLIC
 IMPLEMENT_NETWORKCLASS_ALIASED( TFWeaponBaseMelee, DT_TFWeaponBaseMelee )
 
 BEGIN_NETWORK_TABLE( CTFWeaponBaseMelee, DT_TFWeaponBaseMelee )
+#ifdef CLIENT_DLL
+	RecvPropFloat( RECVINFO( m_flSmackTime ) ),
+#else
+	SendPropFloat( SENDINFO( m_flSmackTime ), 0, SPROP_NOSCALE ),
+#endif
 END_NETWORK_TABLE()
 
 BEGIN_PREDICTION_DATA( CTFWeaponBaseMelee )
+#ifdef CLIENT_DLL
+	DEFINE_PRED_FIELD( m_flSmackTime, FIELD_FLOAT, FTYPEDESC_INSENDTABLE ),
+#endif
 END_PREDICTION_DATA()
 
 LINK_ENTITY_TO_CLASS( tf_weaponbase_melee, CTFWeaponBaseMelee );

--- a/src/game/shared/tf/tf_weaponbase_melee.h
+++ b/src/game/shared/tf/tf_weaponbase_melee.h
@@ -89,7 +89,7 @@ protected:
 
 protected:
 
-	float	m_flSmackTime;
+	CNetworkVar( float, m_flSmackTime );
 	bool	m_bConnected;
 	bool	m_bMiniCrit;
 


### PR DESCRIPTION
Fixes client desync issues on these melee weapons with special attack mechanics by giving them proper prediction:

- **Ullapool Caber** - Whenever a melee hit was registered on the client, but not on the server, the viewmodel would be set to the detonated model on the client and stay that way, even though it did not actually detonate on the server. Fixed by predicting `m_iDetonated` and always instantly updating the model when a prediction error happens, so it's always in sync with the server's detonation state.

Before:

https://github.com/user-attachments/assets/76debeb1-fd3c-4041-bfca-c13114a4ed27

After:

https://github.com/user-attachments/assets/93b670b2-15ee-49bf-9355-68ffa7597945


- **Gunslinger** - The combo mechanic (after 2 consecutive hits, the third one is a guaranteed crit) was not properly implemented on the client at all, and when attacking with the guaranteed crit, the client would always play the non-crit swing animation for some time (depending on ping) before being corrected by the server. Fixed by networking and predicting `m_iComboCount` and `m_flLastComboHit`, so the client now plays the crit swing animation when appropriate.

Before:

https://github.com/user-attachments/assets/3c127b0d-e253-43cf-9cd6-af91884a2db5

After:

https://github.com/user-attachments/assets/afc51282-e93f-492b-88a4-b84200a4fe72

Fixing these two bugs also required networking and predicting `CTFWeaponBaseMelee::m_flSmackTime`, because otherwise `CTFWeaponBaseMelee::Smack()` would not be properly called during prediction.

Fixes https://github.com/ValveSoftware/Source-1-Games/issues/4719, fixes https://github.com/ValveSoftware/Source-1-Games/issues/5750