### PR TITLE
[TF2] Auto-equip powerup canteen when ForceUpgrades is enabled (Freaky Fair)

### DIFF
--- a/src/game/shared/tf/tf_gamerules.cpp
+++ b/src/game/shared/tf/tf_gamerules.cpp
@@ -2124,7 +2124,7 @@ bool CTFGameRules::GameModeUsesUpgrades( void )
 	if ( m_nForceUpgrades == 1 )
 		return false;
 
-	if ( m_nForceUpgrades == 2 )
+	if ( m_nForceUpgrades == 2 || m_nForceUpgrades == 3 )
 		return true;
 
 	if ( IsMannVsMachineMode() || IsBountyMode() )
@@ -3699,6 +3699,12 @@ bool CTFGameRules::CanInitiateDuels( void )
 		return false;
 
 	return true;
+}
+
+//-----------------------------------------------------------------------------
+bool CTFGameRules::ShouldProvidePowerupBottle( void )
+{
+	return GameModeUsesUpgrades() && m_nForceUpgrades != 3;
 }
 
 //-----------------------------------------------------------------------------

--- a/src/game/shared/tf/tf_gamerules.h
+++ b/src/game/shared/tf/tf_gamerules.h
@@ -733,6 +733,7 @@ bool IsCreepWaveMode( void ) const;
 
 	bool IsUsingSpells( void ) const;
 	bool IsUsingGrapplingHook( void ) const;
+	bool ShouldProvidePowerupBottle( void );
 
 	bool IsTruceActive( void ) const; 
 

--- a/src/game/shared/tf/tf_item_inventory.cpp
+++ b/src/game/shared/tf/tf_item_inventory.cpp
@@ -686,7 +686,7 @@ CEconItemView *CTFInventoryManager::GetBaseItemForClass( int iClass, int iSlot )
 		}
 
 		static CSchemaItemDefHandle pItemDef_MvMCanteen( "Default Power Up Canteen (MvM)" );
-		if ( TFGameRules() && TFGameRules()->IsMannVsMachineMode() && pItemDef_MvMCanteen )
+		if ( TFGameRules() && TFGameRules()->ShouldProvidePowerupBottle() && pItemDef_MvMCanteen )
 		{
 			stockActionItemDefIndices.AddToTail( pItemDef_MvMCanteen->GetDefinitionIndex() );
 		}


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description

**TL;DR:** this PR auto-equips a free powerup canteen on cp_freaky_fair (and other non-MvM maps with Upgrades), a QoL change already applied to other gameplay-relevant action items, and even canteens in MvM.

When playing MvM, you get a powerup canteen as a default Action Item in your loadout menu that gets auto-equipped if your action slot is empty.
Similarly, you auto-equip a free Spellbook Magazine on maps that use Spells and the Grappling Hook in Mannpower.

This, however, isn't the case on non-MvM maps with Upgrades enabled via `ForceEnableUpgrades`. One such map, cp_freaky_fair, was added in Scream Fortress 2024.
You have to manually equip your powerup canteen in your loadout... Assuming you have one... Which will then remain equipped and prevent you from using the Spells on other Halloween maps.

This Pull Request fixes that and gives you a temporary powerup canteen if `ForceEnableUpgrades` is set to `2`, which is how non-MvM maps enable Upgrades.

This PR also adds mode `3` to `ForceEnableUpgrades`. This new mode enables the Upgrades but does NOT auto-equip the canteen.
This is made for potential maps that would want to use MvM money for purposes not related to Upgrades.
Because most (if not all) maps that currently use `ForceEnableUpgrades` do so specifically for the Upgrades, it's worth having canteens auto-equipped by default should Upgrades be enabled, unless specifically told not to.

<img width="200" alt="image" src="https://github.com/user-attachments/assets/d90d1265-c1c3-4743-b91d-be182e4c2dc0" />