### PR TITLE
Fix class select animation playback

### DIFF
--- a/src/game/client/tf/vgui/tf_playermodelpanel.cpp
+++ b/src/game/client/tf/vgui/tf_playermodelpanel.cpp
@@ -2295,6 +2295,7 @@ void CTFPlayerModelPanel::SetupFlexWeights( void )
 		}
 
 		m_flSceneTime += (m_RootMDL.m_MDL.m_flTime - m_flLastTickTime);
+		m_flSceneTime = Max( m_flSceneTime, -0.1f );
 		m_flLastTickTime = m_RootMDL.m_MDL.m_flTime;
 
 		if ( m_flSceneEndTime > FLT_EPSILON && m_flSceneTime > m_flSceneEndTime )

--- a/src/game/client/tf/vgui/tf_playermodelpanel.cpp
+++ b/src/game/client/tf/vgui/tf_playermodelpanel.cpp
@@ -34,6 +34,8 @@
 
 DECLARE_BUILD_FACTORY( CTFPlayerModelPanel );
 
+#define SCENE_LERP_TIME 0.1f
+
 char g_szSceneTmpName[256];
 
 static bool IsTauntItem( GameItemDefinition_t *pItemDef, const int iTeam, const int iClass, const char **ppSequence = NULL, const char **ppRequiredItem = NULL, const char **ppScene = NULL )
@@ -466,7 +468,7 @@ CChoreoScene *LoadSceneForModel( const char *filename, IChoreoEventCallback *pCa
 
 		if ( bSetEndTime )
 		{
-			*flSceneEndTime += 0.1f; // give time for lerp to idle pose
+			*flSceneEndTime += SCENE_LERP_TIME; // give time for lerp to idle pose
 		}
 	}
 
@@ -2291,11 +2293,11 @@ void CTFPlayerModelPanel::SetupFlexWeights( void )
 		// Advance time
 		if ( m_flLastTickTime < FLT_EPSILON )
 		{
-			m_flLastTickTime = m_RootMDL.m_MDL.m_flTime - 0.1;
+			m_flLastTickTime = m_RootMDL.m_MDL.m_flTime - SCENE_LERP_TIME;
 		}
 
 		m_flSceneTime += (m_RootMDL.m_MDL.m_flTime - m_flLastTickTime);
-		m_flSceneTime = Max( m_flSceneTime, -0.1f );
+		m_flSceneTime = Max( m_flSceneTime, -SCENE_LERP_TIME );
 		m_flLastTickTime = m_RootMDL.m_MDL.m_flTime;
 
 		if ( m_flSceneEndTime > FLT_EPSILON && m_flSceneTime > m_flSceneEndTime )


### PR DESCRIPTION
> This is a resubmission of #1285, which closed because of a deleted fork. I am the original author.

Hi. This fixes a bug where class select animations will freeze if you go back and forth in the menu.

Related issues:

* https://github.com/ValveSoftware/Source-1-Games/issues/4121
* https://github.com/ValveSoftware/Source-1-Games/issues/2116

## Before
[fix-class-select-anims-before.mp4](https://private-user-images.githubusercontent.com/181786564/444328579-2a1c625e-ba25-4048-bf60-08cc4140d0f0.mp4?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NTQ2ODk2MTIsIm5iZiI6MTc1NDY4OTMxMiwicGF0aCI6Ii8xODE3ODY1NjQvNDQ0MzI4NTc5LTJhMWM2MjVlLWJhMjUtNDA0OC1iZjYwLTA4Y2M0MTQwZDBmMC5tcDQ_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjUwODA4JTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI1MDgwOFQyMTQxNTJaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT1mMmJmMzg3MjViNDM3NWY0N2FjZTI4OGI3YzM3MWRkZDA5NDNlMWIyMWJkNWU2NTBhNzg5YmFmYTdlZjg1Y2ZlJlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCJ9.DJR4heSHUWdWs2gw0VVFq69C0FAreTdCYr5pLVStNao)
## After
[fix-class-select-anims-after.mp4](https://private-user-images.githubusercontent.com/181786564/444328601-da9ab140-d697-4ad5-bdff-888d0d6e86db.mp4?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NTQ2ODk2MTIsIm5iZiI6MTc1NDY4OTMxMiwicGF0aCI6Ii8xODE3ODY1NjQvNDQ0MzI4NjAxLWRhOWFiMTQwLWQ2OTctNGFkNS1iZGZmLTg4OGQwZDZlODZkYi5tcDQ_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjUwODA4JTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI1MDgwOFQyMTQxNTJaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT0zOWYyYzgxZjU2NTdkZTk1Y2E1NjFlNTE5NzgyOTY5YTA5Njc1MTdlMDQ5ZWQwMGQzNDMwMmMyNmI2OWE0YzVmJlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCJ9.KWWyNpZL6fDp9gt3d2A-_iI0ZRunzcJAGW5Q_Zsnqo0)
## Details

When reusing the shared CTFPlayerModelPanel in the class select screen, `SetupFlexWeights` would incorrectly calculate a large negative `m_flSceneTime`. This would result in class select animations freezing when going back and forth in the class select menu.

-0.1s start times are allowed to give the system time to lerp to the looping animation. This constant is already used in neighboring code.

The 2nd commit just replaces this `0.1f` magic number with a macro constant. This is optional, I just thought it would be a nice improvement.