### PR TITLE
Fix VRAD prop indirect lighting regression

### DIFF
--- a/src/utils/vrad/vrad.cpp
+++ b/src/utils/vrad/vrad.cpp
@@ -119,7 +119,7 @@ bool		g_bStaticPropLighting = false;
 bool        g_bStaticPropPolys = false;
 bool        g_bTextureShadows = false;
 bool        g_bDisablePropSelfShadowing = false;
-
+int			g_nIndirectPropLightingMode = 0;
 
 CUtlVector<byte> g_FacesVisibleToLights;
 
@@ -2408,6 +2408,18 @@ int ParseCommandLine( int argc, char **argv, bool *onlydetail )
 		{
 			g_bDisablePropSelfShadowing = true;
 		}
+		else if ( !Q_stricmp( argv[i], "-StaticPropIndirectMode" ) )
+		{
+			if ( ++i < argc )
+			{
+				g_nIndirectPropLightingMode = atoi( argv[i] );
+			}
+			else
+			{
+				Warning( "Error: expected a value after '-StaticPropIndirectMode'\n" );
+				return -1;
+			}
+		}
 		else if ( !Q_stricmp( argv[i], "-textureshadows" ) )
 		{
 			g_bTextureShadows = true;
@@ -2871,6 +2883,7 @@ void PrintUsage( int argc, char **argv )
 		"                          light across a wider area.\n"
         "  -StaticPropLighting   : generate backed static prop vertex lighting\n"
         "  -StaticPropPolys   : Perform shadow tests of static props at polygon precision\n"
+		"  -StaticPropIndirectMode : Override prop indirect lighting algorithm (0 - default, 1 - TF2, 2 - Orangebox)\n"
         "  -OnlyStaticProps   : Only perform direct static prop lighting (vrad debug option)\n"
 		"  -StaticPropNormals : when lighting static props, just show their normal vector\n"
 		"  -textureshadows : Allows texture alpha channels to block light - rays intersecting alpha surfaces will sample the texture\n"

--- a/src/utils/vrad/vrad.h
+++ b/src/utils/vrad/vrad.h
@@ -290,6 +290,7 @@ extern bool g_bStaticPropPolys;
 extern bool g_bTextureShadows;
 extern bool g_bShowStaticPropNormals;
 extern bool g_bDisablePropSelfShadowing;
+extern int g_nIndirectPropLightingMode;
 
 extern CUtlVector<char const *> g_NonShadowCastingMaterialStrings;
 extern void ForceTextureShadowsOnModel( const char *pModelName );


### PR DESCRIPTION
VRAD's prop lighting has been noted to regress since Orangebox particularly in TF2. Specifically, prop lighting appears to be darker and more harsh overall. After some digging, this is caused by a faulty calculation for how indirect (bounced) lighting is sampled on props. This has been broken since around 2014 (when `rd_asteroid` was released.)

Orangebox VRAD did not take into account any falloff or dot from a lighting sample. However because of this, it lead to an unnaturally bright result, although some users opinionated this is an improvement over current VRAD.

Current (TF2) VRAD accounts falloff from the sample, using an inverse square law, presumably to fix the bright results of the Orangebox's method. Unfortunately, this falloff is quite harsh and therefore creates an unnaturally dark result.

This PR implements a middleground of those both in VRAD. It only takes into account the dot of a sample, which leads to a decent spot in-between where it's not too dark or not bright. In-fact, this is the same change that CS:GO VRAD implemented to have more natural prop lighting. A bonus is this also more closely matches the indirect lighting calculation for brushes.

However, for the sake of compatibility with maps that might depend on the previous algorithms' results, a new VRAD option named `-StaticPropIndirectMode` is added to allow users to switch to the old TF2 or Orangebox algorithm.

Comparison:
![2fort](https://github.com/user-attachments/assets/6ebfc54d-6c0f-489f-a201-484805d2fa5d)
