### PR TITLE
tf2: Fix MvM bots not being able to use their items

### DIFF
--- a/src/game/server/tf/bot/behavior/tf_bot_use_item.cpp
+++ b/src/game/server/tf/bot/behavior/tf_bot_use_item.cpp
@@ -47,9 +47,12 @@ ActionResult< CTFBot >	CTFBotUseItem::Update( CTFBot *me, float interval )
 	{
 		if ( m_cooldownTimer.IsElapsed() )
 		{
-			// use it
-			me->PressFireButton();
-			m_cooldownTimer.Invalidate();
+			if ( me->GetNextAttack() <= gpGlobals->curtime )
+			{
+				// use it
+				me->PressFireButton();
+				m_cooldownTimer.Invalidate();
+			}
 		}
 	}
 	else // used


### PR DESCRIPTION
In some cases, robots in MvM mode can not use their items (Buff Banner, Bonk, etc.), due to the timer in `CTFBotUseItem` ending before the weapon is fully deployed. This leads to a loop of robots constantly switching to their items without activating it.

We should wait until the bot is actually able to "attack" aka use the item.

Resubmission of #875 due to a deleted fork