### PR TITLE
[TF2] Fix jump start animation not working when the player has increased jump height

### DIFF
--- a/src/game/shared/tf/tf_playeranimstate.cpp
+++ b/src/game/shared/tf/tf_playeranimstate.cpp
@@ -1453,6 +1453,11 @@ bool CTFPlayerAnimState::HandleJumping( Activity &idealActivity )
 		{
 			CALL_ATTRIB_HOOK_FLOAT_ON_OTHER( pWpn, flJumpMod, mod_jump_height_from_weapon );
 		}
+
+		if ( m_pTFPlayer->m_Shared.GetCarryingRuneType() == RUNE_AGILITY )
+		{
+			flJumpMod *= 1.8f;
+		}
 	}
 
 	if ( bValidAirWalkClass && ( vecVelocity.z > 300.0f * flJumpMod || m_bInAirWalk || m_pTFPlayer->GetGrapplingHookTarget() != NULL ) && !bInDuck )


### PR DESCRIPTION
Under normal circumstances, when a player jumps from the ground, they will play a short hopping animation (ACT_MP_JUMP_START). However, if the player has enough of a jump height boost from any source, such as attributes or the Mannpower agility rune, the jump start animation will not play, and instead it will play the airwalking animation (ACT_MP_AIRWALK). This is because the airwalk animation begins playing when the player's Z velocity goes above 300. Jump height boosts increase the player's jump height by multiplying the Z velocity boost from jumping, which is what causes the airwalk animation to play instead of the jump start animation. I've fixed this issue by making sure that the Z velocity check of 300 for the airwalk animation takes jump height boosts into account.

## Before Fix
https://github.com/user-attachments/assets/f3c5d56c-fcd9-47da-824a-5f89b4f6d800

## After Fix

https://github.com/user-attachments/assets/fdcb7693-5a89-43b3-8332-f1bb7e577218

