### PR TITLE
[HL2MP] Fix empty icons in weapon selector

### DIFF
--- a/src/game/client/hl2/hud_weaponselection.cpp
+++ b/src/game/client/hl2/hud_weaponselection.cpp
@@ -699,10 +699,11 @@ void CHudWeaponSelection::Paint()
 												bSelected ? selectedColor : m_BoxColor, 
 												GetWeaponBoxAlpha( bSelected ), 
 												bDrawBucketNumber ? i + 1 : -1 );
+
+							// move down to the next bucket
+							ypos += (largeBoxTall + m_flBoxGap);
 						}
 
-						// move down to the next bucket
-						ypos += (largeBoxTall + m_flBoxGap);
 						bDrawBucketNumber = false;
 					}
 


### PR DESCRIPTION

### Bug

There's a blank space in the 1st slot for one of the melee weapons (depending on the team), which isn't cycled when I am selecting weapons, but still displayed.

### Media

![image1](https://github.com/user-attachments/assets/68a874a4-66a4-443b-a081-9c539b7dc166)

![image2](https://github.com/user-attachments/assets/ac9ac7e4-164e-47eb-973c-47f3659a7c14)
