### PR TITLE
[TF2] Fix ownerless sentry rockets dealing no damage

### DIFF
--- a/src/game/shared/tf/tf_weaponbase_rocket.cpp
+++ b/src/game/shared/tf/tf_weaponbase_rocket.cpp
@@ -484,7 +484,7 @@ void CTFBaseRocket::Explode( trace_t *pTrace, CBaseEntity *pOther )
 	// Damage.
 	CBaseEntity *pAttacker = GetOwnerEntity();
 	IScorer *pScorerInterface = dynamic_cast<IScorer*>( pAttacker );
-	if ( pScorerInterface )
+	if ( pScorerInterface && pScorerInterface->GetScorer() )
 	{
 		pAttacker = pScorerInterface->GetScorer();
 	}


### PR DESCRIPTION
# Description
This PR fixes ownerless sentry rockets dealing no damage.
This is fixed by having the scorer not override the attacker if the scorer is null.