### PR TITLE
Fix Vaccinator resist icons persisting when a player changes (displayed) team

### DIFF
--- a/src/game/shared/tf/tf_player_shared.cpp
+++ b/src/game/shared/tf/tf_player_shared.cpp
@@ -4768,14 +4768,8 @@ static void RemoveResistParticle( CTFPlayer* pPlayer, medigun_resist_types_t nRe
 	if ( bKeep )
 		return;
 	
-	if ( pPlayer->m_Shared.GetDisplayedTeam() == TF_TEAM_RED )
-	{
-		pPlayer->RemoveOverheadEffect( s_pszRedResistOverheadEffectName[ nResistType ], true );
-	}
-	else
-	{
-		pPlayer->RemoveOverheadEffect( s_pszBlueResistOverheadEffectName[ nResistType ], true );
-	}
+	pPlayer->RemoveOverheadEffect( s_pszRedResistOverheadEffectName[ nResistType ], true );
+	pPlayer->RemoveOverheadEffect( s_pszBlueResistOverheadEffectName[ nResistType ], true );
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Whenever a player gains or loses Vaccinator resist conds, the client adds/removes a team-colored icon above their head corresponding to the resistance they have. However, if a player loses a resist cond *and* changes their displayed team on the same frame (such as when [a disguised enemy spy being healed by a friendly Vaccinator medic undisguises](https://www.youtube.com/watch?v=BiPUtnrYSpY), or when someone actually switches teams while being healed by the Vaccinator, manually or via round end team swap), the game only removes the icon corresponding to the team they just changed to, not the icon for the previous team, which is the one they actually have, so the icon stays above their head, and persists even through deaths (and gives away cloaked spies' positions).

Fixed by simply removing the icons for both teams whenever a player loses the relevant cond, instead of only the icon for their current displayed team.

Fixes https://github.com/ValveSoftware/Source-1-Games/issues/2334, fixes https://github.com/ValveSoftware/Source-1-Games/issues/3941