### PR TITLE
[HL2MP] Fix Physcannon getting animation

### DIFF
--- a/src/game/shared/hl2mp/weapon_physcannon.cpp
+++ b/src/game/shared/hl2mp/weapon_physcannon.cpp
@@ -1071,7 +1071,7 @@ bool CWeaponPhysCannon::Deploy( void )
 
 	if ( pOwner )
 	{
-		pOwner->SetNextAttack( gpGlobals->curtime );
+		pOwner->SetNextAttack( gpGlobals->curtime + 0.25f );
 	}
 
 	return bReturn;


### PR DESCRIPTION

### Bug

Fixed the animation of getting a physcannon when the cursor is hovered over the phys prop.

### Media

Video demonstrating the bug:

https://github.com/user-attachments/assets/4f678670-323b-49c9-b69d-6b4c88984fa8

Video demonstrating the fix:

https://github.com/user-attachments/assets/82eb0b2b-7542-439c-b13e-2594d11c24b1