### PR TITLE
[TF2] Restore the ability to voice command spam as an optional feature for server operator

### DIFF
--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -199,7 +199,7 @@ ConVar tf_damage_multiplier_blue( "tf_damage_multiplier_blue", "1.0", FCVAR_CHEA
 ConVar tf_damage_multiplier_red( "tf_damage_multiplier_red", "1.0", FCVAR_CHEAT, "All incoming damage to a red player is multiplied by this value" );
 
 
-ConVar tf_max_voice_speak_delay( "tf_max_voice_speak_delay", "1.5", FCVAR_DEVELOPMENTONLY, "Max time after a voice command until player can do another one", true, 0.1f, false, 0.f );
+ConVar tf_max_voice_speak_delay( "tf_max_voice_speak_delay", "1.5", FCVAR_DEVELOPMENTONLY, "Max time after a voice command until player can do another one" );
 
 ConVar tf_allow_player_use( "tf_allow_player_use", "0", FCVAR_NOTIFY, "Allow players to execute +use while playing." );
 
@@ -7173,6 +7173,40 @@ static void DebugEconItemView( const char *pszDescStr, CEconItemView *pEconItemV
 	Warning("%s: \"%s\"\n", pszDescStr, pItemDef->GetDefinitionName() );
 }
 #endif
+
+//-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
+bool CTFPlayer::ShouldRunRateLimitedVoiceCommand( const CCommand &args )
+{
+	return ShouldRunRateLimitedVoiceCommand( args[0] );
+}
+
+ConVar tf_voice_command_rate_limit( "tf_voice_command_rate_limit", "0.3", FCVAR_DEVELOPMENTONLY, "", true, 0.05f, true, 0.3f );
+//-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
+bool CTFPlayer::ShouldRunRateLimitedVoiceCommand( const char *pszCommand )
+{
+	const char *pcmd = pszCommand;
+
+	int i = m_RateLimitLastCommandTimes.Find( pcmd );
+	if ( i == m_RateLimitLastCommandTimes.InvalidIndex() )
+	{
+		m_RateLimitLastCommandTimes.Insert( pcmd, gpGlobals->curtime );
+		return true;
+	}
+	else if ( (gpGlobals->curtime - m_RateLimitLastCommandTimes[i]) < tf_voice_command_rate_limit.GetFloat() )
+	{
+		// Too fast.
+		return false;
+	}
+	else
+	{
+		m_RateLimitLastCommandTimes[i] = gpGlobals->curtime;
+		return true;
+	}
+}
 
 bool CTFPlayer::ClientCommand( const CCommand &args )
 {

--- a/src/game/server/tf/tf_player.h
+++ b/src/game/server/tf/tf_player.h
@@ -1586,6 +1586,14 @@ public:
 
 	virtual bool BCanCallVote() OVERRIDE;
 	bool m_bFirstSpawnAndCanCallVote = false;
+
+// Command rate limiting.
+	bool ShouldRunRateLimitedVoiceCommand( const CCommand &args );
+	bool ShouldRunRateLimitedVoiceCommand( const char *pszCommand );
+private:
+
+	// This lets us rate limit the commands the players can execute so they don't overflow things like reliable buffers.
+	CUtlDict<float,int>	m_RateLimitLastCommandTimes;
 };
 
 //-----------------------------------------------------------------------------

--- a/src/game/shared/tf/tf_gamerules.cpp
+++ b/src/game/shared/tf/tf_gamerules.cpp
@@ -7733,6 +7733,23 @@ bool CTFGameRules::ClientCommand( CBaseEntity *pEdict, const CCommand &args )
 	CTFPlayer *pPlayer = ToTFPlayer( pEdict );
 
 	const char *pcmd = args[0];
+	if ( FStrEq( pcmd, "voicemenu" ) )
+	{
+		if ( args.ArgC() < 3 )
+			return true;
+
+		CTFPlayer *pTFPlayer = dynamic_cast< CTFPlayer * >( pPlayer );
+
+		if ( pTFPlayer && pTFPlayer->ShouldRunRateLimitedVoiceCommand( pcmd ) )
+		{
+			int iMenu = atoi( args[1] );
+			int iItem = atoi( args[2] );
+
+			VoiceCommand( pTFPlayer, iMenu, iItem );
+		}
+
+		return true;
+	}
 
 	if ( IsInTournamentMode() == true && IsInPreMatch() == true )
 	{


### PR DESCRIPTION
https://youtu.be/uyjZ45GJwPk
Before 2018, the community server operators were able to enable voice command spam by using sourcemod with "sm_cvar tf_max_voice_speak_delay -1" command. But during 2018, the malicious actors were able to lag any servers by simply spamming the voicemenu command as fast as possible. Valve fixed this by adding 0.3 seconds delay every time the client calls for the command.  But by doing so, it's now impossible to use voice command faster than 0.3 seconds.

In order to restore this feature without getting rid of the rate limiter entirely, I introduce this new convar "tf_voice_command_rate_limit". Community server operators could use the command "sm_cvar tf_voice_command_rate_limit" and set the value as low as 0.05 to restore this feature. The lower bound value for tf_max_voice_speak_delay command is also removed for the same reason.