### PR TITLE
[TF] Implement a way for users to toggle paint on items

### DIFF
--- a/src/game/shared/econ/econ_wearable.cpp
+++ b/src/game/shared/econ/econ_wearable.cpp
@@ -459,6 +459,8 @@ RenderGroup_t CEconWearable::GetRenderGroup()
 	return BaseClass::GetRenderGroup();
 }
 
+ConVar econ_allow_painted_items( "econ_allow_painted_items", "1", FCVAR_ARCHIVE );
+
 //-----------------------------------------------------------------------------
 // Purpose: Wearable tint colors
 //-----------------------------------------------------------------------------
@@ -468,6 +470,13 @@ public:
 	void OnBind( void *pC_BaseEntity )
 	{
 		Assert( m_pResult );
+		
+		if ( !econ_allow_painted_items.GetBool() )
+		{
+			m_pResult->SetVecValue( 1.f, 1.f, 1.f );
+			return;
+		}
+		
 		Vector vResult = Vector( 0, 0, 0 );
 
 		if ( pC_BaseEntity )

--- a/src/game/shared/econ/econ_wearable.cpp
+++ b/src/game/shared/econ/econ_wearable.cpp
@@ -473,7 +473,7 @@ public:
 		
 		if ( !econ_allow_paint_tint.GetBool() )
 		{
-			m_pResult->SetVecValue( 1.f, 1.f, 1.f );
+			m_pResult->SetVecValue( 0, 0, 0 );
 			return;
 		}
 		

--- a/src/game/shared/econ/econ_wearable.cpp
+++ b/src/game/shared/econ/econ_wearable.cpp
@@ -459,7 +459,7 @@ RenderGroup_t CEconWearable::GetRenderGroup()
 	return BaseClass::GetRenderGroup();
 }
 
-ConVar econ_allow_painted_items( "econ_allow_painted_items", "1", FCVAR_CLIENTDLL | FCVAR_ARCHIVE );
+ConVar econ_allow_paint_tint( "econ_allow_paint_tint", "1", FCVAR_CLIENTDLL | FCVAR_ARCHIVE );
 
 //-----------------------------------------------------------------------------
 // Purpose: Wearable tint colors
@@ -471,7 +471,7 @@ public:
 	{
 		Assert( m_pResult );
 		
-		if ( !econ_allow_painted_items.GetBool() )
+		if ( !econ_allow_paint_tint.GetBool() )
 		{
 			m_pResult->SetVecValue( 1.f, 1.f, 1.f );
 			return;

--- a/src/game/shared/econ/econ_wearable.cpp
+++ b/src/game/shared/econ/econ_wearable.cpp
@@ -459,7 +459,7 @@ RenderGroup_t CEconWearable::GetRenderGroup()
 	return BaseClass::GetRenderGroup();
 }
 
-ConVar econ_allow_painted_items( "econ_allow_painted_items", "1", FCVAR_ARCHIVE );
+ConVar econ_allow_painted_items( "econ_allow_painted_items", "1", FCVAR_CLIENTDLL | FCVAR_ARCHIVE );
 
 //-----------------------------------------------------------------------------
 // Purpose: Wearable tint colors


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
As of recent, community made cosmetics implemented in TF2 have had various issues where the majority of the cosmetic can be recolored, causing team recognition issues (and potentially accessibility issues). Most of the time, the problem can be fixed by the community member creating the item, but sometimes cosmetics can be unchanged for a long period of time without changes.

This PR adds the client-side ConVar "econ_allow_paint_tint", which allows users to toggle whether or not they want to see paint on items. Having this turned off resets the item to the normal item color. This solution doesn't fix the team recognition issue, but allows users to have a temporary workaround until the effected items are fixed.