### PR TITLE
Fix for using the "correct" LCID for LatAm Spanish

### DIFF
--- a/src/common/language.cpp
+++ b/src/common/language.cpp
@@ -27,6 +27,7 @@ struct Language_t
 // es_ES - use new world spanish country code instead?
 // zh_CN - validate that SC date formats come through
 // bt_BR - assume we should use Brazilian rather than Iberian portguese
+// es_419 - latam does not have a specific LCID; the Mexican Spanish LCID will be used instead
 
 static const Language_t s_LanguageNames[] = 
 {
@@ -57,7 +58,7 @@ static const Language_t s_LanguageNames[] =
 	{	"Bulgarian",			"bulgarian",	"#GameUI_Language_Bulgarian",			"bg_BG",	k_Lang_Bulgarian,			1026 },
 	{	"Greek",				"greek",		"#GameUI_Language_Greek",				"el_GR",	k_Lang_Greek,				1032 },
 	{	"Ukrainian",			"ukrainian",	"#GameUI_Language_Ukrainian",			"uk_UA",	k_Lang_Ukrainian,			1058 },
-	{	"Latam_Spanish",		"latam",		"#GameUI_Language_Latam_Spanish",		"es_419",	k_Lang_Latam_Spanish,		1034 },
+	{	"Latam_Spanish",		"latam",		"#GameUI_Language_Latam_Spanish",		"es_419",	k_Lang_Latam_Spanish,		2058 },
 };	
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION

<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

Honestly, I doubt the LCID is actually used, but I wanted to fix it since the wrong one was being used.
