### PR TITLE
all games: Fix segfaults in CBaseEntity when VScript is disabled

### DIFF
--- a/src/game/server/baseentity.cpp
+++ b/src/game/server/baseentity.cpp
@@ -8311,12 +8311,10 @@ bool CBaseEntity::ValidateScriptScope()
 //-----------------------------------------------------------------------------
 void CBaseEntity::RunVScripts()
 {
-	if( m_iszVScripts == NULL_STRING )
+	if( m_iszVScripts == NULL_STRING || !ValidateScriptScope() )
 	{
 		return;
 	}
-
-	ValidateScriptScope();
 
 	// All functions we want to have call chained instead of overwritten
 	// by other scripts in this entities list.
@@ -8388,7 +8386,7 @@ void CBaseEntity::RunVScripts()
 //--------------------------------------------------------------------------------------------------
 void CBaseEntity::RunPrecacheScripts( void )
 {
-	if( m_iszVScripts == NULL_STRING )
+	if( m_iszVScripts == NULL_STRING || !ValidateScriptScope() )
 	{
 		return;
 	}
@@ -8403,7 +8401,7 @@ void CBaseEntity::RunPrecacheScripts( void )
 
 void CBaseEntity::RunOnPostSpawnScripts( void )
 {
-	if( m_iszVScripts == NULL_STRING )
+	if( m_iszVScripts == NULL_STRING || !ValidateScriptScope() )
 	{
 		return;
 	}


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
When VScript is disabled using the `-noscripting` commandline param or when an invalid scripting language is specified, the VScript VM doesn't get initialized which shouldn't be fatal. However the server will attempt to dereference a NULL `g_pScriptVM` pointer due to missing checks in `CBaseEntity::RunVScripts`, `CBaseEntity::RunPrecacheScripts` and `CBaseEntity::RunOnPostSpawnScripts` leading to a server crash on map load if there are any entities with scripts assigned to them.

The fix for this is to make the functions return early if `ValidateScriptScope` fails.

Closes https://github.com/ValveSoftware/Source-1-Games/issues/5122