### PR TITLE
tf2: Fix tank deploy sound playing even after tank is destroyed

### DIFF
--- a/src/game/server/tf/player_vs_environment/tf_tank_boss.cpp
+++ b/src/game/server/tf/player_vs_environment/tf_tank_boss.cpp
@@ -518,6 +518,7 @@ void CTFTankBoss::Spawn( void )
 void CTFTankBoss::UpdateOnRemove( void )
 {
 	StopSound( "MVM.TankEngineLoop" );
+	StopSound( "MVM.TankDeploy" );
 
 	if ( TFObjectiveResource() )
 	{
@@ -981,6 +982,7 @@ void CTFTankBoss::FirePopFileEvent( EventInfo *eventInfo )
 void CTFTankBoss::Explode( void )
 {
 	StopSound( "MVM.TankEngineLoop" );
+	StopSound( "MVM.TankDeploy" );
 
 	FirePopFileEvent( &m_onKilledEventInfo );
 


### PR DESCRIPTION
The deploy sound is lengthy, so it is quite common to still hear it long after the tank has been destroyed.