### PR TITLE
[TF] Fixed Ullapool Caber explosions not counting as melee kills and ignoring damage/radius attributes.

### DIFF
--- a/src/game/shared/tf/tf_weapon_bottle.cpp
+++ b/src/game/shared/tf/tf_weapon_bottle.cpp
@@ -254,12 +254,19 @@ void CTFStickBomb::Smack( void )
 
 			TE_TFExplosion( filter, 0.0f, explosion, Vector(0,0,1), TF_WEAPON_GRENADELAUNCHER, pTFPlayer->entindex(), -1, SPECIAL1, iCustomParticleIndex );
 
-			int dmgType = DMG_BLAST | DMG_USEDISTANCEMOD;
+			int dmgType = DMG_BLAST | DMG_USEDISTANCEMOD | DMG_MELEE;
 			if ( IsCurrentAttackACrit() )
 				dmgType |= DMG_CRITICAL;
+			
+			float flDamage = 75.0f;
+			CALL_ATTRIB_HOOK_FLOAT( flDamage, mult_dmg );
 
-			CTakeDamageInfo info( pTFPlayer, pTFPlayer, this, explosion, explosion, 75.0f, dmgType, TF_DMG_CUSTOM_STICKBOMB_EXPLOSION, &explosion );
-			CTFRadiusDamageInfo radiusinfo( &info, explosion, 100.f );
+			CTakeDamageInfo info( pTFPlayer, pTFPlayer, this, explosion, explosion, flDamage, dmgType, TF_DMG_CUSTOM_STICKBOMB_EXPLOSION, &explosion );
+			
+			float flRadius = 100.f;
+			CALL_ATTRIB_HOOK_FLOAT( flRadius, mult_explosion_radius );
+			
+			CTFRadiusDamageInfo radiusinfo( &info, explosion, flRadius );
 			TFGameRules()->RadiusDamage( radiusinfo );
 		}
 #endif


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
This PR adds 2 fixes for the Ullapool Caber:

- Fixed the Ullapool Caber's explosion not being counted as melee damage (for kill_refills_meter)
- Fixed the Ullapool Caber's explosion ignoring mult_dmg and mult_explosion_radius attributes

This PR does NOT fix the Ullapool Caber's mini-crit bug. That's already handled by #1120.