### PR TITLE
[HL2MP] Fix Teeth Vertices stretch on specific citizen models

### DIFF
--- a/src/materialsystem/stdshaders/teeth_vs20.fxc
+++ b/src/materialsystem/stdshaders/teeth_vs20.fxc
@@ -67,6 +67,12 @@ struct VS_OUTPUT
 VS_OUTPUT main( const VS_INPUT v )
 {
 	VS_OUTPUT o = ( VS_OUTPUT )0;
+	if(length(v.vPos.xy) > 10)
+	{
+		float4 FinalProj = mul( float4(0.0, 0.0, 0.0, 1.0), cViewProj );
+		o.projPos = FinalProj;
+		return o;
+	}
 
 	bool bDynamicLight = DYNAMIC_LIGHT ? true : false;
 	bool bStaticLight = STATIC_LIGHT ? true : false;


### PR DESCRIPTION
### Bug
Fixes a bug, discribed in the issue #683 
Bug: Some citizen models have random teeth vertices stretching to the map origin and other positions.

### Media

Video demonstrating the bug:

https://github.com/user-attachments/assets/f659da80-6b83-4e91-8b1f-50e4de6ce594

Video demonstrating the fix:

https://github.com/user-attachments/assets/9f47369a-e198-4c76-840b-3f25e5c99c5e

