### PR TITLE
[TF] Fix and rework Pyro bot airblast

### DIFF
--- a/src/game/server/tf/bot/tf_bot.cpp
+++ b/src/game/server/tf/bot/tf_bot.cpp
@@ -42,7 +42,6 @@ ConVar tf_bot_force_class( "tf_bot_force_class", "", FCVAR_GAMEDLL, "If set to a
 ConVar tf_bot_notice_gunfire_range( "tf_bot_notice_gunfire_range", "3000", FCVAR_GAMEDLL );
 ConVar tf_bot_notice_quiet_gunfire_range( "tf_bot_notice_quiet_gunfire_range", "500", FCVAR_GAMEDLL );
 ConVar tf_bot_sniper_personal_space_range( "tf_bot_sniper_personal_space_range", "1000", FCVAR_CHEAT, "Enemies beyond this range don't worry the Sniper" );
-ConVar tf_bot_pyro_deflect_tolerance( "tf_bot_pyro_deflect_tolerance", "0.5", FCVAR_CHEAT );
 ConVar tf_bot_keep_class_after_death( "tf_bot_keep_class_after_death", "0", FCVAR_GAMEDLL );
 ConVar tf_bot_prefix_name_with_difficulty( "tf_bot_prefix_name_with_difficulty", "0", FCVAR_GAMEDLL, "Append the skill level of the bot to the bot's name" );
 ConVar tf_bot_near_point_travel_distance( "tf_bot_near_point_travel_distance", "750", FCVAR_CHEAT, "If within this travel distance to the current point, bot is 'near' it" );

--- a/src/game/server/tf/bot/tf_bot.cpp
+++ b/src/game/server/tf/bot/tf_bot.cpp
@@ -4171,12 +4171,61 @@ bool CTFBot::ShouldFireCompressionBlast( void )
 		if ( pObject->IsPlayer() )
 			continue;
 
-		// is this something I want to deflect?
-		if ( !pObject->IsDeflectable() )
+		bool bSeesProjectile = false;
+
+		CTFBaseRocket *pBaseRocket = dynamic_cast< CTFBaseRocket * >( pObject );
+		if ( pBaseRocket )
+		{
+			// is this something I want to deflect?
+			if ( pBaseRocket->IsDeflectable() )
+			{
+				bSeesProjectile = true;
+			}
+		}
+
+		if ( !bSeesProjectile )
+		{
+			CTFGrenadePipebombProjectile *pBaseGrenade = dynamic_cast< CTFGrenadePipebombProjectile * >( pObject );
+			if ( pBaseGrenade )
+			{
+				// is this something I want to deflect?
+				if ( pBaseGrenade->IsDeflectable() )
+				{
+					bSeesProjectile = true;
+				}
+			}
+		}
+
+		// we can't deflect it.
+		if ( !bSeesProjectile )
 			continue;
 
-		if ( FClassnameIs( pObject, "tf_projectile_rocket" ) || FClassnameIs( pObject, "tf_projectile_energy_ball" ) )
+		if ( bSeesProjectile )
 		{
+			// on hard or expert, we're not restricted to what projectiles we should reflect.
+			// on lower difficulties, only deflect rockets or energy balls.
+			if ( !IsDifficulty( CTFBot::HARD ) && !IsDifficulty( CTFBot::EXPERT ) )
+			{
+				bool bCanReflectThisProj = false;
+
+				CTFProjectile_Rocket *pRocket = dynamic_cast< CTFProjectile_Rocket * >( pObject );
+				if ( pRocket )
+				{
+					bCanReflectThisProj = true;
+				}
+				else
+				{
+					CTFProjectile_EnergyBall *pBall = dynamic_cast< CTFProjectile_EnergyBall * >( pObject );
+					if ( pBall )
+					{
+						bCanReflectThisProj = true;
+					}
+				}
+
+				if ( !bCanReflectThisProj )
+					continue;
+			}
+
 			// is it headed right for me?
 			Vector vecThemUnitVel = pObject->GetAbsVelocity();
 			vecThemUnitVel.z = 0.0f;
@@ -4185,16 +4234,12 @@ bool CTFBot::ShouldFireCompressionBlast( void )
 			Vector horzForward( vecForward.x, vecForward.y, 0.0f );
 			horzForward.NormalizeInPlace();
 
-			if ( DotProduct( horzForward, vecThemUnitVel ) > -tf_bot_pyro_deflect_tolerance.GetFloat() )
+			if ( DotProduct( horzForward, vecThemUnitVel ) > 0 )
 				continue;
+
+			// bounce it!
+			return true;
 		}
-
-		// can I see it?
-		if ( !GetVisionInterface()->IsLineOfSightClear( pObject->WorldSpaceCenter() ) )
-			continue;
-
-		// bounce it!
-		return true;
 	}
 
 	return false;

--- a/src/game/server/tf/bot/tf_bot.cpp
+++ b/src/game/server/tf/bot/tf_bot.cpp
@@ -28,6 +28,7 @@
 #include "tf_weapon_medigun.h"
 #include "func_respawnroom.h"
 #include "soundenvelope.h"
+#include "tf_projectile_energy_ball.h"
 
 #include "econ_entity_creation.h"
 


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
This PR overhauls Pyro bot airblast functionality to reflect more projectiles. The previous implementation only functioned with a few projectiles and ignores other projectiles such as:

- The Flying Guillotine cleavers
- Huntsman Arrows
- Pipebombs/Cannonbals
- Sandman balls
- Crusader's Crossbow healing bolts
- Flares
- Stickybombs
- and others

This implementation allows the Pyro bot to recognize each of the above as projectiles and deflect them. In easy and normal difficulties however, the Pyro bot only recognizes Cow Mangler Energy Balls and Rockets as deflectable projectiles.

In addition, this makes bot airblasts more responsive as the IsLineOfSightClear() seems to return false if there's a projectile in front of the Pyro. This also removes tf_bot_pyro_deflect_tolerance, as the dot product is always 0 when there's a projectile in front of the Pyro.