### PR TITLE
[TF2] Make tf_scoreboard_mouse_mode 2 activate the mouse cursor only with right-click

### DIFF
--- a/src/game/client/tf/vgui/tf_clientscoreboard.cpp
+++ b/src/game/client/tf/vgui/tf_clientscoreboard.cpp
@@ -2325,7 +2325,7 @@ int	CTFClientScoreBoardDialog::HudElementKeyInput( int down, ButtonCode_t keynum
 
 	if ( tf_scoreboard_mouse_mode.GetInt() == 2 )
 	{
-		if ( !m_bMouseActivated && ( keynum == MOUSE_LEFT || keynum == MOUSE_RIGHT ) )
+		if ( !m_bMouseActivated && ( keynum == MOUSE_RIGHT ) )
 		{
 			m_bMouseActivated = true;
 			InitializeInputScheme();


### PR DESCRIPTION
I messed up -- I accidentally closed the previous [pull request](https://github.com/ValveSoftware/source-sdk-2013/pull/874) for the same issue just because I updated the branch, and I only just realized it.
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Original Description
### Fixes this [issue](https://github.com/ValveSoftware/Source-1-Games/issues/6342).
As the title says, this makes the `tf_scoreboard_mouse_mode 2` command activate the mouse cursor only with right-click, just like in CS2.