### PR TITLE
[TF2] Add CVar to adjuct spectator bar alpha

### DIFF
--- a/src/game/client/tf/vgui/tf_spectatorgui.cpp
+++ b/src/game/client/tf/vgui/tf_spectatorgui.cpp
@@ -68,7 +68,7 @@ CTFSpectatorGUI *GetTFSpectatorGUI()
 //-----------------------------------------------------------------------------
 ConVar cl_spec_carrieditems( "cl_spec_carrieditems", "1", FCVAR_ARCHIVE, "Show non-standard items being carried by player you're spectating." );
 
-void HUDTournamentSpecChangedCallBack( IConVar *var, const char *pOldString, float flOldValue )
+void HUDSpecInvalidateLayout( IConVar *var, const char *pOldString, float flOldValue )
 {
 	CTFSpectatorGUI *pPanel = (CTFSpectatorGUI*)gViewPortInterface->FindPanelByName( PANEL_SPECGUI );
 	if ( pPanel )
@@ -76,7 +76,8 @@ void HUDTournamentSpecChangedCallBack( IConVar *var, const char *pOldString, flo
 		pPanel->InvalidateLayout( true, true );
 	}
 }
-ConVar cl_use_tournament_specgui( "cl_use_tournament_specgui", "0", FCVAR_ARCHIVE, "When in tournament mode, use the advanced tournament spectator UI.", HUDTournamentSpecChangedCallBack );
+ConVar cl_use_tournament_specgui( "cl_use_tournament_specgui", "0", FCVAR_ARCHIVE, "When in tournament mode, use the advanced tournament spectator UI.", HUDSpecInvalidateLayout);
+ConVar cl_spec_baralpha("cl_spec_baralpha", "200", FCVAR_ARCHIVE, "How transparent the spectator bars should be.", true, 0, true, 255, HUDSpecInvalidateLayout);
 
 //-----------------------------------------------------------------------------
 // Purpose: Constructor

--- a/src/game/client/tf/vgui/tf_spectatorgui.h
+++ b/src/game/client/tf/vgui/tf_spectatorgui.h
@@ -18,6 +18,7 @@
 #include <vgui_controls/EditablePanel.h>
 
 extern ConVar cl_use_tournament_specgui;
+extern ConVar cl_spec_baralpha;
 class CAvatarImagePanel;
 class CTFPlayerPanel;
 class CSCHintIcon;
@@ -65,7 +66,7 @@ public:
 	virtual bool ShouldShowPlayerLabel( int specmode ) { return false; }
 	void		 UpdateReinforcements( void );
 	virtual void ShowPanel(bool bShow);
-	virtual Color GetBlackBarColor( void ) { return Color(52,48,45, 255); }
+	virtual Color GetBlackBarColor( void ) { return Color(52,48,45, cl_spec_baralpha.GetInt()); }
 
 	void		UpdateKeyLabels( void );
 


### PR DESCRIPTION
# Description
This PR adds `cl_spec_baralpha`, a CVar that sets the transparency of the spectator bars.
These bars are often seen as obtrusive, with the only way to reduce their presence is by modifying how tall they are, which in the case of the top bar, is directly linked to the position of the kill feed and engineer/spy building status y position when spectating.

Being able to freely modify the alpha of these bars would allow players using the default hud to improve their spectating 
experience hassle free and custom hud creators to be more creative without the fear of making new elements that occupy the same space as existing elements.

The CVar defaults at 200, which should be a good compromise between the bars being visible without being obtrusive to vision.
<img src="https://github.com/user-attachments/assets/92d77b4e-8538-40ae-a08d-43e45beca94b" width="480">
<img src="https://github.com/user-attachments/assets/7fc5750e-f339-447f-be29-2dcbb593998b" width="480">
<img src="https://github.com/user-attachments/assets/6638b321-3a60-4a4c-a268-5aa4b5f2fc85" width="480">