### PR TITLE
Freezecam mat_viewportscale fix

### DIFF
--- a/src/game/client/viewrender.cpp
+++ b/src/game/client/viewrender.cpp
@@ -5200,6 +5200,12 @@ void CFreezeFrameView::Draw( void )
 	pRenderContext->PushVertexShaderGPRAllocation( 16 ); //max out pixel shader threads
 #endif
 
+	if ( mat_viewportupscale.GetBool() && mat_viewportscale.GetFloat() < 1.0f )
+	{
+		// mat_viewportscale breaks it without that
+		vgui::surface()->GetScreenSize(width, height);
+	}
+
 	// we might only need half of the texture if we're rendering in stereo
 	int nTexX0 = 0, nTexY0 = 0;
 	int nTexX1 = width, nTexY1 = height;


### PR DESCRIPTION
# Description
When you change mat_viewportscale on something lower then 1 freezecam doesnt map on screen correctly.

Ive made a fix/hack that helps preventing it to happen. But i think i can be done better then that.

Thats how it looks before and after a fix/hack:
<img width="1920" height="1080" alt="изображение" src="https://github.com/user-attachments/assets/923ccb91-fcab-4549-80ac-8d4663a1106c" />

<img width="1920" height="1080" alt="изображение" src="https://github.com/user-attachments/assets/bf24ff63-1cc9-450b-99af-cd3b16dcbc82" />
