### PR TITLE
[TF2] Fix Sappers becoming indestructible under certain circumstances

### DIFF
--- a/src/game/server/tf/tf_obj.cpp
+++ b/src/game/server/tf/tf_obj.cpp
@@ -3207,7 +3207,7 @@ void CBaseObject::AttachObjectToObject( CBaseEntity *pEntity, int iPoint, Vector
 				iAttachment = pBPInterface->GetBuildPointAttachmentIndex( iPoint );
 
 				// re-link to the build points if the sapper is already built
-				if ( !( IsPlacing() || IsBuilding() ) )
+				if ( !IsPlacing() )
 				{
 					pBPInterface->SetObjectOnBuildPoint( m_iBuiltOnPoint, this );
 				}


### PR DESCRIPTION
Fixes https://github.com/ValveSoftware/Source-1-Games/issues/6689

The Spy's Sapper has a 0.1s build time between being placed on a building and becoming active. During this time, Engineers can still upgrade the building. Whenever a building's model changes (which happens during upgrades depending on the building type), build points are reset, and an attempt is made to re-attach any previously attached Sappers to the new build points, but for some reason, the code responsible will refuse to re-attach a Sapper that is still in the process of being built.

As a result, the build point that the Sapper was previously attached to will be empty, at least until the building swaps models again, at which point it will be re-attached correctly since the 0.1s build time has passed. However, while the build point is empty, the Spy can actually place a second Sapper, and if he does, there will be 2 Sappers attached to the same building. Once the next model change happens (when the upgrade finishes, in the case of the Sentry), the first Sapper will be reattached, but since there's only one build point, the second Sapper will be destroyed, setting the sapped building's `m_bHasSapper` to false, which re-enables the building and prevents the Engineer from damaging the first Sapper (it can be removed by picking up the building).

Fixed by removing the condition preventing re-attachment of Sappers that are not yet fully built. There doesn't really seem to be any reason for this condition to exist.