### PR TITLE
[TF2] fix: exploit allowing casual players to farm points via repeated sandman stuns

### DIFF
--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -956,6 +956,7 @@ CTFPlayer::CTFPlayer()
 	m_flLastCoachCommand = 0;
 
 	m_flNextTimeCheck = gpGlobals->curtime;
+	m_flNextSandmanStunBonusTime = gpGlobals->curtime;
 	m_flSpawnTime = 0;
 
 	m_flWaterExitTime = 0;

--- a/src/game/server/tf/tf_player.h
+++ b/src/game/server/tf/tf_player.h
@@ -986,6 +986,7 @@ public:
 	int					m_iBlastJumpState;
 	float				m_flBlastJumpLandTime;
 	bool				m_bTakenBlastDamageSinceLastMovement;
+	float               m_flNextSandmanStunBonusTime;
 
 	void				SetTargetDummy( void ){ m_bIsTargetDummy = true; }
 

--- a/src/game/shared/tf/tf_weapon_bat.cpp
+++ b/src/game/shared/tf/tf_weapon_bat.cpp
@@ -753,7 +753,12 @@ void CTFStunBall::ApplyBallImpactEffectOnVictim( CBaseEntity *pOther )
 			}
 		}
 
-		CTF_GameStats.Event_PlayerStunBall( pOwner, ( bMax ) ? true : false );
+		// Rate limit: only award Sandman stun bonus once per 10 seconds per player
+		if ( pOwner && gpGlobals->curtime >= pOwner->m_flNextSandmanStunBonusTime )
+		{
+			CTF_GameStats.Event_PlayerStunBall( pOwner, ( bMax ) ? true : false );
+			pOwner->m_flNextSandmanStunBonusTime = gpGlobals->curtime + 10.0f;
+		}
 
 		if ( pPlayer->GetWaterLevel() != WL_Eyes )
 		{


### PR DESCRIPTION
Sandman ball stuns grant bonus points. With enough healing, 2 scout players on opposing teams can exploit this fact by repeatedly stunning each other. This is further helped by the fact that the ball instantly comes available when being hit by another scout's sandman.

This has been prevalent for years in MannPower mode, since its powerups provide the necessary healing power. In the past there have been players using bots to kick everyone from a server, only to be able to do this exploit. So this fix, or one like it, would be very welcome to the community!!

Completely removing bonus points from sandman stuns seems excessive, and might hurt other game modes where this exploit is not an issue. Hence, I think deterring exploiters by limiting the rate at which bonus points may be received from the sandman is enough. I figure this won't have any impact elsewhere.

Looking forward to your feedback!

---

This commit applies a rate limit to the number of bonus points a player can receive from sandman stuns.
