### PR TITLE
[TF] Allow TFBots to use the Shortstop's shove

### DIFF
--- a/src/game/server/tf/bot/behavior/tf_bot_behavior.cpp
+++ b/src/game/server/tf/bot/behavior/tf_bot_behavior.cpp
@@ -16,6 +16,7 @@
 #include "tf_weapon_flamethrower.h"
 #include "tf_weapon_sniperrifle.h"
 #include "tf_weapon_compound_bow.h"
+#include "tf_weapon_pistol.h"
 #include "bot/tf_bot.h"
 #include "bot/tf_bot_manager.h"
 #include "bot/behavior/tf_bot_behavior.h"
@@ -1365,6 +1366,18 @@ void CTFBotMainAction::FireWeaponAtEnemy( CTFBot *me )
 				  me->IsDistanceBetweenLessThan( threat->GetEntity(), me->GetMaxAttackRange() ) )
 		{
 			me->PressFireButton( tf_bot_fire_weapon_min_time.GetFloat() );
+		}
+
+		return;
+	}
+	else if ( myWeapon->IsWeapon( TF_WEAPON_HANDGUN_SCOUT_PRIMARY ) )
+	{
+		CTFPistol_ScoutPrimary *pPistolPrimary = assert_cast<CTFPistol_ScoutPrimary*>( myWeapon );
+		// watch for enemy projectiles heading our way
+		if ( pPistolPrimary->CanUsePush() && me->ShouldFireCompressionBlast() )
+		{
+			// bounce missiles with compression blast
+			me->PressAltFireButton();
 		}
 
 		return;

--- a/src/game/server/tf/bot/tf_bot.cpp
+++ b/src/game/server/tf/bot/tf_bot.cpp
@@ -4145,6 +4145,10 @@ bool CTFBot::ShouldFireCompressionBlast( void )
 		}
 	}
 
+	// if we use the shortstop, we shouldn't try to push enemy projectiles here.
+	CTFWeaponBase *myWeapon = m_Shared.GetActiveTFWeapon();
+	if ( myWeapon->IsWeapon( TF_WEAPON_HANDGUN_SCOUT_PRIMARY ) )
+		return false;
 
 	Vector vecEye = EyePosition();
 	Vector vecForward, vecRight, vecUp;

--- a/src/game/shared/tf/tf_weapon_pistol.cpp
+++ b/src/game/shared/tf/tf_weapon_pistol.cpp
@@ -196,6 +196,11 @@ void CTFPistol_ScoutPrimary::Push( void )
 #endif
 }
 
+bool CTFPistol_ScoutPrimary::CanUsePush()
+{
+	return ( m_flPushTime > -1.f && gpGlobals->curtime > m_flPushTime );
+}
+
 //-----------------------------------------------------------------------------
 // Purpose: 
 // Input  :  - 
@@ -203,7 +208,7 @@ void CTFPistol_ScoutPrimary::Push( void )
 void CTFPistol_ScoutPrimary::ItemPostFrame()
 {
 	// Check for smack.
-	if ( m_flPushTime > -1.f && gpGlobals->curtime > m_flPushTime )
+	if ( CanUsePush() )
 	{
 		Push();
 		m_flPushTime = -1.f;

--- a/src/game/shared/tf/tf_weapon_pistol.h
+++ b/src/game/shared/tf/tf_weapon_pistol.h
@@ -78,6 +78,7 @@ public:
 	virtual int		GetWeaponID( void ) const	{ return TF_WEAPON_HANDGUN_SCOUT_PRIMARY; }
 	virtual void	PlayWeaponShootSound( void );
 	virtual void	SecondaryAttack( void );
+	bool			CanUsePush();
 	virtual void	ItemPostFrame();
 	virtual bool	Holster( CBaseCombatWeapon *pSwitchingTo );
 	virtual void	Precache( void );


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
This PR enables bots to use the Shortstop's shove, using the same calculations used for the Pyro bots' compression blast. In this instance though, the shove only works if the Scout detects a player that's too close to him (as that's how the shove works).