### PR TITLE
[HL2MP] Fix bot quota not functioning outside of teamplay

### DIFF
--- a/src/game/server/hl2mp/bot/hl2mp_bot_manager.cpp
+++ b/src/game/server/hl2mp/bot/hl2mp_bot_manager.cpp
@@ -245,10 +245,18 @@ void CHL2MPBotManager::MaintainBotQuota()
 			{
 				nHL2MPBotsOnGameTeams++;
 			}
+			else if ( !HL2MPRules()->IsTeamplay() && pPlayer->GetTeamNumber() == TEAM_UNASSIGNED )
+			{
+				nHL2MPBotsOnGameTeams++;
+			}
 		}
 		else
 		{
 			if ( pPlayer->GetTeamNumber() == TEAM_REBELS || pPlayer->GetTeamNumber() == TEAM_COMBINE )
+			{
+				nNonHL2MPBotsOnGameTeams++;
+			}
+			else if ( !HL2MPRules()->IsTeamplay() && pPlayer->GetTeamNumber() == TEAM_UNASSIGNED )
 			{
 				nNonHL2MPBotsOnGameTeams++;
 			}
@@ -484,7 +492,7 @@ CHL2MPBot* CHL2MPBotManager::GetAvailableBotFromPool()
 		if ( ( pBot->GetFlags() & FL_FAKECLIENT ) == 0 )
 			continue;
 
-		if ( pBot->GetTeamNumber() == TEAM_SPECTATOR || pBot->GetTeamNumber() == TEAM_UNASSIGNED )
+		if ( pBot->GetTeamNumber() == TEAM_SPECTATOR || ( HL2MPRules()->IsTeamplay() && pBot->GetTeamNumber() == TEAM_UNASSIGNED ) )
 		{
 			pBot->ClearAttribute( CHL2MPBot::QUOTA_MANANGED );
 			return pBot;


### PR DESCRIPTION
The bot quota system in HL2:DM only functions when teamplay is enabled. Outside of teamplay, the bot quota does not affect the bot count. If `hl2mp_bot_join_after_player` is enabled (as is the default) and all non-bot players are spectating, the first bot will also rapidly switch between models.

Here's a video showing this behavior, first as intended with teamplay, then with the issue outside of teamplay:

https://drive.google.com/file/d/1A2MYnnzCSl_X1gTatdIp9YEFtfbQ8RHA/view?usp=sharing

---

This issue is caused by the bot quota system not recognizing unassigned players as active participants in the game. This pull request fixes the issue by counting unassigned players as such when teamplay is disabled.