### PR TITLE
Fix viewpunch not being interpolated

### DIFF
--- a/src/game/client/c_baseplayer.cpp
+++ b/src/game/client/c_baseplayer.cpp
@@ -418,7 +418,9 @@ LINK_ENTITY_TO_CLASS( player, C_BasePlayer );
 C_BasePlayer::C_BasePlayer() : m_iv_vecViewOffset( "C_BasePlayer::m_iv_vecViewOffset" )
 {
 	AddVar( &m_vecViewOffset, &m_iv_vecViewOffset, LATCH_SIMULATION_VAR );
-	
+	AddVar( &m_Local.m_vecPunchAngle, &m_Local.m_iv_vecPunchAngle, LATCH_SIMULATION_VAR );
+	AddVar( &m_Local.m_vecPunchAngleVel, &m_Local.m_iv_vecPunchAngleVel, LATCH_SIMULATION_VAR );
+
 #ifdef _DEBUG																
 	m_vecLadderNormal.Init();
 	m_vecOldViewAngles.Init();

--- a/src/game/client/hl2/c_basehlplayer.cpp
+++ b/src/game/client/hl2/c_basehlplayer.cpp
@@ -76,9 +76,6 @@ static ConCommand dropprimary("dropprimary", CC_DropPrimary, "dropprimary: Drops
 //-----------------------------------------------------------------------------
 C_BaseHLPlayer::C_BaseHLPlayer()
 {
-	AddVar( &m_Local.m_vecPunchAngle, &m_Local.m_iv_vecPunchAngle, LATCH_SIMULATION_VAR );
-	AddVar( &m_Local.m_vecPunchAngleVel, &m_Local.m_iv_vecPunchAngleVel, LATCH_SIMULATION_VAR );
-
 	m_flZoomStart		= 0.0f;
 	m_flZoomEnd			= 0.0f;
 	m_flZoomRate		= 0.0f;


### PR DESCRIPTION
In all games except HL2, viewpunch is not interpolated. This is more noticeable when the server runs at a lower tickrate, when using low timescale, or having a monitor refresh rate higher than the tickrate.

The issue is that only the HL2 player class adds the variables to the interpolation list. This PR moves it down to the generic player base class.

Before:

https://github.com/user-attachments/assets/18fca75e-7f93-480c-8aff-486144acfadf

After:

https://github.com/user-attachments/assets/1d0e4962-a0a8-4f05-be2f-80705e28ee84



