### PR TITLE
[ALL] (Vscript) Make/Destroy Physics

### DIFF
--- a/src/game/server/baseentity.cpp
+++ b/src/game/server/baseentity.cpp
@@ -2404,6 +2404,9 @@ BEGIN_ENT_SCRIPTDESC_ROOT( CBaseEntity, "Root class of all server-side entities"
 	DEFINE_SCRIPTFUNC_NAMED( ScriptGetSolid, "GetSolid", "" )
 	DEFINE_SCRIPTFUNC_NAMED( ScriptSetSolid, "SetSolid", "" )
 	
+	DEFINE_SCRIPTFUNC_NAMED( ScriptMakePhysics, "MakePhysical", "Give the entity Physics" )
+	DEFINE_SCRIPTFUNC_NAMED( ScriptDestroyPhysics, "DestroyPhysics", "Remove the entity Physics" )
+	
 	DEFINE_SCRIPTFUNC( TerminateScriptScope, "Clear the current script scope for this entity" )
 
 	DEFINE_SCRIPTFUNC_NAMED( ScriptAcceptInput, "AcceptInput", "Generate a synchronous I/O event" )

--- a/src/game/server/baseentity.h
+++ b/src/game/server/baseentity.h
@@ -1340,6 +1340,16 @@ public:
 		return (int)GetSolid();
 	}
 
+	void ScriptMakePhysics( int nSolidType, int nSolidFlags, bool asleep ) 
+	{ 
+		VPhysicsInitNormal( (SolidType_t) nSolidType, nSolidFlags, asleep ); 
+	}
+
+	void ScriptDestroyPhysics( void ) 
+	{ 
+		VPhysicsDestroyObject(); 
+	}
+
 	HSCRIPT ScriptGetModelKeyValues( void );
 
 	void ScriptPrecacheModel( const char *name );


### PR DESCRIPTION
MakePhysical( nSolidType, nSolidFlags, asleep )
DestroyPhysics()

# Description
These vscript function can be called on any entity, to make, or destroy physics, letting the user experiment more for their creations, instead on relaying on prop_phyisics or other already physical entities.

this doesn't come with safety checks, so for example, you can run this on players if you ever wanted to, so use at own risk.