### PR TITLE
[TF2] Fixed Widowmaker not giving metal on friendly disguises

### DIFF
--- a/src/game/shared/tf/tf_weaponbase.cpp
+++ b/src/game/shared/tf/tf_weaponbase.cpp
@@ -4969,6 +4969,7 @@ void CTFWeaponBase::ApplyOnHitAttributes( CBaseEntity *pVictimBaseEntity, CTFPla
 		if ( pVictim && 
 			 pVictim->IsPlayerClass( TF_CLASS_SPY ) && 
 			 pVictim->m_Shared.InCond( TF_COND_DISGUISED ) && 
+			 (pVictim->m_Shared.GetDisguiseTeam() != pVictim->GetTeamNumber()) &&
 			 !( pVictim->m_Shared.IsStealthed() || pVictim->m_Shared.InCond( TF_COND_STEALTHED_BLINK ) ) )
 		{
 			flPercentage = 0.0f;


### PR DESCRIPTION
If a Spy disguises as their own team, being shot by the Widowmaker does not give back any metal. Currently it works like [this](https://www.youtube.com/watch?v=r_fcuVyMoBM), where shooting a RED Spy disguised as a RED player gives no metal back.

If this is implemented, it would function like [this](https://www.youtube.com/watch?v=crSAsPp_0SA), where shooting a RED Spy disguised as a RED player gives back the metal as it should.

It's a simple check to see if the Spy's disguise is not the same as his team. Fixes https://github.com/ValveSoftware/Source-1-Games/issues/7475.

I also made another fix for on-hit attributes, at #1540, which fixes 5 other weapons' on-hit attributes not being triggered (but are triggered through a different way).