### PR TITLE
[TF2] fix IncrementAmmo removing ammo if m_iClip1 was already at Max capacity

### DIFF
--- a/src/game/shared/tf/tf_weaponbase.cpp
+++ b/src/game/shared/tf/tf_weaponbase.cpp
@@ -2090,8 +2090,11 @@ void CTFWeaponBase::IncrementAmmo( void )
 		{
 			if ( pPlayer && pPlayer->GetAmmoCount( m_iPrimaryAmmoType ) > 0 )
 			{
-				m_iClip1 = MIN( ( m_iClip1 + 1 ), GetMaxClip1() );
-				pPlayer->RemoveAmmo( 1, m_iPrimaryAmmoType );
+				if ( m_iClip1 < GetMaxClip1() )
+				{
+					m_iClip1++;
+					pPlayer->RemoveAmmo( 1, m_iPrimaryAmmoType );
+				}
 			}
 		}
 	}


### PR DESCRIPTION
# Description

If a player were to touch a resupply during a reload it would then still remove ammo from the player even though the weapons clip is already full. This prevents this by only removing ammo if m_iClip1 is smaller than the max clip capacity.

Before:

https://github.com/user-attachments/assets/06fa1395-8334-4ead-9265-899668946aa4

After:

https://github.com/user-attachments/assets/08611230-ba1b-4a11-acca-fa43f6abf147

