### PR TITLE
[TF2] Remove ammo metal prediction if the weapon has add_onhit_ammo

### DIFF
--- a/src/game/shared/tf/tf_weaponbase_gun.cpp
+++ b/src/game/shared/tf/tf_weaponbase_gun.cpp
@@ -384,8 +384,15 @@ void CTFWeaponBaseGun::RemoveProjectileAmmo( CTFPlayer *pPlayer )
 	{
 		if ( m_iWeaponMode == TF_WEAPON_PRIMARY_MODE )
 		{
-			pPlayer->RemoveAmmo( GetAmmoPerShot(), m_iPrimaryAmmoType );
-
+#if CLIENT_DLL
+			// delay removing metal when we could give it right back
+			int iAmmoOnHit = 0;
+			CALL_ATTRIB_HOOK_INT( iAmmoOnHit, add_onhit_addammo )
+			if ( !( iAmmoOnHit && m_iPrimaryAmmoType == TF_AMMO_METAL ) )
+#endif
+			{
+				pPlayer->RemoveAmmo( GetAmmoPerShot(), m_iPrimaryAmmoType );
+			}
 #ifndef CLIENT_DLL
 			// delayed ammo adding for the onhit attribute
 			if ( m_iAmmoToAdd > 0 )
@@ -397,8 +404,15 @@ void CTFWeaponBaseGun::RemoveProjectileAmmo( CTFPlayer *pPlayer )
 		}
 		else
 		{
-			pPlayer->RemoveAmmo( GetAmmoPerShot(), m_iSecondaryAmmoType );
-
+#if CLIENT_DLL
+			// delay removing metal when we could give it right back
+			int iAmmoOnHit = 0;
+			CALL_ATTRIB_HOOK_INT( iAmmoOnHit, add_onhit_addammo )
+			if ( !( iAmmoOnHit && m_iSecondaryAmmoType == TF_AMMO_METAL ) )
+#endif
+			{
+				pPlayer->RemoveAmmo( GetAmmoPerShot(), m_iSecondaryAmmoType );
+			}
 #ifndef CLIENT_DLL
 			// delayed ammo adding for the onhit attribute
 			if ( m_iAmmoToAdd > 0 )


### PR DESCRIPTION
# Description

This PR removes ammo removal prediction when the weapon ammo type is TF_AMMO_METAL and it has the `add_onhit_addammo` attribute.
This fixes an issue where when firing the Widowmaker a -30 and (on successful hit) a +30 will overlap, creating issues where numbers become hard to read or unreadable.

This changes will delay the resulting ammo when the shot is registered into a single metal ammo account delta change, resulting in a clean and readable number.

https://github.com/user-attachments/assets/6ebbe5e3-757d-40d1-81a4-c6904fcd4e94

