### PR TITLE
[TF2] Properly remove/scale Spy cigarette/Medic glasses with decapitation/head smash/big head transformations

### DIFF
--- a/src/game/client/tf/c_tf_player.cpp
+++ b/src/game/client/tf/c_tf_player.cpp
@@ -8393,10 +8393,12 @@ void BuildBigHeadTransformations( CBaseAnimating *pObject, CStudioHdr *hdr, Vect
 	// Scale the head.
 	MatrixScaleBy ( flScale, transform );
 
-	const int cMaxNumHelms = 2;
+	const int cMaxNumHelms = 4;
 	int iHelmIndex[cMaxNumHelms];
 	iHelmIndex[0] = pObject->LookupBone( "prp_helmet" );
 	iHelmIndex[1] = pObject->LookupBone( "prp_hat" );
+	iHelmIndex[2] = pObject->LookupBone( "prp_cig" );
+	iHelmIndex[3] = pObject->LookupBone( "prp_glasses" );
 
 	for ( int i = 0; i < cMaxNumHelms; i++ )
 	{
@@ -8443,6 +8445,20 @@ void BuildDecapitatedTransformations( CBaseAnimating *pObject, CStudioHdr *hdr, 
 		matrix3x4_t  &transformhelmet = pObject->GetBoneForWrite( iHelm );
 		MatrixScaleByZero ( transformhelmet );
 	}
+
+	iHelm = pObject->LookupBone( "prp_cig" );
+	if ( iHelm != -1 )
+	{
+		matrix3x4_t  &transformhelmet = pObject->GetBoneForWrite( iHelm );
+		MatrixScaleByZero ( transformhelmet );
+	}
+
+	iHelm = pObject->LookupBone( "prp_glasses" );
+	if ( iHelm != -1 )
+	{
+		matrix3x4_t  &transformhelmet = pObject->GetBoneForWrite( iHelm );
+		MatrixScaleByZero ( transformhelmet );
+	}
 }
 
 
@@ -8482,6 +8498,16 @@ void BuildNeckScaleTransformations( CBaseAnimating *pObject, CStudioHdr *hdr, Ve
 		{
 			matrix3x4_t  &cig_transform = pObject->GetBoneForWrite( iCig );
 			MatrixScaleByZero ( cig_transform );
+		}
+	}
+
+	if ( iClass == TF_CLASS_MEDIC )
+	{
+		int iGlasses = pObject->LookupBone( "prp_glasses" );
+		if ( iGlasses != -1 )
+		{
+			matrix3x4_t  &glasses_transform = pObject->GetBoneForWrite( iGlasses );
+			MatrixScaleByZero ( glasses_transform );
 		}
 	}
 
@@ -8542,7 +8568,7 @@ void AppendChildren_R( CUtlVector< const mstudiobone_t * > *pChildBones, const s
 //-----------------------------------------------------------------------------
 // Purpose: 
 //-----------------------------------------------------------------------------
-void BuildTorsoScaleTransformations( CBaseAnimating *pObject, CStudioHdr *hdr, Vector *pos, Quaternion q[], const matrix3x4_t& cameraTransform, int boneMask, CBoneBitList &boneComputed, float flScale, int iClass )
+void BuildTorsoScaleTransformations( CBaseAnimating *pObject, CStudioHdr *hdr, Vector *pos, Quaternion q[], const matrix3x4_t& cameraTransform, int boneMask, CBoneBitList &boneComputed, float flScale )
 {
 	if ( !pObject || flScale == 1.f )
 		return;
@@ -8711,7 +8737,7 @@ void C_TFPlayer::BuildTransformations( CStudioHdr *hdr, Vector *pos, Quaternion 
 	m_BoneAccessor.SetWritableBones( BONE_USED_BY_ANYTHING );
 	float flHeadScale = m_Shared.InCond( TF_COND_HALLOWEEN_GHOST_MODE ) ? 1.5 : m_flHeadScale;
 	BuildBigHeadTransformations( this, hdr, pos, q, cameraTransform, boneMask, boneComputed, flHeadScale );
-	BuildTorsoScaleTransformations( this, hdr, pos, q, cameraTransform, boneMask, boneComputed, m_flTorsoScale, GetPlayerClass()->GetClassIndex() );
+	BuildTorsoScaleTransformations( this, hdr, pos, q, cameraTransform, boneMask, boneComputed, m_flTorsoScale );
 	BuildHandScaleTransformations( this, hdr, pos, q, cameraTransform, boneMask, boneComputed, m_flHandScale );
 
 	BuildFirstPersonMeathookTransformations( hdr, pos, q, cameraTransform, boneMask, boneComputed, "bip_head" );
@@ -8727,7 +8753,7 @@ void C_TFRagdoll::BuildTransformations( CStudioHdr *hdr, Vector *pos, Quaternion
 
 	m_BoneAccessor.SetWritableBones( BONE_USED_BY_ANYTHING );
 	BuildBigHeadTransformations( this, hdr, pos, q, cameraTransform, boneMask, boneComputed, m_flHeadScale );
-	BuildTorsoScaleTransformations( this, hdr, pos, q, cameraTransform, boneMask, boneComputed, m_flTorsoScale, GetClass() );
+	BuildTorsoScaleTransformations( this, hdr, pos, q, cameraTransform, boneMask, boneComputed, m_flTorsoScale );
 	BuildHandScaleTransformations( this, hdr, pos, q, cameraTransform, boneMask, boneComputed, m_flHandScale );
 
 	if ( IsDecapitation() && !m_bBaseTransform )


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
This addresses a handful of missing handling cases for player model transformations:
* Decapitated and head-smashed ragdolls keep the Spy's cigarette and the Medic's glasses floating above the severed neck/shortened neck model; this patch hides them under these conditions
* The Big Head transformations do not scale the cigarette/glasses, resulting in them disappearing underneath the enlarged model; this patch scales them so that they appear alongside the enlarged (or shrunken) heads in the correct positions
* Removes iClass param from BuildTorsoScaleTransformations as it is entirely unused