### PR TITLE
Workaround for CTFStatPanel not hiding on freezecam screenshot

### DIFF
--- a/src/game/client/tf/tf_hud_freezepanel.cpp
+++ b/src/game/client/tf/tf_hud_freezepanel.cpp
@@ -1126,6 +1126,11 @@ int	CTFFreezePanel::HudElementKeyInput( int down, ButtonCode_t keynum, const cha
 				engine->ClientCmd( "extendfreeze" );
 				view->FreezeFrame( 3.0f );
 
+				// Hide StatPanel here as a workaround for not hiding in time for freezecam screenshots
+				CTFStatPanel* pStatPanel = GET_HUDELEMENT(CTFStatPanel);
+				if (pStatPanel && pStatPanel->IsVisible())
+					pStatPanel->SetVisible(false);
+
 				//Hide the reminder panel
 				m_flShowSnapshotReminderAt = 0;
 				ShowSnapshotPanel( false );


### PR DESCRIPTION
Hiding CTFStatPanel inside CTFFreezePanel's key press event handler provides an easy workaround for CTFStatPanel failing to hide on freezecam screenshot at high fps.

Fixes https://github.com/ValveSoftware/Source-1-Games/issues/7477