### PR TITLE
[TF2] Fix Pyrovision nullifying other voice pitch alterations

### DIFF
--- a/src/game/client/tf/c_tf_player.cpp
+++ b/src/game/client/tf/c_tf_player.cpp
@@ -11611,25 +11611,22 @@ void C_TFPlayer::ClientAdjustVOPitch( int& pitch )
 		pitch *= 1.3f;
 	}
 	// Halloween voice futzery?
-	else
+	float flVoicePitchScale = 1.f;
+	CALL_ATTRIB_HOOK_FLOAT( flVoicePitchScale, voice_pitch_scale );
+
+	int iHalloweenVoiceSpell = 0;
+	if ( TF_IsHolidayActive( kHoliday_HalloweenOrFullMoon ) )
 	{
-		float flVoicePitchScale = 1.f;
-		CALL_ATTRIB_HOOK_FLOAT( flVoicePitchScale, voice_pitch_scale );
+		CALL_ATTRIB_HOOK_INT( iHalloweenVoiceSpell, halloween_voice_modulation );
+	}
 
-		int iHalloweenVoiceSpell = 0;
-		if ( TF_IsHolidayActive( kHoliday_HalloweenOrFullMoon ) )
-		{
-			CALL_ATTRIB_HOOK_INT( iHalloweenVoiceSpell, halloween_voice_modulation );
-		}
-
-		if ( iHalloweenVoiceSpell > 0 )
-		{
-			pitch *= 0.8f;
-		}
-		else if ( flVoicePitchScale != 1.f )
-		{
-			pitch *= flVoicePitchScale;
-		}
+	if ( iHalloweenVoiceSpell > 0 )
+	{
+		pitch *= 0.8f;
+	}
+	else if ( flVoicePitchScale != 1.f )
+	{
+		pitch *= flVoicePitchScale;
 	}
 }
 


### PR DESCRIPTION
## Description
Currently, Pyrovision's voice pitch alteration overrides any other voice pitch alterations, namely,
`player.AddCustomAttribute("voice pitch scale", 0, -1);`
used to mute the underlying character's voice lines for VScript characters such as Saxton Hale.
The cause (and thus the fix) is rather simple - all pitch alterations besides Pyrovision are inside the `else` branch.

## Alternative
If Pyrovision overriding `halloween_voice_modulation` attribute is still wanted, an extra read for `voice pitch scale` could be introduced inside the pyrovision branch. AFAIK `voice pitch scale` is only used by VScript.