### PR TITLE
matsys_controls: Add inverse kinematics solving in model panels

### DIFF
--- a/src/public/matsys_controls/mdlpanel.h
+++ b/src/public/matsys_controls/mdlpanel.h
@@ -26,6 +26,7 @@ namespace vgui
 {
 	class IScheme;
 }
+class CIKContext;
 
 // 
 struct MDLAnimEventState_t
@@ -118,6 +119,7 @@ protected:
 		float		m_flCycleStartTime;
 		CStudioHdr	*m_pStudioHdr;
 		uint32		m_unMdlCacheSerial;
+		CIKContext  *m_pIKContext;
 	};
 
 	MDLData_t				m_RootMDL;
@@ -143,6 +145,9 @@ private:
 
 	void DrawCollisionModel();
 	void UpdateStudioRenderConfig( void );
+
+	void SetupBones( MDLData_t& mdlData, int nMaxBoneCount, matrix3x4_t* pBoneToWorld,
+					 const float* pflPoseParameters = NULL, MDLSquenceLayer_t* pSequenceLayers = NULL, int nNumSequenceLayers = 0 );
 
 	CTextureReference m_DefaultEnvCubemap;
 	CTextureReference m_DefaultHDREnvCubemap;


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
Tier3's MDL utility class that's used in CMDLPanel doesn't account for IK, causing for instance attached weapons to not be positioned correctly when a playermodel is looking up/down or in some cases during the idle animation. An example of this being an issue is on TF's loadout menu with Scout's pistols, the Shortstop and all the Medi Guns:
| Before (handle clipping through hand)| After |
|--------|--------|
| ![medic_medigun_unfixed](https://github.com/user-attachments/assets/b62d0f12-7c70-455e-92f5-52b6474251ef) | ![medic_medigun_fixed](https://github.com/user-attachments/assets/ecb08418-f110-404e-a02e-ce02643f7418) |

| Before (hand clipping through grip)| After |
|--------|--------|
| ![scout_pistol_unfixed](https://github.com/user-attachments/assets/4ed48444-2655-4019-96ee-aff2421fcf44) | ![scout_pistol_fixed](https://github.com/user-attachments/assets/c4cce973-23c5-485a-830e-ffb3674e73c7) |

To resolve this, this PR implements a custom bones setup routine in CMDLPanel that properly applies IK to the model.