### PR TITLE
[TF2] Fix Buggy movement when colliding with players

### DIFF
--- a/src/game/shared/tf/tf_gamemovement.cpp
+++ b/src/game/shared/tf/tf_gamemovement.cpp
@@ -1359,7 +1359,7 @@ int CTFGameMovement::CheckStuck( void )
 		const Vector &originalPos = mv->GetAbsOrigin();
 		trace_t traceresult;
 
-		TracePlayerBBox( originalPos, originalPos, PlayerSolidMask(), COLLISION_GROUP_PLAYER_MOVEMENT, traceresult );
+		TracePlayerBBox( originalPos, originalPos, PlayerSolidMask() | CONTENTS_STUCK, COLLISION_GROUP_PLAYER_MOVEMENT, traceresult );
 
 #ifdef GAME_DLL
 		if ( TFGameRules() && TFGameRules()->IsMannVsMachineMode() && m_pTFPlayer && m_pTFPlayer->GetTeamNumber() == TF_TEAM_PVE_INVADERS )
@@ -1404,7 +1404,7 @@ int CTFGameMovement::CheckStuck( void )
 				m_isPassingThroughEnemies = true;
 
 				// verify position is now clear
-				TracePlayerBBox( originalPos, originalPos, PlayerSolidMask(), COLLISION_GROUP_PLAYER_MOVEMENT, traceresult );
+				TracePlayerBBox( originalPos, originalPos, PlayerSolidMask() | CONTENTS_STUCK, COLLISION_GROUP_PLAYER_MOVEMENT, traceresult );
 
 				if ( !traceresult.DidHit() )
 				{
@@ -1428,7 +1428,7 @@ int CTFGameMovement::CheckStuck( void )
 					tryPos = mv->GetAbsOrigin();
 					tryPos.z += shift;
 
-					TracePlayerBBox( tryPos, tryPos, PlayerSolidMask(), COLLISION_GROUP_PLAYER_MOVEMENT, traceresult );
+					TracePlayerBBox( tryPos, tryPos, PlayerSolidMask() | CONTENTS_STUCK, COLLISION_GROUP_PLAYER_MOVEMENT, traceresult );
 					if ( !traceresult.DidHit() || ( traceresult.m_pEnt && traceresult.m_pEnt->IsPlayer() ) )
 					{
 						// no longer stuck
@@ -2320,7 +2320,10 @@ void CTFGameMovement::TracePlayerBBox( const Vector& start, const Vector& end, u
 		return BaseClass::TracePlayerBBox( start, end, fMask, collisionGroup, pm );
 
 	Ray_t ray;
-	ray.Init( start, end, GetPlayerMins(), GetPlayerMaxs() );
+	Vector stuckModifier = (fMask & CONTENTS_STUCK ? Vector{ 1, 1, 1 } : Vector{ 0, 0, 0 });
+	Vector playerMins = GetPlayerMins() + stuckModifier;
+	Vector playerMaxs = GetPlayerMaxs() - stuckModifier;
+	ray.Init(start, end, playerMins, playerMaxs);
 	
 	CTraceFilterObject traceFilter( mv->m_nPlayerHandle.Get(), collisionGroup );
 

--- a/src/public/bspflags.h
+++ b/src/public/bspflags.h
@@ -74,6 +74,7 @@
 #define	CONTENTS_TRANSLUCENT	0x10000000	// auto set if any surface has trans
 #define	CONTENTS_LADDER			0x20000000
 #define CONTENTS_HITBOX			0x40000000	// use accurate hitboxes on trace
+#define CONTENTS_STUCK			0x80000000
 
 
 // NOTE: These are stored in a short in the engine now.  Don't use more than 16 bits


### PR DESCRIPTION

### Bug

When colliding with players it tends to produce prediction errors: A player gets stuck in another player.

### Media

Video demonstrating the bug:

https://github.com/user-attachments/assets/d5759744-3556-4e7c-a436-2d9204d343ee

Video demonstrating the fix:

https://github.com/user-attachments/assets/59356753-7a90-41f4-8298-d5c768b0d3a6

