### PR TITLE
Add nullptr check for pTFAttacker

### DIFF
--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -9837,21 +9837,24 @@ int CTFPlayer::OnTakeDamage( const CTakeDamageInfo &inputInfo )
 	}
 
 
-	CTFWeaponBase *pTFWeapon = GetKilleaterWeaponFromDamageInfo( &info );
-	if ( !pTFWeapon )
+	if ( pTFAttacker )
 	{
-		// Check Wearable instead like demoshields or manntreads
-		CTFWearable *pWearable = dynamic_cast< CTFWearable* >( info.GetWeapon() );
-		if ( pWearable )
+		CTFWeaponBase *pTFWeapon = GetKilleaterWeaponFromDamageInfo( &info );
+		if ( !pTFWeapon )
 		{
-			EconEntity_OnOwnerKillEaterEvent_Batched( pWearable, pTFAttacker, this, kKillEaterEvent_DamageDealt, info.GetDamage() );
-			EconEntity_OnOwnerKillEaterEvent_Batched( pWearable, pTFAttacker, this, kKillEaterEvent_PlayersHit, 1 );
+			// Check Wearable instead like demoshields or manntreads
+			CTFWearable *pWearable = dynamic_cast< CTFWearable* >( info.GetWeapon() );
+			if ( pWearable )
+			{
+				EconEntity_OnOwnerKillEaterEvent_Batched( pWearable, pTFAttacker, this, kKillEaterEvent_DamageDealt, info.GetDamage() );
+				EconEntity_OnOwnerKillEaterEvent_Batched( pWearable, pTFAttacker, this, kKillEaterEvent_PlayersHit, 1 );
+			}
 		}
-	}
-	else
-	{
-		EconEntity_OnOwnerKillEaterEvent_Batched( pTFWeapon, pTFAttacker, this, kKillEaterEvent_DamageDealt, info.GetDamage() );
-		EconEntity_OnOwnerKillEaterEvent_Batched( pTFWeapon, pTFAttacker, this, kKillEaterEvent_PlayersHit, 1 );
+		else
+		{
+			EconEntity_OnOwnerKillEaterEvent_Batched( pTFWeapon, pTFAttacker, this, kKillEaterEvent_DamageDealt, info.GetDamage() );
+			EconEntity_OnOwnerKillEaterEvent_Batched( pTFWeapon, pTFAttacker, this, kKillEaterEvent_PlayersHit, 1 );
+		}
 	}
 
 	if ( bTookDamage && m_Shared.InCond( TF_COND_GAS ) )


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description

This fixes a very rare crash in 

https://github.com/ValveSoftware/source-sdk-2013/blob/39f6dde8fbc238727c020d13b05ecadd31bda4c0/src/game/shared/tf/tf_gamerules.cpp#L10659-L10661

As you can see `pOwner` is never null checked for. And in very rare instances 

https://github.com/ValveSoftware/source-sdk-2013/blob/39f6dde8fbc238727c020d13b05ecadd31bda4c0/src/game/server/tf/tf_player.cpp#L9840-L9855

That function is called when `pTFAttacker` is nullptr.

Since `pTFAttacker` is already null-checked in lot of places inside `int CTFPlayer::OnTakeDamage( const CTakeDamageInfo &inputInfo )` let's just add one extra check there (see PR changes).