### PR TITLE
Fix motionmapper Too few arguments to formatting function

### DIFF
--- a/src/utils/motionmapper/motionmapper.cpp
+++ b/src/utils/motionmapper/motionmapper.cpp
@@ -3214,7 +3214,7 @@ int main (int argc, char **argv)
 	// Verbose stuff
 	if (!g_quiet)
 	{
-		vprint( 0, "%s, %s, %s, path %s\n", qdir, gamedir, g_outfile );
+		vprint( 0, "%s, %s, %s, path %s\n", qdir, gamedir, g_outfile, fullpath );
 	}
 	// ??
 	Q_DefaultExtension(g_outfile, ".smd", sizeof( g_outfile ) );


### PR DESCRIPTION
fix the problem, we need to ensure that the number of arguments passed to `vprint` matches the number of format specifiers in the format string. In this case, the format string `"%s, %s, %s, path %s\n"` expects four arguments, but only three are provided. The best fix is to determine what the fourth argument should be. Based on the context, the format string is printing out some directory and file information. The three arguments provided are `qdir`, `gamedir`, and `g_outfile`. The format string also includes "path %s", suggesting that a path variable should be printed. If there is a variable representing the path (possibly `fullpath`), it should be passed as the fourth argument. If not, and if only three items are intended to be printed, the format string should be changed to only include three `%s` specifiers.

The most likely intended variable for "path %s" is `g_outfile` or `fullpath`. Since `g_outfile` is already passed as the third argument, and `fullpath` is set just below this code, it makes sense to use `fullpath` as the fourth argument. line 3217 in `src/utils/motionmapper/motionmapper.cpp` to add `fullpath` as the fourth argument to `vprint`.


### References
CERT C Coding Standard: [FIO47-C. Use valid format strings](https://wiki.sei.cmu.edu/confluence/display/c/FIO47-C.+Use+valid+format+strings)
Microsoft C Runtime Library Reference: [printf, wprintf](https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/printf-printf-l-wprintf-wprintf-l)