### PR TITLE
[TF2] Fix Engineer melee swing storage/double swing exploit

### DIFF
--- a/src/game/shared/tf/tf_player_shared.cpp
+++ b/src/game/shared/tf/tf_player_shared.cpp
@@ -12548,8 +12548,14 @@ bool CTFPlayer::TryToPickupBuilding()
 		CTFWeaponBuilder *pBuilder = dynamic_cast<CTFWeaponBuilder*>(Weapon_OwnsThisID( TF_WEAPON_BUILDER ));
 		if ( pBuilder )
 		{
-			if ( GetActiveTFWeapon() == pBuilder )
-				SetActiveWeapon( NULL );
+			if ( pWeapon )
+			{
+				// Prevent weapon from attacking this frame after it's been holstered
+				pWeapon->m_flNextPrimaryAttack = gpGlobals->curtime + 0.1f;
+
+				if ( pWeapon == pBuilder )
+					SetActiveWeapon( NULL );
+			}
 
 			Weapon_Switch( pBuilder );
 			pBuilder->m_flNextSecondaryAttack = gpGlobals->curtime + 0.5f;


### PR DESCRIPTION
Fixes https://github.com/ValveSoftware/Source-1-Games/issues/4039

`CBaseCombatWeapon::ItemPostFrame()` is responsible for calling both `SecondaryAttack()` and `PrimaryAttack()`, in that order, depending on the player's input. Engineer's building pickup ability (`CTFPlayer::DoClassSpecialSkill()`) is called from within the active weapon's `SecondaryAttack()`, but if it activates (and switches to `tf_weapon_builder`, calling `Holster()` on the previous weapon in the process), it doesn't do anything to block a subsequent primary attack, so if both attack inputs are pressed simultaneously, `ItemPostFrame()` ends up calling `PrimaryAttack()` immediately afterwards too. This results in the previous weapon attacking *after* it has supposedly been switched away from and holstered. `PrimaryAttack()` then schedules the melee hit by setting `m_flSmackTime`. `Holster()` would normally unset `m_flSmackTime` to prevent this attack from being stored between weapon switches, but since this is being done after `Holster()` was already called, it stays stored, and activates as soon as the weapon is deployed again.

Fixed by blocking primary attacks on the same frame as a building pickup by setting `m_flNextPrimaryAttack`.
