### PR TITLE
[TF2] Fix sentry "buffering" wrangler inputs

### DIFF
--- a/src/game/server/tf/tf_obj_sentrygun.cpp
+++ b/src/game/server/tf/tf_obj_sentrygun.cpp
@@ -296,6 +296,9 @@ void CObjectSentrygun::SentryThink( void )
 
 	SetContextThink( &CObjectSentrygun::SentryThink, gpGlobals->curtime + SENTRY_THINK_DELAY, SENTRYGUN_CONTEXT );
 
+	m_bFireNextFrame = false;
+	m_bFireRocketNextFrame = false;
+
 	if ( m_nShieldLevel > 0 && (gpGlobals->curtime > m_flShieldFadeTime) )
 	{
 		m_nShieldLevel.Set( SHIELD_NONE );


### PR DESCRIPTION
# Description
Fixes ValveSoftware/Source-1-Games/issues/4237 by setting `m_bFireNextFrame` and `m_bFireRocketNextFrame` to false after when the sentry would've attacked that think.
If it did attack that think, it's already false, if it didn't, it shouldn't be true for the next think.