### PR TITLE
[ALL] Add `r_nearz` ConVar

### DIFF
--- a/src/game/client/view.cpp
+++ b/src/game/client/view.cpp
@@ -123,6 +123,7 @@ static ConVar r_mapextents( "r_mapextents", "16384", FCVAR_CHEAT,
 ConVar	gl_clear( "gl_clear", "0");
 ConVar	gl_clear_randomcolor( "gl_clear_randomcolor", "0", FCVAR_CHEAT, "Clear the back buffer to random colors every frame. Helps spot open seams in geometry." );
 
+static ConVar r_nearz( "r_nearz", "-1", FCVAR_CHEAT, "Override the near clipping plane." );
 static ConVar r_farz( "r_farz", "-1", FCVAR_CHEAT, "Override the far clipping plane. -1 means to use the value in env_fog_controller." );
 static ConVar cl_demoviewoverride( "cl_demoviewoverride", "0", 0, "Override view during demo playback" );
 
@@ -592,7 +593,19 @@ static QAngle s_DbgSetupAngles;
 //-----------------------------------------------------------------------------
 float CViewRender::GetZNear()
 {
-	return VIEW_NEARZ;
+	// Initialize view structure with default values
+	float nearZ;
+	if ( r_nearz.GetFloat() < 0 )
+	{
+		// TODO: scale/change based on current FOV
+		nearZ = VIEW_NEARZ;
+	}
+	else
+	{
+		nearZ = r_nearz.GetFloat();
+	}
+
+	return nearZ;
 }
 
 float CViewRender::GetZFar()


### PR DESCRIPTION
This simply adds a new console variable called "`r_nearz`" in a similar vain to the pre-existing "`r_farz`" ConVar for the purpose of overriding the NearZ clipping plane during runtime via the console easily (I was always annoyed this didn't exist to begin with).
Ideally a value of "`-1`" would result in it being scaled from the currently set FOV however I don't know what the logic for that would look like so instead it just returns the value of `VIEW_NEARZ`.