### PR TITLE
[TF2] Fix Some weapons with 'On Hit' effect ignore Spy's disguise

### DIFF
--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -8254,7 +8254,7 @@ void CTFPlayer::TraceAttack( const CTakeDamageInfo &info, const Vector &vecDir, 
 {
 	if ( m_takedamage != DAMAGE_YES )
 		return;
-	
+
 	CTFPlayer *pAttacker = ToTFPlayer( info.GetAttacker() );
 	if ( pAttacker )
 	{
@@ -8397,7 +8397,7 @@ void CTFPlayer::TraceAttack( const CTakeDamageInfo &info, const Vector &vecDir, 
 		// This does smaller splotches on the guy and splats blood on the world.
 		TraceBleed( info_modified.GetDamage(), vecDir, ptr, info_modified.GetDamageType() );
 	}
-	
+
 	AddMultiDamage( info_modified, this );
 }
 

--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -9102,7 +9102,7 @@ int CTFPlayer::OnTakeDamage( const CTakeDamageInfo &inputInfo )
 		CTFBonesaw *pBoneSaw = static_cast< CTFBonesaw* >( pWeapon );
 		if ( pBoneSaw->GetBonesawType() == BONESAW_UBER_SAVEDONDEATH )
 		{
-			if (!m_Shared.InCond(TF_COND_DISGUISED))
+			if (!m_Shared.InCond(TF_COND_DISGUISED) || (GetHealth() - info.GetDamage() <= 0.f))
 			{
 				// Spawn their spleen
 				CPhysicsProp* pRandomInternalOrgan = dynamic_cast<CPhysicsProp*>(CreateEntityByName("prop_physics_override"));
@@ -10522,6 +10522,7 @@ int CTFPlayer::OnTakeDamage_Alive( const CTakeDamageInfo &info )
 	outParams.bSelfBlastDmg = false;
 	outParams.bSendPreFeignDamage = false;
 	outParams.bPlayDamageReductionSound = false;
+	float flOldHealth = GetHealth();
 	float realDamage = info.GetDamage();
 	int iPreFeignDamage = realDamage;
 	if ( TFGameRules() )
@@ -10674,7 +10675,7 @@ int CTFPlayer::OnTakeDamage_Alive( const CTakeDamageInfo &info )
 		if ( pSniper && ( pSniper->IsZoomed() || ( pSniper->GetWeaponID() == TF_WEAPON_SNIPERRIFLE_CLASSIC ) ) )
 		{
 			float flJarateTime = pSniper->GetJarateTime();
-			if ( flJarateTime >= 1.f && !m_Shared.InCond(TF_COND_DISGUISED) )
+			if ( flJarateTime >= 1.f && (!m_Shared.InCond(TF_COND_DISGUISED) || (flOldHealth - realDamage <= 0.f)))
 			{
 				if ( !m_Shared.IsInvulnerable() && !m_Shared.InCond( TF_COND_PHASE ) && !m_Shared.InCond( TF_COND_PASSTIME_INTERCEPTION ) )
 				{
@@ -10839,7 +10840,7 @@ int CTFPlayer::OnTakeDamage_Alive( const CTakeDamageInfo &info )
 				DispatchParticleEffect( "bot_impact_heavy", GetAbsOrigin(), vec3_angle );
 			}
 		}
-		else
+		else if (!m_Shared.InCond(TF_COND_DISGUISED))
 		{
 			CPVSFilter filter( vDamagePos );
 			TE_TFBlood( filter, 0.0, vDamagePos, -vecDir, entindex() );

--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -8254,7 +8254,7 @@ void CTFPlayer::TraceAttack( const CTakeDamageInfo &info, const Vector &vecDir, 
 {
 	if ( m_takedamage != DAMAGE_YES )
 		return;
-
+	
 	CTFPlayer *pAttacker = ToTFPlayer( info.GetAttacker() );
 	if ( pAttacker )
 	{
@@ -8379,7 +8379,7 @@ void CTFPlayer::TraceAttack( const CTakeDamageInfo &info, const Vector &vecDir, 
 	{
 		info_modified.SetDamage( info_modified.GetDamage() * tf_damage_multiplier_red.GetFloat() );
 	}
-
+	
 	if ( m_Shared.InCond( TF_COND_DISGUISED ) )
 	{
 		// no impact effects
@@ -8397,7 +8397,7 @@ void CTFPlayer::TraceAttack( const CTakeDamageInfo &info, const Vector &vecDir, 
 		// This does smaller splotches on the guy and splats blood on the world.
 		TraceBleed( info_modified.GetDamage(), vecDir, ptr, info_modified.GetDamageType() );
 	}
-
+	
 	AddMultiDamage( info_modified, this );
 }
 
@@ -9102,35 +9102,38 @@ int CTFPlayer::OnTakeDamage( const CTakeDamageInfo &inputInfo )
 		CTFBonesaw *pBoneSaw = static_cast< CTFBonesaw* >( pWeapon );
 		if ( pBoneSaw->GetBonesawType() == BONESAW_UBER_SAVEDONDEATH )
 		{
-			// Spawn their spleen
-			CPhysicsProp *pRandomInternalOrgan = dynamic_cast< CPhysicsProp* >( CreateEntityByName( "prop_physics_override" ) );
-			if ( pRandomInternalOrgan )
+			if (!m_Shared.InCond(TF_COND_DISGUISED))
 			{
-				pRandomInternalOrgan->SetCollisionGroup( COLLISION_GROUP_DEBRIS );
-				pRandomInternalOrgan->AddFlag( FL_GRENADE );
-				char buf[512];
-				Q_snprintf( buf, sizeof( buf ), "%.10f %.10f %.10f", GetAbsOrigin().x, GetAbsOrigin().y, GetAbsOrigin().z );
-				pRandomInternalOrgan->KeyValue( "origin", buf );
-				Q_snprintf( buf, sizeof( buf ), "%.10f %.10f %.10f", GetAbsAngles().x, GetAbsAngles().y, GetAbsAngles().z );
-				pRandomInternalOrgan->KeyValue( "angles", buf );
-				pRandomInternalOrgan->KeyValue( "model", "models/player/gibs/random_organ.mdl" );
-				pRandomInternalOrgan->KeyValue( "fademindist", "-1" );
-				pRandomInternalOrgan->KeyValue( "fademaxdist", "0" );
-				pRandomInternalOrgan->KeyValue( "fadescale", "1" );
-				pRandomInternalOrgan->KeyValue( "inertiaScale", "1.0" );
-				pRandomInternalOrgan->KeyValue( "physdamagescale", "0.1" );
-				DispatchSpawn( pRandomInternalOrgan );
-				pRandomInternalOrgan->m_takedamage = DAMAGE_YES;	// Take damage, otherwise this can block trains
-				pRandomInternalOrgan->SetHealth( 100 );
-				pRandomInternalOrgan->Activate();
+				// Spawn their spleen
+				CPhysicsProp* pRandomInternalOrgan = dynamic_cast<CPhysicsProp*>(CreateEntityByName("prop_physics_override"));
+				if (pRandomInternalOrgan)
+				{
+					pRandomInternalOrgan->SetCollisionGroup(COLLISION_GROUP_DEBRIS);
+					pRandomInternalOrgan->AddFlag(FL_GRENADE);
+					char buf[512];
+					Q_snprintf(buf, sizeof(buf), "%.10f %.10f %.10f", GetAbsOrigin().x, GetAbsOrigin().y, GetAbsOrigin().z);
+					pRandomInternalOrgan->KeyValue("origin", buf);
+					Q_snprintf(buf, sizeof(buf), "%.10f %.10f %.10f", GetAbsAngles().x, GetAbsAngles().y, GetAbsAngles().z);
+					pRandomInternalOrgan->KeyValue("angles", buf);
+					pRandomInternalOrgan->KeyValue("model", "models/player/gibs/random_organ.mdl");
+					pRandomInternalOrgan->KeyValue("fademindist", "-1");
+					pRandomInternalOrgan->KeyValue("fademaxdist", "0");
+					pRandomInternalOrgan->KeyValue("fadescale", "1");
+					pRandomInternalOrgan->KeyValue("inertiaScale", "1.0");
+					pRandomInternalOrgan->KeyValue("physdamagescale", "0.1");
+					DispatchSpawn(pRandomInternalOrgan);
+					pRandomInternalOrgan->m_takedamage = DAMAGE_YES;	// Take damage, otherwise this can block trains
+					pRandomInternalOrgan->SetHealth(100);
+					pRandomInternalOrgan->Activate();
 
-				Vector vecImpulse = RandomVector( -1.f, 1.f );
-				vecImpulse.z = 1.f;
-				VectorNormalize( vecImpulse );
-				Vector vecVelocity = vecImpulse * 250.0;
-				pRandomInternalOrgan->ApplyAbsVelocityImpulse( vecVelocity );
+					Vector vecImpulse = RandomVector(-1.f, 1.f);
+					vecImpulse.z = 1.f;
+					VectorNormalize(vecImpulse);
+					Vector vecVelocity = vecImpulse * 250.0;
+					pRandomInternalOrgan->ApplyAbsVelocityImpulse(vecVelocity);
 
-				pRandomInternalOrgan->ThinkSet( &CBaseEntity::SUB_Remove, gpGlobals->curtime + 5.f, "DieContext" );
+					pRandomInternalOrgan->ThinkSet(&CBaseEntity::SUB_Remove, gpGlobals->curtime + 5.f, "DieContext");
+				}
 			}
 		}
 	}
@@ -9707,7 +9710,10 @@ int CTFPlayer::OnTakeDamage( const CTakeDamageInfo &inputInfo )
 	{
 		// Buff flag 1: we get rage when we deal damage. Here, that means the soldier that attacked
 		// gets rage when we take damage.
-		HandleRageGain( pTFAttacker, kRageBuffFlag_OnDamageDealt, info.GetDamage() * flRageScale, 6.0f );
+		if (!m_Shared.InCond(TF_COND_DISGUISED))
+		{
+			HandleRageGain(pTFAttacker, kRageBuffFlag_OnDamageDealt, info.GetDamage() * flRageScale, 6.0f);
+		}
 
 		// Buff flag 2: we get rage when we take damage.
 		if (  !( info.GetDamageType() & DMG_FALL ) )
@@ -10668,7 +10674,7 @@ int CTFPlayer::OnTakeDamage_Alive( const CTakeDamageInfo &info )
 		if ( pSniper && ( pSniper->IsZoomed() || ( pSniper->GetWeaponID() == TF_WEAPON_SNIPERRIFLE_CLASSIC ) ) )
 		{
 			float flJarateTime = pSniper->GetJarateTime();
-			if ( flJarateTime >= 1.f )
+			if ( flJarateTime >= 1.f && !m_Shared.InCond(TF_COND_DISGUISED) )
 			{
 				if ( !m_Shared.IsInvulnerable() && !m_Shared.InCond( TF_COND_PHASE ) && !m_Shared.InCond( TF_COND_PASSTIME_INTERCEPTION ) )
 				{

--- a/src/game/shared/tf/tf_gamerules.cpp
+++ b/src/game/shared/tf/tf_gamerules.cpp
@@ -6774,7 +6774,7 @@ bool CTFGameRules::ApplyOnDamageModifyRules( CTakeDamageInfo &info, CBaseEntity 
 		{
 			int iAddCloakOnHit = 0;
 			CALL_ATTRIB_HOOK_INT_ON_OTHER( pTFAttacker->GetActiveWeapon(), iAddCloakOnHit, add_cloak_on_hit );
-			if ( iAddCloakOnHit > 0 && !pVictim->m_Shared.InCond(TF_COND_DISGUISED))
+			if ( iAddCloakOnHit > 0 && (!pVictim->m_Shared.InCond(TF_COND_DISGUISED) || (pVictim->GetHealth() - flDamage <= 0.f)))
 			{
 				pTFAttacker->m_Shared.AddToSpyCloakMeter( iAddCloakOnHit, true );
 			}
@@ -7490,7 +7490,7 @@ float CTFGameRules::ApplyOnDamageAliveModifyRules( const CTakeDamageInfo &info, 
 				}
 			}
 
-			if (pVictim && !pVictim->m_Shared.InCond(TF_COND_DISGUISED))
+			if (pVictim && (!pVictim->m_Shared.InCond(TF_COND_DISGUISED) || (pVictim->GetHealth() - flRealDamage <= 0.f)))
 			{
 				int iHypeOnDamage = 0;
 				CALL_ATTRIB_HOOK_INT_ON_OTHER(pTFAttacker, iHypeOnDamage, hype_on_damage);

--- a/src/game/shared/tf/tf_gamerules.cpp
+++ b/src/game/shared/tf/tf_gamerules.cpp
@@ -5617,8 +5617,11 @@ void CTFGameRules::RadiusDamage( CTFRadiusDamageInfo &info )
 				// Keep track of any enemies we damaged
 				if ( pEntity->IsPlayer() && !pEntity->InSameTeam( info.dmgInfo->GetAttacker() ) )
 				{
-					nDamageDealt+= iDamageToEntity;
-					iDamageEnemies++;
+					if (!ToTFPlayer(pEntity)->m_Shared.InCond(TF_COND_DISGUISED))
+					{
+						nDamageDealt += iDamageToEntity;
+						iDamageEnemies++;
+					}
 				}
 			}
 		}
@@ -6771,7 +6774,7 @@ bool CTFGameRules::ApplyOnDamageModifyRules( CTakeDamageInfo &info, CBaseEntity 
 		{
 			int iAddCloakOnHit = 0;
 			CALL_ATTRIB_HOOK_INT_ON_OTHER( pTFAttacker->GetActiveWeapon(), iAddCloakOnHit, add_cloak_on_hit );
-			if ( iAddCloakOnHit > 0 )
+			if ( iAddCloakOnHit > 0 && !pVictim->m_Shared.InCond(TF_COND_DISGUISED))
 			{
 				pTFAttacker->m_Shared.AddToSpyCloakMeter( iAddCloakOnHit, true );
 			}
@@ -7487,12 +7490,15 @@ float CTFGameRules::ApplyOnDamageAliveModifyRules( const CTakeDamageInfo &info, 
 				}
 			}
 
-			int iHypeOnDamage = 0;
-			CALL_ATTRIB_HOOK_INT_ON_OTHER( pTFAttacker, iHypeOnDamage, hype_on_damage );
-			if ( iHypeOnDamage )
+			if (pVictim && !pVictim->m_Shared.InCond(TF_COND_DISGUISED))
 			{
-				float flHype = RemapValClamped( flRealDamage, 1.f, 200.f, 1.f, 50.f );
-				pTFAttacker->m_Shared.SetScoutHypeMeter( Min( 100.f, flHype + pTFAttacker->m_Shared.GetScoutHypeMeter() ) );
+				int iHypeOnDamage = 0;
+				CALL_ATTRIB_HOOK_INT_ON_OTHER(pTFAttacker, iHypeOnDamage, hype_on_damage);
+				if (iHypeOnDamage)
+				{
+					float flHype = RemapValClamped(flRealDamage, 1.f, 200.f, 1.f, 50.f);
+					pTFAttacker->m_Shared.SetScoutHypeMeter(Min(100.f, flHype + pTFAttacker->m_Shared.GetScoutHypeMeter()));
+				}
 			}
 		}
 	}

--- a/src/game/shared/tf/tf_weapon_bonesaw.cpp
+++ b/src/game/shared/tf/tf_weapon_bonesaw.cpp
@@ -87,27 +87,30 @@ void CTFBonesaw::DoMeleeDamage( CBaseEntity* ent, trace_t& trace )
 			CTFPlayer *pTFOwner = ToTFPlayer( GetOwnerEntity() );
 			if ( pTFOwner && pTFOwner->GetTeamNumber() != ent->GetTeamNumber() )
 			{
-				int iDecaps = pTFOwner->m_Shared.GetDecapitations() + 1;
-
-				int iTakeHeads = 0;
-				CALL_ATTRIB_HOOK_INT( iTakeHeads, add_head_on_hit );
-				if ( iTakeHeads )
+				if (!ToTFPlayer(ent)->m_Shared.InCond(TF_COND_DISGUISED))
 				{
-					// We hit a target, take a head
-					pTFOwner->m_Shared.SetDecapitations( iDecaps );
-					pTFOwner->TeamFortress_SetSpeed();
-				}
+					int iDecaps = pTFOwner->m_Shared.GetDecapitations() + 1;
 
-				float flPreserveUber = 0.f;
-				CALL_ATTRIB_HOOK_FLOAT( flPreserveUber, ubercharge_preserved_on_spawn_max );
-				if ( flPreserveUber )
-				{
-					pTFOwner->m_Shared.SetDecapitations( iDecaps );
-
-					CWeaponMedigun *pMedigun = dynamic_cast< CWeaponMedigun* >( pTFOwner->Weapon_OwnsThisID( TF_WEAPON_MEDIGUN ) );
-					if ( pMedigun )
+					int iTakeHeads = 0;
+					CALL_ATTRIB_HOOK_INT(iTakeHeads, add_head_on_hit);
+					if (iTakeHeads)
 					{
-						pMedigun->SetChargeLevelToPreserve( ( iDecaps * VITASAW_CHARGE_PER_HIT ) );
+						// We hit a target, take a head
+						pTFOwner->m_Shared.SetDecapitations(iDecaps);
+						pTFOwner->TeamFortress_SetSpeed();
+					}
+
+					float flPreserveUber = 0.f;
+					CALL_ATTRIB_HOOK_FLOAT(flPreserveUber, ubercharge_preserved_on_spawn_max);
+					if (flPreserveUber)
+					{
+						pTFOwner->m_Shared.SetDecapitations(iDecaps);
+
+						CWeaponMedigun* pMedigun = dynamic_cast<CWeaponMedigun*>(pTFOwner->Weapon_OwnsThisID(TF_WEAPON_MEDIGUN));
+						if (pMedigun)
+						{
+							pMedigun->SetChargeLevelToPreserve((iDecaps * VITASAW_CHARGE_PER_HIT));
+						}
 					}
 				}
 			}

--- a/src/game/shared/tf/tf_weapon_bonesaw.cpp
+++ b/src/game/shared/tf/tf_weapon_bonesaw.cpp
@@ -87,7 +87,14 @@ void CTFBonesaw::DoMeleeDamage( CBaseEntity* ent, trace_t& trace )
 			CTFPlayer *pTFOwner = ToTFPlayer( GetOwnerEntity() );
 			if ( pTFOwner && pTFOwner->GetTeamNumber() != ent->GetTeamNumber() )
 			{
-				if (!ToTFPlayer(ent)->m_Shared.InCond(TF_COND_DISGUISED))
+				float MeleeDamage = 0.f;
+#ifndef CLIENT_DLL
+				int iCustomDamage = GetDamageCustom();
+				int iDmgType = DMG_MELEE | DMG_NEVERGIB | DMG_CLUB;
+				MeleeDamage = GetMeleeDamage(ent, &iDmgType, &iCustomDamage);
+#endif
+				if (!ToTFPlayer(ent)->m_Shared.InCond(TF_COND_DISGUISED) || 
+					(ent->GetHealth() - MeleeDamage <= 0.f))
 				{
 					int iDecaps = pTFOwner->m_Shared.GetDecapitations() + 1;
 

--- a/src/game/shared/tf/tf_weapon_jar.cpp
+++ b/src/game/shared/tf/tf_weapon_jar.cpp
@@ -1062,7 +1062,14 @@ void CTFProjectile_Cleaver::OnHit( CBaseEntity *pOther )
 	EmitSound( filter, entindex(), params );
 
 	CSingleUserRecipientFilter attackerFilter( pOwner );
-	EmitSound( attackerFilter, pOwner->entindex(), params );
+	if (!pPlayer->m_Shared.InCond(TF_COND_DISGUISED))
+	{
+		EmitSound( attackerFilter, pOwner->entindex(), params );
+	}
+	else
+	{
+		EmitSound(TF_WEAPON_CLEAVER_IMPACT_WORLD_SOUND);
+	}
 
 	RemoveCleaver();
 

--- a/src/game/shared/tf/tf_weapon_jar.cpp
+++ b/src/game/shared/tf/tf_weapon_jar.cpp
@@ -1010,13 +1010,16 @@ void CTFProjectile_Cleaver::OnHit( CBaseEntity *pOther )
 
 	CBaseEntity *pInflictor = GetLauncher();
 
-	float flLifeTime = gpGlobals->curtime - m_flCreationTime;
-	if ( flLifeTime >= FLIGHT_TIME_TO_REDUCE_COOLDOWN )
+	if (!pPlayer->m_Shared.InCond(TF_COND_DISGUISED))
 	{
-		auto pLauncher = dynamic_cast<CTFWeaponBase*>( pInflictor );
-		if ( pLauncher && pOwner != pPlayer && pLauncher->HasEffectBarRegeneration() )
+		float flLifeTime = gpGlobals->curtime - m_flCreationTime;
+		if (flLifeTime >= FLIGHT_TIME_TO_REDUCE_COOLDOWN)
 		{
-			pLauncher->DecrementBarRegenTime( 1.5f );
+			auto pLauncher = dynamic_cast<CTFWeaponBase*>(pInflictor);
+			if (pLauncher && pOwner != pPlayer && pLauncher->HasEffectBarRegeneration())
+			{
+				pLauncher->DecrementBarRegenTime(1.5f);
+			}
 		}
 	}
 

--- a/src/game/shared/tf/tf_weapon_smg.cpp
+++ b/src/game/shared/tf/tf_weapon_smg.cpp
@@ -180,13 +180,14 @@ void CTFChargedSMG::ApplyOnHitAttributes( CBaseEntity *pVictimBaseEntity, CTFPla
 	BaseClass::ApplyOnHitAttributes( pVictimBaseEntity, pAttacker, info );
 
 	CTFPlayer* pVictim = ToTFPlayer(pVictimBaseEntity);
+	bool bIsVictimDisguised = false;
 	if (pVictim && pVictim->m_Shared.InCond(TF_COND_DISGUISED))
-		return;
+		bIsVictimDisguised = true;
 
 	if ( pAttacker )
 	{
 		CTFPlayer *pPlayer = ToTFPlayer( GetOwner() );
-		if ( pPlayer && !pPlayer->m_Shared.InCond( TF_COND_ENERGY_BUFF ) )
+		if ( pPlayer && !pPlayer->m_Shared.InCond( TF_COND_ENERGY_BUFF ) && !bIsVictimDisguised)
 		{
 			float damage = info.GetDamage();
 			float flChargeRate = 0.0f;

--- a/src/game/shared/tf/tf_weapon_smg.cpp
+++ b/src/game/shared/tf/tf_weapon_smg.cpp
@@ -187,7 +187,8 @@ void CTFChargedSMG::ApplyOnHitAttributes( CBaseEntity *pVictimBaseEntity, CTFPla
 	if ( pAttacker )
 	{
 		CTFPlayer *pPlayer = ToTFPlayer( GetOwner() );
-		if ( pPlayer && !pPlayer->m_Shared.InCond( TF_COND_ENERGY_BUFF ) && !bIsVictimDisguised)
+		if ( pPlayer && !pPlayer->m_Shared.InCond( TF_COND_ENERGY_BUFF ) && 
+			(!bIsVictimDisguised || (pVictim->GetHealth() - info.GetDamage() <= 0.f)))
 		{
 			float damage = info.GetDamage();
 			float flChargeRate = 0.0f;

--- a/src/game/shared/tf/tf_weapon_smg.cpp
+++ b/src/game/shared/tf/tf_weapon_smg.cpp
@@ -178,6 +178,11 @@ void CTFChargedSMG::SecondaryAttack()
 void CTFChargedSMG::ApplyOnHitAttributes( CBaseEntity *pVictimBaseEntity, CTFPlayer *pAttacker, const CTakeDamageInfo &info )
 {
 	BaseClass::ApplyOnHitAttributes( pVictimBaseEntity, pAttacker, info );
+
+	CTFPlayer* pVictim = ToTFPlayer(pVictimBaseEntity);
+	if (pVictim && pVictim->m_Shared.InCond(TF_COND_DISGUISED))
+		return;
+
 	if ( pAttacker )
 	{
 		CTFPlayer *pPlayer = ToTFPlayer( GetOwner() );


### PR DESCRIPTION
### Bug

In [August 13, 2009 Patch](https://wiki.teamfortress.com/wiki/August_13,_2009_Patch) Spy's disguises were changed so 'On Hit' effects no longer trigger when the Spy is disguised. However some weapons from following list ignore this rule:
Soda Popper
Flying Guillotine
Black Box
Buff Banner
Battalion's Backup
Concheror
Sydney Sleeper
Cleaner's Carbine
Vita-Saw
L'Etranger

This PR also closes [#6344](https://github.com/ValveSoftware/Source-1-Games/issues/6344)

### Media

Soda Popper (Hype meter)

https://github.com/user-attachments/assets/9057e16b-e9c2-43b6-81d8-204e1fa3b647

Flying Guillotine (Reduced cooldown on long range hits)

https://github.com/user-attachments/assets/706b4598-e4fa-4868-8063-65f307941f1e

Black Box (Health on hit)

https://github.com/user-attachments/assets/b469f83f-b84f-48cc-a23e-90bebecf6e9a

Buff Banner (Rage meter)

https://github.com/user-attachments/assets/d483052c-470e-470d-b222-190d66a517f3

Battalion's Backup (Rage meter)

https://github.com/user-attachments/assets/5a125311-fda2-409f-8779-6c0c61fec139

Concheror (Rage meter)

https://github.com/user-attachments/assets/a3b3a0d5-d922-44b1-97c3-eafec64de1ca

Sydney Sleeper (Jarate effect)

https://github.com/user-attachments/assets/23b7ebf0-bc85-4e33-b816-a72a3397ef85

Sydney Sleeper (Reduced Jarate cooldown on headshots)

https://github.com/user-attachments/assets/270e4e1d-0393-43d6-8770-93582f7c69e7

Cleaner's Carbine (Crikey meter)

https://github.com/user-attachments/assets/21ad9936-2da0-471a-b436-14e87c7b58a6

Vita-Saw (Collecting organs)

https://github.com/user-attachments/assets/b3c8cf43-f978-4ba8-a9a2-92f888fb5b80

L'Etranger (Cloak on hit)

https://github.com/user-attachments/assets/edfd07da-8ef4-46ec-8c06-14d5d01fee6a

Bleeding also filled the meters, even if the spy was disguised.

https://github.com/user-attachments/assets/6101b7d7-9604-49f6-9e93-5e59987fac9c

