### PR TITLE
[TF2] Fix Thermal Thruster passives not being removed if it's unequipped during use (or player is a Medic)

### DIFF
--- a/src/game/shared/tf/tf_player_shared.cpp
+++ b/src/game/shared/tf/tf_player_shared.cpp
@@ -3135,6 +3135,11 @@ void CTFPlayerShared::ConditionThink( void )
 #endif
 				}
 			}
+			else
+			{
+				// RocketPack not found, may have been unequipped, or we may be a Medic who inherited the cond
+				RemoveCond( TF_COND_ROCKETPACK );
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/ValveSoftware/Source-1-Games/issues/4731

The `TF_COND_ROCKETPACK` cond (stomp, lower fall damage, etc) from the Thermal Thruster is supposed to be removed as soon as the player touches the ground, but the code responsible does not do this if the player does not have a Thermal Thruster equipped.

As a result, players can stop the cond from being removed and keep it until they die by unequipping the Thermal Thruster after using it but before touching the ground (such as by flying into a resupply cabinet after changing their loadout). Additionally, Medics with the Quick Fix will always keep the cond until they die if they heal a Pyro as he uses the Thermal Thruster, since they inherit the cond from the Pyro but don't have the weapon themselves, so the cond is never removed from them.

Fixed by removing `TF_COND_ROCKETPACK` if a player touches the ground without the Thermal Thruster equipped.