### PR TITLE
[TF2] Make Eyelander's health gain & overheal drain consistent with other weapons

### DIFF
--- a/src/game/shared/tf/tf_weapon_sword.cpp
+++ b/src/game/shared/tf/tf_weapon_sword.cpp
@@ -349,13 +349,10 @@ void CTFSword::OnDecapitation( CTFPlayer *pDeadPlayer )
 		}
 		pOwner->m_Shared.SetDecapitations( ++iDecap );
 		pOwner->TeamFortress_SetSpeed();
-		if ( pOwner->m_Shared.GetBestOverhealDecayMult() == -1.f )
-		{
-			pOwner->m_Shared.SetBestOverhealDecayMult( 0.25f );
-		}
+
 		if ( pOwner->GetHealth() < pOwner->m_Shared.GetMaxBuffedHealth() )
 		{
-			pOwner->TakeHealth( 15, DMG_IGNORE_MAXHEALTH );
+			pOwner->TakeHealth( 15, DMG_GENERIC );
 		}
 		if ( !pOwner->m_Shared.InCond( TF_COND_DEMO_BUFF ) )
 		{


### PR DESCRIPTION
# Current Mechanics
Getting a kill with the Eyelander will grant 15 health with the ability to overheal. If a kill granted overheal while not already overhealed, the overheal will decay quickly. From looking at the code, I can only assume that your overheal is set to decay quickly so that your health will return to your new max health quickly. However this raises issues.

#  Why It's An Issue
1. When an Eyelander kill grants overheal and you are healed by another source such as the Medigun or Uber spell before your Eyelander overheal fully decays, the increased overheal from those sources will continue to decay rapidly.
2. When VScript or a server plugin sets a player's `m_iHealth` to an overheal value and the player then gets an Eyelander kill, their overheal will rapidly drain.

# Description
This PR aims to fix this issue by removing the use of `SetBestOverhealDecayMult()` (The only use of it in the code) to rapidly decay overheal, and instead heals the player to their new maximum health without unnecessary overheal that ends up decaying in 0.15 seconds anyway (10 game ticks). This achieves the previously assumed intention by the developer of setting a player's new max health quickly as possible after collecting a head without issue. This PR's solution also makes the Eyelander's health on kill consistent with other weapons like the Powerjack and Warrior's Spirit, neither of which are able to overheal.

https://github.com/user-attachments/assets/a93aa383-ab54-4b4f-b10e-1db4cd1406c5


