### PR TITLE
[TF2] Improve the random class selection algorithm to reduce the chance of failure

### DIFF
--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -6868,20 +6868,29 @@ void CTFPlayer::HandleCommand_JoinClass( const char *pClassName, bool bAllowSpaw
 	}
 	else
 	{
-		int iTries = 20;
-		// The player has selected Random class...so let's pick one for them.
-		do{
-			// Don't let them be the same class twice in a row
-			iClass = random->RandomInt( TF_FIRST_NORMAL_CLASS, TF_LAST_NORMAL_CLASS - 1 ); // -1 to remove the civilian from the randomness
-			iTries--;
-		} while( iClass == GetPlayerClass()->GetClassIndex() || (iTries > 0 && !TFGameRules()->CanPlayerChooseClass(this,iClass)) );
+		int iChoices = 0;
+		int iClasses[TF_LAST_NORMAL_CLASS - 1] = {}; // -1 to remove the civilian from the randomness
+		int iCurrentClass = GetPlayerClass()->GetClassIndex();
 
-		if ( iTries <= 0 )
+		for ( iClass = TF_FIRST_NORMAL_CLASS; iClass < TF_LAST_NORMAL_CLASS; iClass++ )
 		{
+			if ( iClass != iCurrentClass && TFGameRules()->CanPlayerChooseClass( this, iClass ) )
+			{
+				iClasses[iChoices++] = iClass;
+			}
+		}
+
+		if ( !iChoices )
+		{
+			if ( TFGameRules()->CanPlayerChooseClass( this, iCurrentClass ) )
+				return;
+
 			// We failed to find a random class. Bring up the class menu again.
 			ShowViewPortPanel( ( GetTeamNumber() == TF_TEAM_RED ) ? PANEL_CLASS_RED : PANEL_CLASS_BLUE );
 			return;
 		}
+
+		iClass = iClasses[random->RandomInt( 0, iChoices - 1 )];
 	}
 
 	if ( TFGameRules() && TFGameRules()->State_Get() == GR_STATE_RND_RUNNING )


### PR DESCRIPTION
# Description

When picking a random class, the game requires that the randomly chosen class meets the following criteria:
- The class isn't your current class
- The class is able to be chosen after checking for gamerules such as tournament mode class limits

Currently, when you choose the random button on the class select menu, the game rolls the dice upwards of **20 times** and compares the randomly chosen class to the criteria above on each roll. In the unlikely event that this algorithm fails to find a valid class, the player will be shown the class select menu again. It's possible for this algorithm to fail even when there are valid classes to randomly choose from. This algorithm fails the most when strict class limits are involved on a full server.

This PR reworks the random class selection algorithm to form a list of valid classes before rolling for a valid class from the list. If the only class available is your current class, then it won't redisplay the menu unnecessarily. If there are two classes available and you are already one of them, the random button will always choose the other available class when rolling the dice. The only case where the class select menu will redisplay (to my knowledge) is when every class's limit is full, in which case there's a problem with the server's configuration.

This video showcases a before and after of what happens when the algorithm fails to pick a valid class despite your current class being the only one available. This also happens when the old algorithm picks invalid classes **20** times.

https://github.com/user-attachments/assets/73731726-ab48-4155-b7e3-1979026507b3

