### PR TITLE
[HL2MP] Fix Ammo pickup icon mostly missing

### DIFF
--- a/src/game/client/c_baseplayer.cpp
+++ b/src/game/client/c_baseplayer.cpp
@@ -789,7 +789,10 @@ void C_BasePlayer::OnPreDataChanged( DataUpdateType_t updateType )
 {
 	for (int i = 0; i < MAX_AMMO_TYPES; ++i)
 	{
-		m_iOldAmmo[i] = GetAmmoCount(i);
+		if (GetAmmoCount(i) < m_iOldAmmo[i])
+		{
+			m_iOldAmmo[i] = GetAmmoCount(i);
+		}
 	}
 
 	m_bWasFreezeFraming = (GetObserverMode() == OBS_MODE_FREEZECAM);
@@ -1018,7 +1021,7 @@ void C_BasePlayer::OnDataChanged( DataUpdateType_t updateType )
 #endif
 
 	BaseClass::OnDataChanged( updateType );
-
+	
 	// Only care about this for local player
 	if ( IsLocalPlayer() )
 	{
@@ -1030,6 +1033,9 @@ void C_BasePlayer::OnDataChanged( DataUpdateType_t updateType )
 		{
 			if ( GetAmmoCount(i) > m_iOldAmmo[i] )
 			{
+				int iCount = abs(GetAmmoCount(i) - m_iOldAmmo[i]);
+				m_iOldAmmo[i] = GetAmmoCount(i);
+
 				// Don't add to ammo pickup if the ammo doesn't do it
 				const FileWeaponInfo_t *pWeaponData = gWR.GetWeaponFromAmmo(i);
 
@@ -1039,7 +1045,7 @@ void C_BasePlayer::OnDataChanged( DataUpdateType_t updateType )
 					CHudHistoryResource *pHudHR = GET_HUDELEMENT( CHudHistoryResource );
 					if( pHudHR )
 					{
-						pHudHR->AddToHistory( HISTSLOT_AMMO, i, abs(GetAmmoCount(i) - m_iOldAmmo[i]) );
+						pHudHR->AddToHistory( HISTSLOT_AMMO, i, iCount );
 					}
 				}
 			}


### PR DESCRIPTION

### Bug

For a lot of weapons (nades, shotgun, smg) no pickup is shown, only the icon of 'full' during pickup attempt.

This PR also closes [#7369](https://github.com/ValveSoftware/Source-1-Games/issues/7369)

### Media

Video demonstrating the bug:

https://github.com/user-attachments/assets/e87ba296-c6a0-4635-b7b9-3f6610b49cfc

Video demonstrating the fix:


https://github.com/user-attachments/assets/c6a071ce-1219-41e7-b75d-3f29e9fa0af9

