### PR TITLE
tf: Network player's handedness preference to spectators

### DIFF
--- a/src/game/client/c_baseviewmodel.cpp
+++ b/src/game/client/c_baseviewmodel.cpp
@@ -19,6 +19,7 @@
 #include <KeyValues.h>
 #include "hltvcamera.h"
 #ifdef TF_CLIENT_DLL
+	#include "c_tf_player.h"
 	#include "tf_weaponbase.h"
 #endif
 
@@ -91,6 +92,24 @@ void FormatViewModelAttachment( Vector &vOrigin, bool bInverse )
 	vOrigin = pViewSetup->origin + vOut;
 }
 
+#ifdef TF_CLIENT_DLL
+bool TeamFortress_ShouldFlipClientViewModel( void )
+{
+	bool bFlipViewModels = cl_flipviewmodels.GetBool();
+	
+	if ( IsLocalPlayerSpectator() )
+	{
+		// Use spectated client's handedness preference
+		C_TFPlayer *pSpecTarget = ToTFPlayer( UTIL_PlayerByIndex( GetSpectatorTarget() ) );
+		if ( pSpecTarget )
+		{
+			bFlipViewModels = pSpecTarget->m_bFlipViewModels;
+		}
+	}
+
+	return bFlipViewModels;
+}
+#endif //TF_CLIENT_DLL
 
 void C_BaseViewModel::FormatViewModelAttachment( int nAttachment, matrix3x4_t &attachmentToWorld )
 {
@@ -211,7 +230,7 @@ bool C_BaseViewModel::ShouldFlipViewModel()
 	CBaseCombatWeapon *pWeapon = m_hWeapon.Get();
 	if ( pWeapon )
 	{
-		return pWeapon->m_bFlipViewModel != cl_flipviewmodels.GetBool();
+		return pWeapon->m_bFlipViewModel != TeamFortress_ShouldFlipClientViewModel();
 	}
 #endif
 

--- a/src/game/client/c_baseviewmodel.h
+++ b/src/game/client/c_baseviewmodel.h
@@ -16,4 +16,8 @@
 #include "utlvector.h"
 #include "baseviewmodel_shared.h"
 
+#ifdef TF_CLIENT_DLL
+bool TeamFortress_ShouldFlipClientViewModel( void );
+#endif //TF_CLIENT_DLL
+
 #endif // C_BASEVIEWMODEL_H

--- a/src/game/client/tf/c_tf_player.cpp
+++ b/src/game/client/tf/c_tf_player.cpp
@@ -3727,6 +3727,7 @@ IMPLEMENT_CLIENTCLASS_DT( C_TFPlayer, DT_TFPlayer, CTFPlayer )
 	RecvPropFloat( RECVINFO( m_flMvMLastDamageTime ) ),
 	RecvPropFloat( RECVINFO_NAME( m_flMvMLastDamageTime, "m_flLastDamageTime" ) ), // Renamed
 	RecvPropInt( RECVINFO( m_iSpawnCounter ) ),
+	RecvPropBool( RECVINFO( m_bFlipViewModels ) ),
 	RecvPropBool( RECVINFO( m_bArenaSpectator ) ),
 
 	RecvPropDataTable( RECVINFO_DT( m_AttributeManager ), 0, &REFERENCE_RECV_TABLE(DT_AttributeManager) ),

--- a/src/game/client/tf/c_tf_player.h
+++ b/src/game/client/tf/c_tf_player.h
@@ -662,6 +662,8 @@ public:
 	int				m_iSpawnCounter;
 	bool			m_bArenaSpectator;
 
+	bool			m_bFlipViewModels;
+
 	bool			m_bIsMiniBoss;
 	bool			m_bIsABot;
 	int				m_nBotSkill;

--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -815,6 +815,7 @@ IMPLEMENT_SERVERCLASS_ST( CTFPlayer, DT_TFPlayer )
 
 	SendPropFloat( SENDINFO( m_flMvMLastDamageTime ), 16, SPROP_ROUNDUP ),
 	SendPropInt( SENDINFO( m_iSpawnCounter ) ),
+	SendPropBool( SENDINFO( m_bFlipViewModels ) ),
 	SendPropBool( SENDINFO( m_bArenaSpectator ) ),
 	SendPropFloat( SENDINFO( m_flHeadScale ) ),
 	SendPropFloat( SENDINFO( m_flTorsoScale ) ),

--- a/src/game/server/tf/tf_player.h
+++ b/src/game/server/tf/tf_player.h
@@ -982,7 +982,7 @@ public:
 
 	int					m_iOldStunFlags;
 
-	bool				m_bFlipViewModels;
+	CNetworkVar( bool, m_bFlipViewModels );
 	int					m_iBlastJumpState;
 	float				m_flBlastJumpLandTime;
 	bool				m_bTakenBlastDamageSinceLastMovement;

--- a/src/game/shared/econ/econ_entity.cpp
+++ b/src/game/shared/econ/econ_entity.cpp
@@ -20,6 +20,7 @@
 
 #if defined(TF_CLIENT_DLL)
 #include "c_tf_player.h"
+#include "c_baseviewmodel.h"
 #include "tf_gamerules.h"
 #include "c_playerresource.h"
 #include "tf_shareddefs.h"
@@ -91,9 +92,6 @@ BEGIN_ENT_SCRIPTDESC( CEconEntity, CBaseAnimating, "Econ Entity" )
 END_SCRIPTDESC();
 #endif
 
-#ifdef TF_CLIENT_DLL
-extern ConVar cl_flipviewmodels;
-#endif
 
 
 #ifdef CLIENT_DLL
@@ -857,7 +855,7 @@ int C_ViewmodelAttachmentModel::InternalDrawModel( int flags )
 {
 #ifdef TF_CLIENT_DLL
 	CMatRenderContextPtr pRenderContext( materials );
-	if ( cl_flipviewmodels.GetBool() != m_bAlwaysFlip )
+	if ( TeamFortress_ShouldFlipClientViewModel() != m_bAlwaysFlip )
 	{
 		pRenderContext->CullMode( MATERIAL_CULLMODE_CW );
 	}

--- a/src/game/shared/tf/tf_weaponbase.cpp
+++ b/src/game/shared/tf/tf_weaponbase.cpp
@@ -48,6 +48,7 @@
 // Client specific.
 #else
 #include "c_tf_player.h"
+#include "c_baseviewmodel.h"
 #include "tf_viewmodel.h"
 #include "hud_crosshair.h"
 #include "c_tf_playerresource.h"
@@ -91,7 +92,6 @@ extern ConVar tf_weapon_criticals_bucket_bottom;
 
 #ifdef CLIENT_DLL
 extern ConVar cl_crosshair_file;
-extern ConVar cl_flipviewmodels;
 #endif
 
 //=============================================================================
@@ -5593,7 +5593,7 @@ bool CTFWeaponBase::IsViewModelFlipped( void )
 		return true;
 	}
 #else
-	if ( m_bFlipViewModel != cl_flipviewmodels.GetBool() )
+	if ( m_bFlipViewModel != TeamFortress_ShouldFlipClientViewModel() )
 	{
 		return true;
 	}
@@ -6774,7 +6774,7 @@ void CTFWeaponBase::AddStatTrakModel( CEconItemView *pItem, int nStatTrakType, A
 				pStatTrakEnt->m_nSkin = nSkin;
 				m_viewmodelStatTrakAddon = pStatTrakEnt;
 				
-				if ( cl_flipviewmodels.GetBool() )
+				if ( IsViewModelFlipped() )
 				{
 					pStatTrakEnt->SetBodygroup( 1, 1 ); // use a special mirror-image stattrak module that appears correct for lefties
 					flScale *= -1.0f;					// flip scale


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
Flipping your viewmodel's position changes where projectiles are shot from, which can look silly from the perspective of a spectator with different settings. This PR makes spectators see the same viewmodel orientation as you by sending them the whether you use flipped viewmodels flag that the server already stores.

Before:

[tf_networked_handedness_preference_before.webm](https://github.com/user-attachments/assets/025dd43b-3a01-452c-ade3-e290fca53006)

After:

[tf_networked_handedness_preference_after.webm](https://github.com/user-attachments/assets/1bbfae10-11d1-46c3-a839-f261cbc8cf36)
