### PR TITLE
[TF2] Allow self inspection

### DIFF
--- a/src/game/client/tf/tf_hud_inspectpanel.h
+++ b/src/game/client/tf/tf_hud_inspectpanel.h
@@ -26,7 +26,8 @@ public:
 	virtual bool	ShouldDraw( void );
 
 	virtual int		GetRenderGroupPriority( void ) { return 35; }	// less than statpanel
-	void		UserCmd_InspectTarget( void );
+	void		UserCmd_InspectTarget( bool bForceSelf );
+	void		UserCmd_InspectSelf( void );
 	C_TFPlayer		*GetInspectTarget( C_TFPlayer *pLocalTFPlayer );
 
 	int	HudElementKeyInput( int down, ButtonCode_t keynum, const char *pszCurrentBinding );


### PR DESCRIPTION
# Description
This PR adds the Client `tf_inspect_allow_self` CVar, which defaults to 0, and the `inspect_self` Command.

When `tf_inspect_allow_self` is set to 1 and you attempt to inspect without looking at another player, you will instead inspect your equipped items as if you were inspecting another player, this is useful for custom gamemodes like VScript / SM VSH that often modify the attributes of your weapons, of which provide no simple or intuitive way to view them.

Executing `inspect_self` will always inspect yourself, good for those who wish to bind a key to inspect yourself while keeping the previous functionality of the inspect key.

This PR also allows you to close the inspect panel with `+attack2` and `+attack3`, to more easily close the inspect panel when `tf_inspect_allow_self` is set to 1, just like it already does with `+attack`.