### PR TITLE
[TF] Fix a bug where TFBot Heavies continuously use lunchboxes while at spawn.

### DIFF
--- a/src/game/server/tf/bot/behavior/tf_bot_use_item.cpp
+++ b/src/game/server/tf/bot/behavior/tf_bot_use_item.cpp
@@ -51,6 +51,10 @@ ActionResult< CTFBot >	CTFBotUseItem::Update( CTFBot *me, float interval )
 			me->PressFireButton();
 			m_cooldownTimer.Start( m_item->m_flNextPrimaryAttack - gpGlobals->curtime + 0.25f );
 		}
+		else
+		{
+			return Done( "Can't use our item at the moment" );
+		}
 	}
 	else // used
 	{

--- a/src/game/server/tf/bot/behavior/tf_bot_use_item.cpp
+++ b/src/game/server/tf/bot/behavior/tf_bot_use_item.cpp
@@ -49,7 +49,7 @@ ActionResult< CTFBot >	CTFBotUseItem::Update( CTFBot *me, float interval )
 		{
 			// use it
 			me->PressFireButton();
-			m_cooldownTimer.Invalidate();
+			m_cooldownTimer.Start( m_item->m_flNextPrimaryAttack - gpGlobals->curtime + 0.25f );
 		}
 	}
 	else // used

--- a/src/game/server/tf/bot/tf_bot.cpp
+++ b/src/game/server/tf/bot/tf_bot.cpp
@@ -4591,13 +4591,9 @@ Action< CTFBot > *CTFBot::OpportunisticallyUseWeaponAbilities( void )
 			if ( lunchbox->HasAmmo() )
 			{
 				// scout lunchboxes are also gated by their energy drink meter
-				if ( !IsPlayerClass( TF_CLASS_SCOUT ) || m_Shared.GetScoutEnergyDrinkMeter() >= 100 )
+				CTFLunchBox_Drink* lunchboxDrink = (CTFLunchBox_Drink*)lunchbox;
+				if ( ( !IsPlayerClass( TF_CLASS_SCOUT ) && GetHealth() < GetMaxHealth() ) || ( lunchboxDrink && m_Shared.GetScoutEnergyDrinkMeter() >= 100 ) )
 				{
-					return new CTFBotUseItem( lunchbox );
-				}
-				else if ( GetHealth() < GetMaxHealth() )
-				{
-					// we're a sandvich
 					return new CTFBotUseItem( lunchbox );
 				}
 			}

--- a/src/game/server/tf/bot/tf_bot.cpp
+++ b/src/game/server/tf/bot/tf_bot.cpp
@@ -4590,9 +4590,7 @@ Action< CTFBot > *CTFBot::OpportunisticallyUseWeaponAbilities( void )
 			CTFLunchBox *lunchbox = (CTFLunchBox *)weapon;
 			if ( lunchbox->HasAmmo() )
 			{
-				// scout lunchboxes are also gated by their energy drink meter
-				CTFLunchBox_Drink *lunchboxDrink = (CTFLunchBox_Drink *)lunchbox;
-				if ( ( !IsPlayerClass( TF_CLASS_SCOUT ) && GetHealth() < GetMaxHealth() ) || ( lunchboxDrink && m_Shared.GetScoutEnergyDrinkMeter() >= 100 ) )
+				if ( !IsPlayerClass( TF_CLASS_SCOUT ) || m_Shared.GetScoutEnergyDrinkMeter() >= 100 )
 				{
 					return new CTFBotUseItem( lunchbox );
 				}

--- a/src/game/server/tf/bot/tf_bot.cpp
+++ b/src/game/server/tf/bot/tf_bot.cpp
@@ -4591,7 +4591,7 @@ Action< CTFBot > *CTFBot::OpportunisticallyUseWeaponAbilities( void )
 			if ( lunchbox->HasAmmo() )
 			{
 				// scout lunchboxes are also gated by their energy drink meter
-				CTFLunchBox_Drink* lunchboxDrink = (CTFLunchBox_Drink*)lunchbox;
+				CTFLunchBox_Drink *lunchboxDrink = (CTFLunchBox_Drink *)lunchbox;
 				if ( ( !IsPlayerClass( TF_CLASS_SCOUT ) && GetHealth() < GetMaxHealth() ) || ( lunchboxDrink && m_Shared.GetScoutEnergyDrinkMeter() >= 100 ) )
 				{
 					return new CTFBotUseItem( lunchbox );

--- a/src/game/server/tf/bot/tf_bot.cpp
+++ b/src/game/server/tf/bot/tf_bot.cpp
@@ -4595,6 +4595,11 @@ Action< CTFBot > *CTFBot::OpportunisticallyUseWeaponAbilities( void )
 				{
 					return new CTFBotUseItem( lunchbox );
 				}
+				else if ( GetHealth() < GetMaxHealth() )
+				{
+					// we're a sandvich
+					return new CTFBotUseItem( lunchbox );
+				}
 			}
 		}
 		else if ( weapon->GetWeaponID() == TF_WEAPON_BAT_WOOD )


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
This PR fixes a bug where Bots that are assigned the Sandvich (or any other Heavy lunchbox) will continuously eat their Sandvich in spawn until they're damaged or are distracted by an enemy. This is because TFBots lack anything that checks their health before consuming. This also adds a slight sanity check for drinks to make sure the m_Shared.GetScoutEnergyDrinkMeter() check works properly for Scout.