### PR TITLE
Fix steam input not working for the upgrade station menu

### DIFF
--- a/src/game/client/tf/player_vs_environment/c_tf_upgrades.cpp
+++ b/src/game/client/tf/player_vs_environment/c_tf_upgrades.cpp
@@ -1197,11 +1197,11 @@ void CHudUpgradePanel::UpdateJoystickControls( void )
 	}
 
 	bool bUp = ::input->Joystick_GetForward() < 0.0f || ::input->Joystick_GetPitch() < 0.0f || vgui::input()->IsKeyDown( KEY_XBUTTON_UP ) || vgui::input()->IsKeyDown( KEY_UP ) || vgui::input()->IsKeyDown( STEAMCONTROLLER_DPAD_UP );
-	bool bDown = ::input->Joystick_GetForward() > 0.0f || ::input->Joystick_GetPitch() > 0.0f || vgui::input()->IsKeyDown( KEY_XBUTTON_DOWN ) || vgui::input()->IsKeyDown( KEY_DOWN ) || vgui::input()->IsKeyDown(STEAMCONTROLLER_DPAD_DOWN);
+	bool bDown = ::input->Joystick_GetForward() > 0.0f || ::input->Joystick_GetPitch() > 0.0f || vgui::input()->IsKeyDown( KEY_XBUTTON_DOWN ) || vgui::input()->IsKeyDown( KEY_DOWN ) || vgui::input()->IsKeyDown( STEAMCONTROLLER_DPAD_DOWN );
 	bool bNavUpDownPressed = bUp || bDown;
 
-	bool bLeft = ::input->Joystick_GetSide() < 0.0f || ::input->Joystick_GetYaw() < 0.0f || vgui::input()->IsKeyDown( KEY_XBUTTON_LEFT ) || vgui::input()->IsKeyDown( KEY_LEFT ) || vgui::input()->IsKeyDown(STEAMCONTROLLER_DPAD_LEFT);
-	bool bRight = ::input->Joystick_GetSide() > 0.0f || ::input->Joystick_GetYaw() > 0.0f || vgui::input()->IsKeyDown( KEY_XBUTTON_RIGHT ) || vgui::input()->IsKeyDown( KEY_RIGHT ) || vgui::input()->IsKeyDown(STEAMCONTROLLER_DPAD_RIGHT);
+	bool bLeft = ::input->Joystick_GetSide() < 0.0f || ::input->Joystick_GetYaw() < 0.0f || vgui::input()->IsKeyDown( KEY_XBUTTON_LEFT ) || vgui::input()->IsKeyDown( KEY_LEFT ) || vgui::input()->IsKeyDown( STEAMCONTROLLER_DPAD_LEFT );
+	bool bRight = ::input->Joystick_GetSide() > 0.0f || ::input->Joystick_GetYaw() > 0.0f || vgui::input()->IsKeyDown( KEY_XBUTTON_RIGHT ) || vgui::input()->IsKeyDown( KEY_RIGHT ) || vgui::input()->IsKeyDown( STEAMCONTROLLER_DPAD_RIGHT );
 	bool bNavLeftRightPressed = bLeft || bRight;
 
 	bool bAccept = vgui::input()->IsKeyDown( KEY_XBUTTON_A ) || vgui::input()->IsKeyDown( KEY_ENTER ) || vgui::input()->IsKeyDown( STEAMCONTROLLER_A );

--- a/src/game/client/tf/player_vs_environment/c_tf_upgrades.cpp
+++ b/src/game/client/tf/player_vs_environment/c_tf_upgrades.cpp
@@ -1190,11 +1190,11 @@ void CHudUpgradePanel::UpdateUpgradeButtons( void )
 
 void CHudUpgradePanel::UpdateJoystickControls( void )
 {
-	static ConVarRef joystick( "joystick" );
-	if ( !joystick.IsValid() || !joystick.GetBool() )
-	{
-		return;
-	}
+	//static ConVarRef joystick( "joystick" );
+	//if ( !joystick.IsValid() || !joystick.GetBool() )
+	//{
+	//	return;
+	//}
 
 	bool bUp = ::input->Joystick_GetForward() < 0.0f || ::input->Joystick_GetPitch() < 0.0f || vgui::input()->IsKeyDown( KEY_XBUTTON_UP ) || vgui::input()->IsKeyDown( KEY_UP ) || vgui::input()->IsKeyDown( STEAMCONTROLLER_DPAD_UP );
 	bool bDown = ::input->Joystick_GetForward() > 0.0f || ::input->Joystick_GetPitch() > 0.0f || vgui::input()->IsKeyDown( KEY_XBUTTON_DOWN ) || vgui::input()->IsKeyDown( KEY_DOWN ) || vgui::input()->IsKeyDown( STEAMCONTROLLER_DPAD_DOWN );
@@ -1340,6 +1340,10 @@ void CHudUpgradePanel::UpdateJoystickControls( void )
 		{
 			OnCommand( "close" );
 		}
+		else if ( bRespec )
+		{
+			OnCommand( "respec" );
+		}
 		else if ( bNext )
 		{
 			OnCommand( "next" );
@@ -1347,10 +1351,6 @@ void CHudUpgradePanel::UpdateJoystickControls( void )
 		else if ( bPrev )
 		{
 			OnCommand( "prev" );
-		}
-		else if ( bRespec )
-		{
-			OnCommand( "respec" );
 		}
 	}
 }

--- a/src/game/client/tf/player_vs_environment/c_tf_upgrades.cpp
+++ b/src/game/client/tf/player_vs_environment/c_tf_upgrades.cpp
@@ -1196,20 +1196,21 @@ void CHudUpgradePanel::UpdateJoystickControls( void )
 		return;
 	}
 
-	bool bUp = ::input->Joystick_GetForward() < 0.0f || ::input->Joystick_GetPitch() < 0.0f || vgui::input()->IsKeyDown( KEY_XBUTTON_UP ) || vgui::input()->IsKeyDown( KEY_UP );
-	bool bDown = ::input->Joystick_GetForward() > 0.0f || ::input->Joystick_GetPitch() > 0.0f || vgui::input()->IsKeyDown( KEY_XBUTTON_DOWN ) || vgui::input()->IsKeyDown( KEY_DOWN );
+	bool bUp = ::input->Joystick_GetForward() < 0.0f || ::input->Joystick_GetPitch() < 0.0f || vgui::input()->IsKeyDown( KEY_XBUTTON_UP ) || vgui::input()->IsKeyDown( KEY_UP ) || vgui::input()->IsKeyDown( STEAMCONTROLLER_DPAD_UP );
+	bool bDown = ::input->Joystick_GetForward() > 0.0f || ::input->Joystick_GetPitch() > 0.0f || vgui::input()->IsKeyDown( KEY_XBUTTON_DOWN ) || vgui::input()->IsKeyDown( KEY_DOWN ) || vgui::input()->IsKeyDown(STEAMCONTROLLER_DPAD_DOWN);
 	bool bNavUpDownPressed = bUp || bDown;
 
-	bool bLeft = ::input->Joystick_GetSide() < 0.0f || ::input->Joystick_GetYaw() < 0.0f || vgui::input()->IsKeyDown( KEY_XBUTTON_LEFT ) || vgui::input()->IsKeyDown( KEY_LEFT );
-	bool bRight = ::input->Joystick_GetSide() > 0.0f || ::input->Joystick_GetYaw() > 0.0f || vgui::input()->IsKeyDown( KEY_XBUTTON_RIGHT ) || vgui::input()->IsKeyDown( KEY_RIGHT );
+	bool bLeft = ::input->Joystick_GetSide() < 0.0f || ::input->Joystick_GetYaw() < 0.0f || vgui::input()->IsKeyDown( KEY_XBUTTON_LEFT ) || vgui::input()->IsKeyDown( KEY_LEFT ) || vgui::input()->IsKeyDown(STEAMCONTROLLER_DPAD_LEFT);
+	bool bRight = ::input->Joystick_GetSide() > 0.0f || ::input->Joystick_GetYaw() > 0.0f || vgui::input()->IsKeyDown( KEY_XBUTTON_RIGHT ) || vgui::input()->IsKeyDown( KEY_RIGHT ) || vgui::input()->IsKeyDown(STEAMCONTROLLER_DPAD_RIGHT);
 	bool bNavLeftRightPressed = bLeft || bRight;
 
 	bool bAccept = vgui::input()->IsKeyDown( KEY_XBUTTON_A ) || vgui::input()->IsKeyDown( KEY_ENTER ) || vgui::input()->IsKeyDown( STEAMCONTROLLER_A );
 	bool bBack = vgui::input()->IsKeyDown( KEY_XBUTTON_X ) || vgui::input()->IsKeyDown( KEY_BACKSPACE ) || vgui::input()->IsKeyDown( STEAMCONTROLLER_X );
 	bool bDone = vgui::input()->IsKeyDown( KEY_XBUTTON_B ) || vgui::input()->IsKeyDown( KEY_ESCAPE ) || vgui::input()->IsKeyDown( STEAMCONTROLLER_B );
-	bool bNext = vgui::input()->IsKeyDown( KEY_XBUTTON_RIGHT_SHOULDER ) || vgui::input()->IsKeyDown( KEY_PAGEDOWN );
-	bool bPrev = vgui::input()->IsKeyDown( KEY_XBUTTON_LEFT_SHOULDER ) || vgui::input()->IsKeyDown( KEY_PAGEUP );
-	bool bNavButtonPressed = bAccept || bBack || bDone || bNext || bPrev;
+	bool bRespec = vgui::input()->IsKeyDown( KEY_XBUTTON_Y ) || vgui::input()->IsKeyDown( STEAMCONTROLLER_Y );
+	bool bNext = vgui::input()->IsKeyDown( KEY_XBUTTON_RIGHT_SHOULDER ) || vgui::input()->IsKeyDown( KEY_PAGEDOWN ) || vgui::input()->IsKeyDown( STEAMCONTROLLER_RIGHT_BUMPER );
+	bool bPrev = vgui::input()->IsKeyDown( KEY_XBUTTON_LEFT_SHOULDER ) || vgui::input()->IsKeyDown( KEY_PAGEUP ) || vgui::input()->IsKeyDown( STEAMCONTROLLER_LEFT_BUMPER );
+	bool bNavButtonPressed = bAccept || bBack || bDone || bRespec || bNext || bPrev;
 
 	if ( m_bNavUpDownPressed )
 	{
@@ -1346,6 +1347,10 @@ void CHudUpgradePanel::UpdateJoystickControls( void )
 		else if ( bPrev )
 		{
 			OnCommand( "prev" );
+		}
+		else if ( bRespec )
+		{
+			OnCommand( "respec" );
 		}
 	}
 }

--- a/src/game/client/tf/player_vs_environment/c_tf_upgrades.cpp
+++ b/src/game/client/tf/player_vs_environment/c_tf_upgrades.cpp
@@ -34,6 +34,7 @@
 #include "tf_hud_statpanel.h"
 #include "tf_mann_vs_machine_stats.h"
 #include "c_tf_playerresource.h"
+#include "ienginevgui.h"
 
 #define UPGRADE_PANEL_LEVEL_LABEL_COUNT 10
 
@@ -467,7 +468,7 @@ bool CHudUpgradePanel::ShouldDraw( void )
 	C_TFPlayer *pLocalPlayer = C_TFPlayer::GetLocalTFPlayer();
 	if ( m_hPlayer && pLocalPlayer == m_hPlayer )
 	{
-		if ( !m_hPlayer->IsAlive() || m_hPlayer->m_Shared.IsLoser() || m_hPlayer->GetTeamNumber() == TEAM_SPECTATOR )
+		if ( !m_hPlayer->IsAlive() || m_hPlayer->m_Shared.IsLoser() || m_hPlayer->GetTeamNumber() == TEAM_SPECTATOR || enginevgui->IsGameUIVisible() )
 		{
 			m_bWasInZone = false;
 			return false;
@@ -553,6 +554,9 @@ void CHudUpgradePanel::SetActive( bool bActive )
 
 		// Becoming visible. Get ready.
 		UpdateModelPanels();
+
+		// Hack to prevent a crash when trying to read m_pActiveUpgradeBuyPanel
+		UpgradeItemInSlot( LOADOUT_POSITION_PRIMARY );
 
 		// Accept button is disabled till you buy or sell something
 		m_pSelectWeaponPanel->SetControlEnabled( "CloseButton", false );
@@ -1191,10 +1195,6 @@ void CHudUpgradePanel::UpdateUpgradeButtons( void )
 void CHudUpgradePanel::UpdateJoystickControls( void )
 {
 	//static ConVarRef joystick( "joystick" );
-	//if ( !joystick.IsValid() || !joystick.GetBool() )
-	//{
-	//	return;
-	//}
 
 	bool bUp = ::input->Joystick_GetForward() < 0.0f || ::input->Joystick_GetPitch() < 0.0f || vgui::input()->IsKeyDown( KEY_XBUTTON_UP ) || vgui::input()->IsKeyDown( KEY_UP ) || vgui::input()->IsKeyDown( STEAMCONTROLLER_DPAD_UP );
 	bool bDown = ::input->Joystick_GetForward() > 0.0f || ::input->Joystick_GetPitch() > 0.0f || vgui::input()->IsKeyDown( KEY_XBUTTON_DOWN ) || vgui::input()->IsKeyDown( KEY_DOWN ) || vgui::input()->IsKeyDown( STEAMCONTROLLER_DPAD_DOWN );
@@ -1496,7 +1496,16 @@ void CHudUpgradePanel::UpdateMouseOverHighlight( void )
 
 	int x, y;
 	m_pActiveUpgradeBuyPanel->GetPos( x, y );
-	m_pMouseOverUpgradePanel->SetPos( x - YRES( 1 ), y - YRES( 1 ) );
+	// hide the box so that it doesn't appear over the weapon icon for 1 frame
+	if ( x == 0 && y == 0 )
+	{
+		m_pMouseOverUpgradePanel->SetVisible( false );
+	}
+	else
+	{
+		m_pMouseOverUpgradePanel->SetVisible( true );
+		m_pMouseOverUpgradePanel->SetPos( x - YRES( 1 ), y - YRES( 1 ) );
+	}
 
 	CMannVsMachineUpgrades *pUpgrade = &(g_MannVsMachineUpgrades.m_Upgrades[ m_pActiveUpgradeBuyPanel->m_nUpgradeIndex ]);
 	CEconItemAttributeDefinition *pAttribDef = ItemSystem()->GetStaticDataForAttributeByName( pUpgrade->szAttrib );


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
The upgrade station menu has partial support for controllers, only for Accept, Back and Done. This adds support for viewing upgrades, changing weapon pages and the Refund button.


https://github.com/user-attachments/assets/bc99e511-eca0-4a03-a22c-93cc71ac174f

Sadly, this doesn't seem to work with commands but by binding to gamepad buttons ~and gamepad must be enabled in the options (no -nojoy too)~, which isn't ideal. I could do a better implementation if Valve releases inputsystem to the sdk.

<img width="1280" height="800" alt="imagen" src="https://github.com/user-attachments/assets/198e44a7-c31e-46cd-b244-44a029638ea8" />
