### PR TITLE
[TF2] Fix Joining a new lobby while being revived locks up the camera

### DIFF
--- a/src/game/client/econ/confirm_dialog.cpp
+++ b/src/game/client/econ/confirm_dialog.cpp
@@ -795,7 +795,6 @@ CTFReviveDialog::CTFReviveDialog( const char *pTitle, const char *pText, const c
 	m_pTargetHealth->HideHealthBonusImage();
 	
 	vgui::ivgui()->AddTickSignal( GetVPanel(), 50 );
-	OnTick();
 }
 
 //-----------------------------------------------------------------------------
@@ -813,12 +812,15 @@ void CTFReviveDialog::OnTick()
 {
 	BaseClass::OnTick();
 
-	if ( !m_pTargetHealth )
+	if (!m_hEntity)
+	{
+		FinishUp();
 		return;
+	}
 
-	if ( !m_hEntity )
+	if (!m_pTargetHealth)
 		return;
-
+	
 	float flHealth = m_hEntity->GetHealth();
 	if ( flHealth != m_flPrevHealth )
 	{


### PR DESCRIPTION
### Bug

In Mann Vs. Machine, if you join a new lobby while being revived by a medic, the "Being revived" box will remain upon entering the new lobby. In some cases this causes the mouse to be unlocked and doesn't allow you to move your camera, the box cannot be closed either.

This PR also closes [#6221](https://github.com/ValveSoftware/Source-1-Games/issues/6221)

### Media

Video demonstrating the bug:

https://github.com/user-attachments/assets/919ad5ea-11a3-4d97-8821-5c03937755c9

Video demonstrating the fix:

https://github.com/user-attachments/assets/f8a71281-0781-4b67-90b4-91149206da7f