### PR TITLE
[TF2] Fix Long weapon names extend the panel outside the screen

### DIFF
--- a/src/game/client/tf/tf_hud_target_id.cpp
+++ b/src/game/client/tf/tf_hud_target_id.cpp
@@ -610,12 +610,12 @@ void CTargetID::PerformLayout( void )
 		iWidth += m_pAvatarImage->GetWide() + XRES( 2 );
 	}
 
-	int iTextW, iTextH;
+	int iTextW;
 	int iDataW, iDataH;
 
 	if ( m_pTargetNameLabel && m_pTargetDataLabel )
 	{
-		m_pTargetNameLabel->GetContentSize( iTextW, iTextH );
+		m_pTargetNameLabel->GetTextImage()->GetDrawWidth(iTextW);
 		m_pTargetDataLabel->GetContentSize( iDataW, iDataH );
 		iWidth += MAX(iTextW,iDataW);
 


### PR DESCRIPTION
### Bug

When the weapon name is too long, the panel that displays the name extends beyond the screen's boundaries.

### Media

Video demonstrating the bug:

https://github.com/user-attachments/assets/7c70fe21-a0bb-4086-b082-df9471d13a89

Video demonstrating the fix:

https://github.com/user-attachments/assets/c2c07cf5-d05f-498f-bb45-4a65bfbe34be
