### PR TITLE
[TF2] Fix MoveableSubPanel showing while dead

### DIFF
--- a/src/game/shared/tf/tf_player_shared.cpp
+++ b/src/game/shared/tf/tf_player_shared.cpp
@@ -12339,6 +12339,9 @@ bool CTFPlayer::CanPickupBuilding( CBaseObject *pPickupObject )
 	if ( pPickupObject->GetUpgradeLevel() != pPickupObject->GetHighestUpgradeLevel() )
 		return false;
 
+	if ( !IsAlive() )
+		return false;
+
 	if ( m_Shared.IsCarryingObject() )
 		return false;
 


### PR DESCRIPTION
# Description
Fixes ValveSoftware/Source-1-Games/issues/4155

Adds an extra check to CTFPlayer::CanPickupBuilding() to see if the player is dead, if they are, they can't pickup the building, and shouldn't display the MovableSubPanel.