### PR TITLE
Fix the `tf_projectile_arrow` entity changing direction upon entering water

### DIFF
--- a/src/game/server/tf/tf_projectile_arrow.cpp
+++ b/src/game/server/tf/tf_projectile_arrow.cpp
@@ -234,6 +234,7 @@ void CTFProjectile_Arrow::Spawn()
 	SetSolid( SOLID_BBOX );	
 
 	SetCollisionGroup( TFCOLLISION_GROUP_ROCKETS );
+	AddEFlags( EFL_NO_WATER_VELOCITY_CHANGE );
 	AddEffects( EF_NOSHADOW );
 	AddFlag( FL_GRENADE );
 


### PR DESCRIPTION
# Description
This PR fixes the bug stated in the title. This is due to the `CTFProjectile_Arrow::Spawn()` function not adding the `EFL_NO_WATER_VELOCITY_CHANGE` EFlag like all other projectiles that inherit from `CTFBaseRocket` and call `BaseClass::Spawn()`. 

https://github.com/user-attachments/assets/6de512fb-e16e-49e3-b2d9-c00beabe8712

