### PR TITLE
[TF] Restore functionality of preserve_ubercharge attribute

### DIFF
--- a/src/game/shared/tf/tf_weapon_medigun.cpp
+++ b/src/game/shared/tf/tf_weapon_medigun.cpp
@@ -291,6 +291,17 @@ void CWeaponMedigun::WeaponReset( void )
 	if ( TFGameRules()->State_Get() == GR_STATE_RND_RUNNING )
 	{
 		// This is determined via an attribute in SetStoredChargeLevel()
+		int iPreserveUberCharge = 0;
+		CALL_ATTRIB_HOOK_INT_ON_OTHER( pOwner, iPreserveUberCharge, preserve_ubercharge );
+		if ( iPreserveUberCharge > 0 )
+		{
+#ifdef _WIN32
+			m_flChargeLevelToPreserve = ( iPreserveUberCharge / 99.f );
+#else
+			m_flChargeLevelToPreserve = ( iPreserveUberCharge / 100.f );
+#endif
+		}
+		
 		m_flChargeLevel = Min( (float)m_flChargeLevel, m_flChargeLevelToPreserve );
 	}
 	else


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
This PR reimplements the preserve_ubercharge attribute cut in the Jungle Inferno update in 2017. This attribute was used for the original version of the Vita-Saw. This does not require any items_game.txt modifications to implement.

The input for the attribute is an integer which represents the percent of Ubercharge the Medigun should save upon the player's death. For example, the original Vita-Saw used 20%, so the integer calculated must be 20. The code will then calculate the value as a percentage and pass it into m_flChargeLevelToPreserve, where it'll be passed to m_flChargeLevel on reset.

This implementation uses the m_flChargeLevelToPreserve variable used for the ubercharge_preserved_on_spawn_max attribute. As a result, both attributes shouldn't be used at the same time.

An additional note: when working on this I noticed that the MSVC compiler has a bit of a rounding/floating point error when calculating the saved Ubercharge (ex. 20% of uber / 100.0% = 0.199999988 = 19% of uber), so WIN32 divides by 99% rather than 100%. MSVC and GCC should be able to both calculate the correct values as a result.