### PR TITLE
[TF2] Treat being in background map as not in-game

### DIFF
--- a/src/game/client/tf/tf_hud_mainmenuoverride.cpp
+++ b/src/game/client/tf/tf_hud_mainmenuoverride.cpp
@@ -963,7 +963,7 @@ void CHudMainMenuOverride::OnUpdateMenu( void )
 	// So try and do the least amount of work if nothing has changed.
 
 	bool bSomethingChanged = false;
-	bool bInGame = engine->IsInGame();
+	bool bInGame = engine->IsInGame() && !engine->IsLevelMainMenuBackground();
 #if defined( REPLAY_ENABLED )
 	bool bInReplay = g_pEngineClientReplay->IsPlayingReplayDemo();
 #else

--- a/src/game/client/tf/vgui/tf_matchmaking_dashboard.cpp
+++ b/src/game/client/tf/vgui/tf_matchmaking_dashboard.cpp
@@ -388,7 +388,7 @@ void CTFMatchmakingDashboard::OnCommand( const char *command )
 	}
 	else if ( FStrEq( command, "quit" ) )
 	{
-		if ( engine->IsInGame() )
+		if ( engine->IsInGame() && !engine->IsLevelMainMenuBackground() )
 		{
 			PromptOrFireCommand( "disconnect" );
 		}


### PR DESCRIPTION
# Description
This PR makes it so that being in a Background Map doesn't count as being in-game for the main menu.
This means the call vote, mute players, request coach and report players buttons won't appear and the disconnect button will be there instead be the quit game button.

The player can still type `disconnect` in console to leave the background map as usual.