### PR TITLE
Always lowercase filenames in CUtlFilenameSymbolTable to fix loading packed files on Linux (fixes #865)

### DIFF
--- a/src/tier1/utlsymbol.cpp
+++ b/src/tier1/utlsymbol.cpp
@@ -327,9 +327,7 @@ FileNameHandle_t CUtlFilenameSymbolTable::FindOrAddFileName( const char *pFileNa
 	char fn[ MAX_PATH ];
 	Q_strncpy( fn, pFileName, sizeof( fn ) );
 	Q_RemoveDotSlashes( fn );
-#ifdef _WIN32
 	Q_strlower( fn );
-#endif
 
 	// Split the filename into constituent parts
 	char basepath[ MAX_PATH ];
@@ -370,9 +368,7 @@ FileNameHandle_t CUtlFilenameSymbolTable::FindFileName( const char *pFileName )
 	char fn[ MAX_PATH ];
 	Q_strncpy( fn, pFileName, sizeof( fn ) );
 	Q_RemoveDotSlashes( fn );
-#ifdef _WIN32
 	Q_strlower( fn );
-#endif
 
 	// Split the filename into constituent parts
 	char basepath[ MAX_PATH ];


### PR DESCRIPTION
# Description
Tracked down in https://github.com/ValveSoftware/source-sdk-2013/issues/865, loading packed files (e.g. from bsps & vpks) is often broken on community maps for Linux users (& servers!!!) leading to missing textures and broken model collisions.

Also reported at https://github.com/ValveSoftware/Source-1-Games/issues/6868

I'm making this PR to bring more visibility to the cause and to hopefully be merged.
(The cause being that `CUtlFilenameSymbolTable` only lowercases filenames on Windows, which is called from `CZipPackFile::GetFileInfo()` to use a cached file-handle.)

## Alternate approach
@mutezero https://github.com/ValveSoftware/source-sdk-2013/issues/865#issuecomment-3149873648