### PR TITLE
Fix point_camera transmit state in multiplayer

### DIFF
--- a/src/game/server/info_camera_link.cpp
+++ b/src/game/server/info_camera_link.cpp
@@ -145,9 +145,11 @@ CBaseEntity *CreateInfoCameraLink( CBaseEntity *pTarget, CPointCamera *pCamera )
 //-----------------------------------------------------------------------------
 void PointCameraSetupVisibility( CBaseEntity *pPlayer, int area, unsigned char *pvs, int pvssize )
 {
+	int nPlayerIndex = pPlayer->entindex();
+
 	for ( CPointCamera *pCameraEnt = GetPointCameraList(); pCameraEnt != NULL; pCameraEnt = pCameraEnt->m_pNext )
 	{
-		pCameraEnt->SetActive( false );
+		pCameraEnt->TransmitToPlayer( nPlayerIndex, false );
 	}
 	
 	intp nNext;
@@ -175,7 +177,7 @@ void PointCameraSetupVisibility( CBaseEntity *pPlayer, int area, unsigned char *
 			if ( pCameraEnt )
 			{
 				engine->AddOriginToPVS( pCameraEnt->GetAbsOrigin() );
-				pCameraEnt->SetActive( true );
+				pCameraEnt->TransmitToPlayer( nPlayerIndex, true );
 			}
 		}
 	}

--- a/src/game/server/point_camera.h
+++ b/src/game/server/point_camera.h
@@ -29,7 +29,9 @@ public:
 
 	// Tell the client that this camera needs to be rendered
 	void SetActive( bool bActive );
-	int  UpdateTransmitState(void);
+	int  ShouldTransmit( const CCheckTransmitInfo* pInfo );
+	int  UpdateTransmitState( void );
+	void TransmitToPlayer( int nPlayerIndex, bool bTransmit );
 
 	void ChangeFOVThink( void );
 
@@ -55,6 +57,8 @@ private:
 
 	// Allows the mapmaker to control whether a camera is active or not
 	bool	m_bIsOn;
+
+	CBitVec< MAX_PLAYERS > m_bitsTransmitPlayers;
 
 public:
 	CPointCamera	*m_pNext;


### PR DESCRIPTION
The newly-added map `koth_boardwalk` features "mirrors" in the map, which is an effect created with the `point_camera` entity
However, in populated servers this doesn't work quite right. The mirrors will sometimes display fine, other times it will be skipping frames, and sometimes it won't refresh at all.

This is caused by an oversight in the visibility code for point_camera. The intention is to only transmit the camera to players who are in PVS of either the camera or its link, but this visibility state is calculated before the engine runs transmit checks for players. and there is only one visibility state. When the engine runs the transmit checks for all players later, it will use this singular visibility state and it's value will be whatever was calculated for the *last* player that joined the server, making it inconsistent for everyone else.

This PR fixes that by storing a visibility state for all players and using that in the transmit checks, so now the engine will correctly transmit on a per-player basis.

Tested with 23 bots with `sv_stressbots 1` (which enables networking to bots) on koth_boardwalk

Before:

<img width="1202" height="764" alt="image" src="https://github.com/user-attachments/assets/631dbd19-95a0-405d-93aa-7b6c129d6d0b" />

After:

<img width="1224" height="769" alt="image" src="https://github.com/user-attachments/assets/aed1097e-0b7c-4261-90c7-61ca6804a5b9" />

