### PR TITLE
[TF2] Hide intel upgrade hud when no intel is enabled

### DIFF
--- a/src/game/client/tf/tf_hud_mann_vs_machine_status.cpp
+++ b/src/game/client/tf/tf_hud_mann_vs_machine_status.cpp
@@ -1982,7 +1982,20 @@ void CTFHudMannVsMachineStatus::ReopenVictoryPanel( void )
 //-----------------------------------------------------------------------------
 void CTFHudMannVsMachineStatus::UpdateBombCarrierProgress ( void )
 {
-	m_pUpgradeLevelContainer->SetVisible( TFGameRules()->State_Get() == GR_STATE_RND_RUNNING );
+	bool bEnabledFlags = false;
+
+	for ( int i=0; i<ICaptureFlagAutoList::AutoList().Count(); ++i )
+	{
+		CCaptureFlag *pFlag = static_cast<CCaptureFlag *>( ICaptureFlagAutoList::AutoList()[i] );
+
+		if ( pFlag && !pFlag->IsDisabled() )
+		{
+			bEnabledFlags = true;
+			break;
+		}
+	}
+
+	m_pUpgradeLevelContainer->SetVisible( bEnabledFlags && ( TFGameRules()->State_Get() == GR_STATE_RND_RUNNING ) );
 
 	if ( !m_pUpgradeLevel1 || !m_pUpgradeLevel2 || !m_pUpgradeLevel3 || !m_pUpgradeLevelBoss )
 		return;


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description

Disable drawing intel upgrade hud when there are no enabled intels. So don't draw this broken state:

<img width="579" height="426" alt="kuva" src="https://github.com/user-attachments/assets/f68ee5cd-1783-43f5-b0e5-b5cef0166c9e" />
