### PR TITLE
[TF2] Fix Switching from the medigun while healing someone screws with viewmodels

### DIFF
--- a/src/game/shared/tf/tf_weapon_medigun.cpp
+++ b/src/game/shared/tf/tf_weapon_medigun.cpp
@@ -458,6 +458,7 @@ bool CWeaponMedigun::Holster( CBaseCombatWeapon *pSwitchingTo )
 //-----------------------------------------------------------------------------
 void CWeaponMedigun::UpdateOnRemove( void )
 {
+	m_bHealing = false;
 	RemoveHealingTarget( true );
 	m_bAttacking = false;
 	m_bChargeRelease = false;


### PR DESCRIPTION

### Bug

Switching from a medic to another class while treating someone breaks the viewmodels. The hand animations broke, and the weapons in those hands became transparent until I switched to a weapon in another slot.

This PR also closes [#5976](https://github.com/ValveSoftware/Source-1-Games/issues/5976)

### Media

Video demonstrating the bug:

https://github.com/user-attachments/assets/3443a007-3118-4acf-a8e6-3b65a90f629f

Video demonstrating the fix:

https://github.com/user-attachments/assets/f2440b32-7f34-4be0-982b-e22cb90d687a
