### PR TITLE
(Temporary workaround) Fix issues with dynamic models on listen servers

### DIFF
--- a/src/game/client/cdll_client_int.cpp
+++ b/src/game/client/cdll_client_int.cpp
@@ -1705,6 +1705,17 @@ void CHLClient::ResetStringTablePointers()
 #endif
 }
 
+static void ClearClientDynamicModelList()
+{
+	// engine bugfix: clear out client dynamic model list for listen servers
+	// TODO remove this when the engine is updated
+	struct CModelInfo : IVModelInfoClient
+	{
+		CUtlVector< model_t* > m_vecDynamicModels;
+	};
+	static_cast<CModelInfo*>( modelinfo )->m_vecDynamicModels.Purge();
+}
+
 //-----------------------------------------------------------------------------
 // Purpose: Per level de-init
 //-----------------------------------------------------------------------------
@@ -1755,6 +1766,8 @@ void CHLClient::LevelShutdown( void )
 	internalCenterPrint->Clear();
 
 	messagechars->Clear();
+
+	ClearClientDynamicModelList();
 
 #ifndef TF_CLIENT_DLL
 	// don't want to do this for TF2 because we have particle systems in our

--- a/src/game/server/gameinterface.cpp
+++ b/src/game/server/gameinterface.cpp
@@ -226,6 +226,8 @@ INetworkStringTable *g_pStringTableServerPopFiles = NULL;
 INetworkStringTable *g_pStringTableServerMapCycleMvM = NULL;
 #endif
 
+INetworkStringTable* g_pStringTableDynamicModels = NULL;
+
 CStringTableSaveRestoreOps g_VguiScreenStringOps;
 
 // Holds global variables shared between engine and game.
@@ -1452,6 +1454,8 @@ void CServerGameDLL::CreateNetworkStringTables( void )
 	g_pStringTableServerPopFiles = networkstringtable->CreateStringTable( "ServerPopFiles", 128 );
 	g_pStringTableServerMapCycleMvM = networkstringtable->CreateStringTable( "ServerMapCycleMvM", 128 );
 #endif
+
+	g_pStringTableDynamicModels = networkstringtable->FindTable( "DynamicModels" );
 
 	bool bPopFilesValid = true;
 	(void)bPopFilesValid; // Avoid unreferenced variable warning


### PR DESCRIPTION
**Disclaimer:** This is a temporary pull request until the engine is updated with the fixes, this is _not_ intended to be merged

TF2 has some issues with dynamic models on listen servers. Dynamic models are models that are loaded on-demand rather than precached, and this system is used by cosmetics and taunts. 

This PR adds a workaround to fix these two engine issues:
1. Dynamic models that are loaded on the host clientside first will not appear for other servers. For example, opening the class menu registers the models clientside, and other players will not see the host's cosmetics. This is because the models are already loaded and the engine thinks they have been marked as loaded for networking, but they aren't.
2. Cosmetics render as the wrong model for the host after a map change (e.g. via `changelevel`), as the engine clears the dynamic model list on the server but forgets to do it on the client

This also fixes the host client crash on changelevel related to invalid bones in cosmetics (this was caused by bug #2).

Once the engine receives these fixes, these temporary workarounds can be removed.