### PR TITLE
[ALL] Fix !picker on entity outputs

### DIFF
--- a/src/game/server/entitylist.cpp
+++ b/src/game/server/entitylist.cpp
@@ -556,7 +556,22 @@ CBaseEntity *CGlobalEntityList::FindEntityProcedural( const char *szName, CBaseE
 		}
 		else if ( FStrEq( pName, "picker" ) )
 		{
-			return FindPickerEntity( UTIL_PlayerByIndex(1) );
+			if ( pSearchingEntity && pSearchingEntity->IsPlayer() )
+			{
+				return FindPickerEntity( (CBasePlayer *)pSearchingEntity );
+			}
+			else if( pActivator && pActivator->IsPlayer() )
+			{
+				return FindPickerEntity( (CBasePlayer *)pActivator );
+			}
+			else if( pCaller && pCaller->IsPlayer() )
+			{
+				return FindPickerEntity( (CBasePlayer *)pCaller );
+			}
+			else
+			{
+				return FindPickerEntity( UTIL_PlayerByIndex(1) );
+			}
 		}
 		else if ( FStrEq( pName, "self" ) )
 		{


### PR DESCRIPTION
# Description
The ent_fire !picker command used to only get the first player in the server and not the player running the command. This PR fixes this issue.

This new fix can also be used by mappers to easily get the entity in front of the player with entity outputs and vscript.