### PR TITLE
[TF2] Allow the Shortstop to shove while reloading

### DIFF
--- a/src/game/shared/tf/tf_weapon_pistol.cpp
+++ b/src/game/shared/tf/tf_weapon_pistol.cpp
@@ -200,6 +200,33 @@ void CTFPistol_ScoutPrimary::Push( void )
 // Purpose: 
 // Input  :  - 
 //-----------------------------------------------------------------------------
+void CTFPistol_ScoutPrimary::ItemBusyFrame()
+{
+	BaseClass::ItemBusyFrame();
+
+	CTFPlayer *pOwner = ToTFPlayer( GetOwner() );
+	if ( !pOwner )
+		return;
+
+	if ( !m_bInAttack2 )
+		return;
+
+	// These are checked in SecondaryAttack too, but reload shouldn't be aborted if these fail
+	if ( !CanAttack() || m_flNextSecondaryAttack > gpGlobals->curtime )
+		return;
+
+	if ( m_bInReload )
+	{
+		AbortReload();
+		pOwner->m_flNextAttack = gpGlobals->curtime;
+		SecondaryAttack();
+	}
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: 
+// Input  :  - 
+//-----------------------------------------------------------------------------
 void CTFPistol_ScoutPrimary::ItemPostFrame()
 {
 	// Check for smack.

--- a/src/game/shared/tf/tf_weapon_pistol.h
+++ b/src/game/shared/tf/tf_weapon_pistol.h
@@ -78,6 +78,7 @@ public:
 	virtual int		GetWeaponID( void ) const	{ return TF_WEAPON_HANDGUN_SCOUT_PRIMARY; }
 	virtual void	PlayWeaponShootSound( void );
 	virtual void	SecondaryAttack( void );
+	virtual void	ItemBusyFrame();
 	virtual void	ItemPostFrame();
 	virtual bool	Holster( CBaseCombatWeapon *pSwitchingTo );
 	virtual void	Precache( void );


### PR DESCRIPTION
# Description
This PR allows the Shortstop to shove during a reload, thereby canceling the reload. You can shoot while reloading, so why not shove? I've heard others who shared this sentiment a lot ever since the addition of the shove, so figuring out that it's been possible all along is really cool.

**Note:** I want to briefly mention that the code block checking for `m_bInReload` was taken from `CTFWeaponBase::ItemBusyFrame()` where `pOwner->m_flNextAttack = gpGlobals->curtime`  allows for `ItemPostFrame()` to run, which then calls the shove function `Push()` . If you find something wrong with this implementation, please let me know. Thank you.

https://github.com/user-attachments/assets/2866315f-c183-4ab8-9724-0f7bd594c27c