### PR TITLE
fix escape button sometimes not closing text chat

### DIFF
--- a/src/game/client/hud_basechat.cpp
+++ b/src/game/client/hud_basechat.cpp
@@ -1273,6 +1273,20 @@ void CBaseHudChat::StopMessageMode( void )
 }
 
 //-----------------------------------------------------------------------------
+// Purpose: Allows to close the chat after clicking on text.
+//-----------------------------------------------------------------------------
+void CBaseHudChat::OnKeyCodeTyped(vgui::KeyCode code )
+{
+	if ( code == KEY_ESCAPE || code == KEY_ENTER )
+	{
+		StopMessageMode();
+		return;
+	}
+
+	BaseClass::OnKeyCodeTyped( code );
+}
+
+//-----------------------------------------------------------------------------
 // Purpose: 
 //-----------------------------------------------------------------------------
 void CBaseHudChat::OnChatEntrySend( void )

--- a/src/game/client/hud_basechat.h
+++ b/src/game/client/hud_basechat.h
@@ -247,6 +247,8 @@ public:
 	virtual void	StopMessageMode( void );
 	void			Send( void );
 
+	virtual void OnKeyCodeTyped(vgui::KeyCode code);
+
 	MESSAGE_FUNC( OnChatEntrySend, "ChatEntrySend" );
 	MESSAGE_FUNC( OnChatEntryStopMessageMode, "ChatEntryStopMessageMode" );
 


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
After clicking on text on the text chat, you cannot close the window with escape until you click again on the input bar. This fixes it.


https://github.com/user-attachments/assets/810b4db2-1e2d-48a3-8cca-eae454d02f49

