### PR TITLE
[TF2] Fix being able to throw the Gas Passer through walls

### DIFF
--- a/src/game/shared/tf/tf_weapon_jar.cpp
+++ b/src/game/shared/tf/tf_weapon_jar.cpp
@@ -206,6 +206,17 @@ void CTFJar::TossJarThink( void )
 		pPlayer->SpeakWeaponFire( MP_CONCEPT_JARATE_LAUNCH );
 	}
 
+	if ( pProjectile->ExplodesOnHit() )
+	{
+		Vector vecEnd = pProjectile->GetAbsOrigin() + ( vecVelocity.Normalized() * 32.0f );
+		UTIL_TraceHull( pProjectile->GetAbsOrigin(), vecEnd, -Vector(8, 8, 8), Vector(8, 8, 8), MASK_SOLID_BRUSHONLY, &traceFilter, &trace );
+
+		if ( trace.fraction < 1.0 )
+		{
+			pProjectile->Explode( &trace, pProjectile->GetDamageType() );
+		}
+	}
+
 #endif
 }
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Fixes https://github.com/ValveSoftware/Source-1-Games/issues/3998

There's something about the Gas Passer's projectile model that makes it consistently pass through walls when thrown very close against them. Might be because the projectile is so much larger than the Jarate that it ends up spawning already inside the wall, but I'm not sure. Either way, this is easily fixed by doing a short trace to check if there's something solid immediately in front of the projectile when it's thrown, and forcing it to explode immediately if so.

This also kinda fixes throwing the Flying Guillotine through walls (which is not nearly as easy and consistent). The projectile will still travel through the wall, as no collision actually happened and it can't explode, but it will behave as if it did hit a wall, and won't hit any players on the other side.