### PR TITLE
fix Potential use after free

### DIFF
--- a/src/vgui2/vgui_controls/TextImage.cpp
+++ b/src/vgui2/vgui_controls/TextImage.cpp
@@ -6,6 +6,7 @@
 //=============================================================================//
 
 #include <string.h>
+#include <new>
 #include <stdio.h>
 #include <ctype.h>
 #include <assert.h>
@@ -210,15 +211,25 @@ void TextImage::SetText(const wchar_t *unicode, bool bClearUnlocalizedSymbol)
 	if (_textLen >= _textBufferLen)
 	{
 		delete [] _utext;
+		_utext = nullptr;
 		_textBufferLen = (short)(_textLen + 1);
-		_utext = new wchar_t[_textBufferLen];
+		_utext = new (std::nothrow) wchar_t[_textBufferLen];
+		if (!_utext)
+		{
+			_textBufferLen = 0;
+			_textLen = 0;
+			return;
+		}
 	}
 
 	m_LineBreaks.RemoveAll();
 	m_LineXIndent.RemoveAll();
 
 	// store the text as unicode
-	wcscpy(_utext, unicode);
+	if (_utext)
+	{
+		wcscpy(_utext, unicode);
+	}
 
 	m_bRecalculateTruncation = true;
 }


### PR DESCRIPTION


# Description
fix the potential use-after-free, we should ensure that after deleting `_utext`, we set it to `nullptr` to avoid dangling pointers. Additionally, after allocating memory for `_utext`, we should check if the allocation succeeded before using it. If the allocation fails, we should handle the error gracefully (e.g., by setting `_textBufferLen` and `_textLen` to 0 and ensuring `_utext` is `nullptr`). The main change is in the `SetText` method in `src/vgui2/vgui_controls/TextImage.cpp`, specifically around the memory management for `_utext`.
```cpp
void f() {
	char* buf = new char[SIZE];
	...
	if (error) {
		delete buf; //error handling has freed the buffer
	}
	...
	log_contents(buf); //but it is still used here for logging
	...
}
```
#### References
I. Gerg. An Overview and Example of the Buffer-Overflow Exploit. IANewsletter vol 7 no 4. 2005.
M. Donaldson. Inside the Buffer Overflow Attack: Mechanism, Method & Prevention. SANS Institute InfoSec Reading Room. 2002.
Common Weakness Enumeration: [CWE-416](https://cwe.mitre.org/data/definitions/416.html).