### PR TITLE
[TF2][MVM] Allow non giant robots and humans to properly gib in man vs machine

### DIFF
--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -10910,10 +10910,6 @@ bool CTFPlayer::ShouldGib( const CTakeDamageInfo &info )
 			return true;
 	}
 
-	// normal players/bots don't gib in MvM
-// 	if ( TFGameRules()->IsMannVsMachineMode() )
-// 		return false;
-
 	// Suicide explode always gibs.
 	if ( m_bSuicideExplode )
 	{

--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -10911,8 +10911,8 @@ bool CTFPlayer::ShouldGib( const CTakeDamageInfo &info )
 	}
 
 	// normal players/bots don't gib in MvM
-	if ( TFGameRules()->IsMannVsMachineMode() )
-		return false;
+// 	if ( TFGameRules()->IsMannVsMachineMode() )
+// 		return false;
 
 	// Suicide explode always gibs.
 	if ( m_bSuicideExplode )


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description

In man vs machine, you will quickly notice that no matter what you do, nothing aside from Giants will ever gib. The reason this is the case is that [Valve disabled gibbing in this mode a long time ago due to severe issues man vs machine had with gibbing](https://www.youtube.com/watch?v=Aqu2Lb2G2ME). This special case for man vs machine can be found within CTFPlayer::ShouldGib. To my knowledge, this bug has been fixed ages ago (By that I mean when I remove this special case stopping gibbing from happening in man vs machine, the old bug that caused Valve to remove gibbing in the first place doesn't resurface. Indeed, libtf2mod [also now only contains logic to remove this check from the game, and no longer contains the old fix it used to have](https://github.com/sigsegv-mvm/libtf2mod/blob/master/patch/mvm_enable_human_gibbing.c)), meaning that this check to stop gibbing in man vs machine is now redundant and can be removed. This restores proper gibbing to man vs machine, and brings this mode closer to parity with the other modes.

This is a visual only change, so game balance is not affected whatsoever. Regardless, this pull request can still be closed if it is decided that this would be detrimental to the game for some reason.