### PR TITLE
[HL2MP] Bots respect crouch nav areas

### DIFF
--- a/src/game/server/hl2mp/bot/hl2mp_bot_locomotion.cpp
+++ b/src/game/server/hl2mp/bot/hl2mp_bot_locomotion.cpp
@@ -8,6 +8,8 @@
 
 extern ConVar falldamage;
 
+ConVar hl2mp_bot_nav_crouch( "hl2mp_bot_nav_crouch", "1", FCVAR_CHEAT );
+
 //-----------------------------------------------------------------------------------------
 void CHL2MPBotLocomotion::Update( void )
 {
@@ -23,6 +25,19 @@ void CHL2MPBotLocomotion::Update( void )
 	if ( IsOnGround() )
 	{
 		me->ReleaseCrouchButton();
+		
+		if ( hl2mp_bot_nav_crouch.GetBool() )
+		{
+			const PathFollower *path = me->GetCurrentPath();
+			if ( path && path->GetCurrentGoal() && path->GetCurrentGoal()->area )
+			{
+				if ( path->GetCurrentGoal()->area->GetAttributes() & NAV_MESH_CROUCH )
+				{
+					// moving through a crouch area
+					me->PressCrouchButton( 0.3f );
+				}
+			}
+		}
 	}
 	else
 	{


### PR DESCRIPTION
HL2MP bots do not voluntarily crouch when entering crouch-only nav areas. This means bots will get stuck when trying to enter a nav area that doesn't have enough vertical space.

An example of this issue can be seen below in `dm_lockdown`, when a bot tries to get health from underneath a staircase:

https://github.com/user-attachments/assets/ddbfa9e1-80c6-4199-96fa-b33ccd0a72e2

The bot eventually either gives up or realizes it's stuck and tries crouch-jumping, which may conveniently allow it to enter the space mid-jump. This is what happens in the video, but the bot doesn't always enter the space successfully.

This pull request allows bots to automatically crouch when entering nav areas that are marked as crouch areas. Here's the situation above with this change in place:

https://github.com/user-attachments/assets/437f8a10-4f6f-4d8f-98fa-94d6b595a242

Nav areas are given the crouch attribute automatically on generation or through manual editing. The areas shown in the video were marked automatically.

---

This behavior could theoretically be expanded to TF bots as well, but I'm not familiar enough with the behavior of bots in TF2 and how they interact with their environment to know the implications of that.