### PR TITLE
[TF2] Add ConVar for Tournament HUD to ensure client visiblity

### DIFF
--- a/src/game/client/tf/tf_hud_tournament.cpp
+++ b/src/game/client/tf/tf_hud_tournament.cpp
@@ -48,7 +48,10 @@ void AddSubKeyNamed( KeyValues *pKeys, const char *pszName );
 
 using namespace vgui;
 
+#define TOURNAMENT_PANEL_OVERFLOW_THRESHOLD 9
 #define TOURNAMENT_PANEL_UPDATE_INTERVAL 0.25f
+
+ConVar cl_hud_tournament_always_centered( "cl_hud_tournament_always_centered", "0", FCVAR_ARCHIVE, "Ensure that the client is always visible within the tournament HUD." );
 
 extern ConVar mp_timelimit;
 extern ConVar mp_winlimit;
@@ -887,6 +890,22 @@ void CHudTournament::RecalculatePlayerPanels( void )
 				pPanel->Setup( 0, steamID, lobbyPlayer.GetName(), lobbyPlayer.GetTeam() );
 				++iPanel;
 			}
+		}
+	}
+
+	if (cl_hud_tournament_always_centered.GetBool())
+	{
+		if (iPanel > TOURNAMENT_PANEL_OVERFLOW_THRESHOLD)
+		{
+			// Get a point close enough to the middle.
+			int middlePoint = RoundInt(iPanel / 2);
+
+			// Switch player locations so that the client is visible once again.
+			CTFPlayerPanel *middlePanel = GetOrAddPanel( middlePoint );
+			middlePanel->SetPlayerIndex( pPlayer->entindex() );
+
+			CTFPlayerPanel *clientPanel = GetOrAddPanel( pPlayer->entindex() );
+			clientPanel->SetPlayerIndex( middlePoint );
 		}
 	}
 


### PR DESCRIPTION
This adds a new ConVar (`cl_hud_tournament_always_centered`) that creates an additional pass to `CHudTournament::RecalculatePlayerPanels` that when enabled and past 9 defenders, will swap out our client with a player in the middle of the panel list, ensuring that we are once again visible.

Useful for community MvM gamemodes utilizing above normal defender counts.

Before:
![Screenshot_2025-06-16_01-27-35](https://github.com/user-attachments/assets/4d6a6bfb-624e-4708-bd78-53e60c5aa65d)

After and enabled:
![Screenshot_2025-06-16_01-27-08](https://github.com/user-attachments/assets/bf803f38-ad15-4868-9ed8-939b5b0fd233)
