### PR TITLE
[All] add cl_no_texture_stream to toggle texture streaming

### DIFF
--- a/src/game/client/cdll_client_int.cpp
+++ b/src/game/client/cdll_client_int.cpp
@@ -331,12 +331,14 @@ class IMoveHelper;
 
 void DispatchHudText( const char *pszName );
 
-static ConVar s_CV_ShowParticleCounts("showparticlecounts", "0", 0, "Display number of particles drawn per frame");
-static ConVar s_cl_team("cl_team", "default", FCVAR_USERINFO|FCVAR_ARCHIVE, "Default team when joining a game");
-static ConVar s_cl_class("cl_class", "default", FCVAR_USERINFO|FCVAR_ARCHIVE, "Default class when joining a game");
+static ConVar s_CV_ShowParticleCounts( "showparticlecounts", "0", 0, "Display number of particles drawn per frame" );
+static ConVar s_cl_team( "cl_team", "default", FCVAR_USERINFO|FCVAR_ARCHIVE, "Default team when joining a game" );
+static ConVar s_cl_class( "cl_class", "default", FCVAR_USERINFO|FCVAR_ARCHIVE, "Default class when joining a game" );
+
+ConVar cl_no_texture_stream( "cl_no_texture_stream", "0", FCVAR_ARCHIVE );
 
 #ifdef HL1MP_CLIENT_DLL
-static ConVar s_cl_load_hl1_content("cl_load_hl1_content", "0", FCVAR_ARCHIVE, "Mount the content from Half-Life: Source if possible");
+static ConVar s_cl_load_hl1_content( "cl_load_hl1_content", "0", FCVAR_ARCHIVE, "Mount the content from Half-Life: Source if possible" );
 #endif
 
 ConVar r_lightmap_bicubic_set( "r_lightmap_bicubic_set", "0", FCVAR_ARCHIVE | FCVAR_HIDDEN, "Hack to get this convar to be re-set on first launch." );
@@ -897,6 +899,12 @@ int CHLClient::Init( CreateInterfaceFn appSystemFactory, CreateInterfaceFn physi
 #ifndef NO_STEAM
 	ClientSteamContext().Activate();
 #endif
+
+	// if -no_texture_stream isn't enabled, append the parm if we're using the cvar
+	if ( cl_no_texture_stream.GetBool() && !CommandLine()->CheckParm( "-no_texture_stream" ) )
+	{
+		CommandLine()->AppendParm( "-no_texture_stream", "1" );
+	}
 
 	// We aren't happy unless we get all of our interfaces.
 	// please don't collapse this into one monolithic boolean expression (impossible to debug)

--- a/src/game/client/cdll_client_int.cpp
+++ b/src/game/client/cdll_client_int.cpp
@@ -903,7 +903,7 @@ int CHLClient::Init( CreateInterfaceFn appSystemFactory, CreateInterfaceFn physi
 	// if -no_texture_stream isn't enabled, append the parm if we're using the cvar
 	if ( cl_no_texture_stream.GetBool() && !CommandLine()->CheckParm( "-no_texture_stream" ) )
 	{
-		CommandLine()->AppendParm( "-no_texture_stream", "1" );
+		CommandLine()->AppendParm( "-no_texture_stream", NULL );
 	}
 
 	// We aren't happy unless we get all of our interfaces.


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
Closes https://github.com/ValveSoftware/Source-1-Games/issues/4884*

Since the Tough Break update in 2015, Source 2013 got texture streaming, which aims to improve performance when loading certain textures in. However, this causes some issues:

- Decreased texture quality when first loading a model
- Slower loading times

-no_texture_stream is the primary option to disable this feature, however it isn't in ConVar form. I added cl_no_texture_stream to add this option automatically on bootup before the client dll loads other modules, enabling users to toggle this setting without messing around with launch options.

*However, this isn't a replacement for -no_texture_stream, as it requires a restart when enabling it. Adding a ConVar that toggles texture steaming dynamically is the best option, but requires access to the materialsystem module code to do so. This implementation is the best possible way to implement this kind of option with the SDK codebase.