### PR TITLE
[TF2] Fix Force-A-Nature, Soda Popper and Shortstop only fire a single crit tracer visually

### DIFF
--- a/src/game/shared/particle_property.cpp
+++ b/src/game/shared/particle_property.cpp
@@ -113,6 +113,7 @@ CNewParticleEffect *CParticleProperty::Create( const char *pszParticleName, Part
 // Purpose: Create a new particle system and attach it to our owner
 //-----------------------------------------------------------------------------
 static ConVar cl_particle_batch_mode( "cl_particle_batch_mode", "1" );
+static ConVar cl_disable_batch_mode_bullet_tracers("cl_disable_batch_mode_for_bullet_tracers", "1");
 CNewParticleEffect *CParticleProperty::Create( const char *pszParticleName, ParticleAttachment_t iAttachType, int iAttachmentPoint, Vector vecOriginOffset )
 {
 	if ( GameRules() )
@@ -122,15 +123,18 @@ CNewParticleEffect *CParticleProperty::Create( const char *pszParticleName, Part
 
 	int nBatchMode = cl_particle_batch_mode.GetInt();
 	CParticleSystemDefinition *pDef = g_pParticleSystemMgr->FindParticleSystem( pszParticleName );
-	bool bRequestedBatch = ( nBatchMode == 2 ) || ( ( nBatchMode == 1 ) && pDef && pDef->ShouldBatch() ); 
-	if ( ( iAttachType == PATTACH_CUSTOMORIGIN ) && bRequestedBatch )
+	if (!(cl_disable_batch_mode_bullet_tracers.GetInt() && V_strstr(pszParticleName, "bullet") && V_strstr(pszParticleName, "tracer")))
 	{
-		int iIndex = FindEffect( pszParticleName );
-		if ( iIndex >= 0 )
+		bool bRequestedBatch = (nBatchMode == 2) || ((nBatchMode == 1) && pDef && pDef->ShouldBatch());
+		if ((iAttachType == PATTACH_CUSTOMORIGIN) && bRequestedBatch)
 		{
-			CNewParticleEffect *pEffect = m_ParticleEffects[iIndex].pParticleEffect.GetObject();
-			pEffect->Restart();
-			return pEffect;
+			int iIndex = FindEffect(pszParticleName);
+			if (iIndex >= 0)
+			{
+				CNewParticleEffect* pEffect = m_ParticleEffects[iIndex].pParticleEffect.GetObject();
+				pEffect->Restart();
+				return pEffect;
+			}
 		}
 	}
 


### PR DESCRIPTION

### Bug

Force-A-Nature, Soda Popper and Shortstop only create a single crit tracer effect when they fire with crits, only one pellet gets a tracer.
The problem was the "Batch Particle Systems" enabled flag in some of the tracer effects. If this flag is disabled in these effects, everything returns to normal.

This PR also closes [#7384](https://github.com/ValveSoftware/Source-1-Games/issues/7384)

### Media

 **Force-A-Nature:**

https://github.com/user-attachments/assets/05d6a6e4-8d94-4648-80ea-ba035664add1

**Soda Popper:**

https://github.com/user-attachments/assets/66e40865-9d9c-4f8c-b0b1-03db0118a00e

**Shortstop:**

https://github.com/user-attachments/assets/0a1c5328-42c9-47c4-99e7-ea98621ba14c
