### PR TITLE
tf: Fix halloween spell projectiles not adjusting to flipped viewmodels

### DIFF
--- a/src/game/shared/tf/halloween/tf_weapon_spellbook.cpp
+++ b/src/game/shared/tf/halloween/tf_weapon_spellbook.cpp
@@ -939,14 +939,14 @@ void CTFSpellBook::TossJarThink( void )
 	Vector vecForward, vecRight, vecUp;
 	AngleVectors( pPlayer->EyeAngles(), &vecForward, &vecRight, &vecUp );
 
-	float fRight = 8.f;
+	float fRight = 7.f;
 	if ( IsViewModelFlipped() )
 	{
 		fRight *= -1;
 	}
 	Vector vecSrc = pPlayer->Weapon_ShootPosition();
 	// Make spell toss position at the hand
-	vecSrc = vecSrc + (vecUp * -9.0f) + (vecRight * 7.0f) + (vecForward * 3.0f);
+	vecSrc = vecSrc + (vecUp * -9.0f) + (vecRight * fRight) + (vecForward * 3.0f);
 
 	Vector vecVelocity = GetVelocityVector( vecForward, vecRight, vecUp ) * pSpellData->m_flSpeedScale;
 	QAngle angForward = pPlayer->EyeAngles();


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
This PR fixes the spell projectile's right offset not being applied to the spell origin calculation (instead it was hard-coded to always be `+ 7.f`), which caused the caster's flipped viewmodels setting (that should invert the firing offset) to be ignored.

Before:

[tf_halloween_spell_flip_projectiles_before.webm](https://github.com/user-attachments/assets/11b002b1-cc0b-4f82-8a4a-d6540e7b52a6)

After:

[tf_halloween_spell_flip_projectiles_after.webm](https://github.com/user-attachments/assets/b3402f65-40cd-4a56-bef5-9e61545ac09c)

Closes https://github.com/ValveSoftware/Source-1-Games/issues/4411