### PR TITLE
Fix Wrangler shield not moving with parented sentrygun

### DIFF
--- a/src/game/client/tf/c_obj_sentrygun.h
+++ b/src/game/client/tf/c_obj_sentrygun.h
@@ -28,6 +28,25 @@ enum
 };
 
 //-----------------------------------------------------------------------------
+// Purpose: Wrangler shield
+//-----------------------------------------------------------------------------
+class C_SentrygunShield : public C_BaseAnimating
+{
+	DECLARE_CLASS( C_SentrygunShield, C_BaseAnimating );
+
+public:
+	static C_SentrygunShield* Create( const char* pszModelName );
+
+	virtual void ClientThink();
+
+	void StartFadeOut( float flDuration );
+
+private:
+	float m_flFadeOutStartTime;
+	float m_flFadeOutEndTime;
+};
+
+//-----------------------------------------------------------------------------
 // Purpose: Sentry object
 //-----------------------------------------------------------------------------
 class C_ObjectSentrygun : public C_BaseObject
@@ -124,7 +143,7 @@ private:
 	bool m_bRecreateLaserBeam;
 	float m_flNextNearMissCheck;
 
-	C_LocalTempEntity *m_pTempShield;
+	CHandle<C_SentrygunShield> m_hShieldModel;
 
 	HPARTICLEFFECT  m_hSirenEffect;
 	HPARTICLEFFECT  m_hShieldEffect;


### PR DESCRIPTION
Wrangler shields don't attach to sentryguns that are parented to a moving object, causing them to float ominously. This PR addresses that by parenting the shield to the sentrygun as well. This is a common problem with community maps that have moving platforms, vehicles etc

Before:

https://github.com/user-attachments/assets/a2287103-b0a6-4ad5-8786-9ce4ed67d9ac

After:

https://github.com/user-attachments/assets/31ce13c9-8c73-4a8b-8f31-1a398205f6fb

