### PR TITLE
[GitHub] Add Test Build Workflow

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,0 +1,44 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Windows Test Build
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  # Path to the solution file relative to the root of the project.
+  SOLUTION_FILE_PATH: ./src
+
+  # Configuration type to build.
+  # You can convert this to a build matrix if you need coverage of multiple configuration types.
+  # https://docs.github.com/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+  BUILD_CONFIGURATION: Release
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+    - name: Checkout Files
+      uses: actions/checkout@v4
+      
+    - name: Generate Visual Studio Projects
+      working-directory: ./src/
+      run: ./createallprojects.bat
+      
+    - name: Add MSBuild to PATH
+      uses: microsoft/setup-msbuild@v1.0.2
+      
+    - name: Build
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      # Add additional options to the MSBuild command line here (like platform or verbosity level).
+      # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
+      run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}}


### PR DESCRIPTION
> [!Warning]
> This PR only tests the repo for Windows!

This PR adds A GitHub workflow for testing the build on windows devices.

The workflow, upon A commit being pushed to the master branch, will copy the repo onto A temporary space on one if it's servers and use that to attempt to build the repo from scratch. GitHub will display the results of the build with either A tick or A cross next to the commit (see image below for example) based on the results of said commit

<img width="1123" height="75" alt="image" src="https://github.com/user-attachments/assets/ba5eea15-092d-4379-b104-12ff6a3b5d2e" />

You can also display A badge showing the build results on the repository's README by placing this anywhere inside the README.md
`[![Windows Test Build](https://github.com/ValveSoftware/source-sdk-2013/actions/workflows/build-windows.yml/badge.svg)](https://github.com/ValveSoftware/source-sdk-2013/actions/workflows/build-windows.yml)`

> [!Note]
> Please note that the server is slower than most of our computers, so the compilation time may estimate to be around half an hour