### PR TITLE
[ALL] Fix NetProps.GetTable() crash

### DIFF
--- a/src/game/server/netpropmanager.cpp
+++ b/src/game/server/netpropmanager.cpp
@@ -1226,6 +1226,13 @@ void CNetPropManager::StoreDataPropValue( typedescription_t *pTypeDesc, CBaseEnt
 	case FIELD_SOUNDNAME:
 	case FIELD_STRING:
 		{
+			PropInfo_t propInfo = GetEntityPropInfo( pBaseEntity, pszPropName, iElement );
+			if ( !propInfo.m_IsPropValid )
+			{
+				g_pScriptVM->SetValue( hTable, pszPropName, "ERROR VALUE" );
+				break;
+			}
+
 			string_t propString = *(string_t *)(uint8 *)pEntityPropData;
 			g_pScriptVM->SetValue( hTable, pszPropName, (propString == NULL_STRING) ? "" : STRING(propString) );
 			break;
@@ -1361,7 +1368,10 @@ void CNetPropManager::CollectNestedDataMaps( datamap_t *pMap, CBaseEntity *pBase
 					g_pScriptVM->ReleaseValue( hPropTable );
 				}
 				else
+				{
+					GetPropStringArray( ToHScript( pBaseEntity ), pTypeDesc->fieldName, 0 ); // fixes a weird bug causing the dataprop to always be invalid
 					StoreDataPropValue( pTypeDesc, pBaseEntity, iOffset, -1, hTable );
+				}
 			}
 		}
 

--- a/src/game/server/netpropmanager.cpp
+++ b/src/game/server/netpropmanager.cpp
@@ -1229,7 +1229,7 @@ void CNetPropManager::StoreDataPropValue( typedescription_t *pTypeDesc, CBaseEnt
 			PropInfo_t propInfo = GetEntityPropInfo( pBaseEntity, pszPropName, iElement );
 			if ( !propInfo.m_IsPropValid )
 			{
-				g_pScriptVM->SetValue( hTable, pszPropName, "ERROR VALUE" );
+				g_pScriptVM->SetValue( hTable, pszPropName, ScriptVariant_t() ); // Return null to be consistent with other script functions
 				break;
 			}
 


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
Fixes a crash when NetProps.GetTable(entity, 1, {}) is used on certain entities as stated in #1357. 
closes #1357.