### PR TITLE
[HL2MP] Fix bots rapidly switching to and from gravity gun

### DIFF
--- a/src/game/server/hl2mp/bot/hl2mp_bot.cpp
+++ b/src/game/server/hl2mp/bot/hl2mp_bot.cpp
@@ -1385,7 +1385,8 @@ bool CHL2MPBot::EquipRequiredWeapon( void )
 	if ( m_requiredWeaponStack.Count() )
 	{
 		CBaseCombatWeapon *pWeapon = m_requiredWeaponStack.Top().Get();
-		return Weapon_Switch( pWeapon );
+		Weapon_Switch( pWeapon );
+		return true;
 	}
 
 	if ( TheHL2MPBots().IsGravGunOnly() || HasWeaponRestriction( GRAVGUN_ONLY ) )


### PR DESCRIPTION
When a HL2MP bot approaches a prop to pick up, it sometimes rapidly switches between its gravity gun and a different weapon. This is because `CHL2MPBot::EquipRequiredWeapon()` returns `Weapon_Switch` directly when using the weapon stack, which is false when the weapon is already out. This causes the required weapon to only be enforced when it is not equipped, hence why it switches back so quickly when another weapon takes its place. This pull request calls `Weapon_Switch` without using its value and always returns true like with the weapon restriction cases.

The prop behavior is the only component that uses the weapon stack, but any other behavior using it would presumably experience a similar issue.