### PR TITLE
[TF] Add null pointer checks for recent casual doors fix.

### DIFF
--- a/src/game/client/tf/tf_hud_match_status.cpp
+++ b/src/game/client/tf/tf_hud_match_status.cpp
@@ -575,32 +575,38 @@ void CTFHudMatchStatus::FireGameEvent( IGameEvent * event )
 
 		const IMatchGroupDescription* pMatchDesc = GetMatchGroupDescription( TFGameRules()->GetCurrentMatchGroup() );
 
-		// FIX: Refresh versus doors so late-joiners do not see the wrong skin
-		int nSkin = 0;
-		int nSubModel = 0;
-		if (pMatchDesc->BGetRoundDoorParameters(nSkin, nSubModel))
+		if ( pMatchDesc )
 		{
-			// Is VS doors model not initialized yet?
-			if (m_pMatchStartModelPanel->m_hModel == NULL)
+			// FIX: Refresh versus doors so late-joiners do not see the wrong skin
+			int nSkin = 0;
+			int nSubModel = 0;
+			if ( pMatchDesc->BGetRoundDoorParameters( nSkin, nSubModel ) )
 			{
-				m_pMatchStartModelPanel->UpdateModel();
+				if ( m_pMatchStartModelPanel )
+				{
+					// Is VS doors model not initialized yet?
+					if ( m_pMatchStartModelPanel->m_hModel == NULL )
+					{
+						m_pMatchStartModelPanel->UpdateModel();
+					}
+
+					m_pMatchStartModelPanel->SetBodyGroup( "logos", nSubModel );
+					m_pMatchStartModelPanel->UpdateModel();
+					m_pMatchStartModelPanel->SetSkin( nSkin );
+				}
 			}
 
-			m_pMatchStartModelPanel->SetBodyGroup( "logos", nSubModel );
-			m_pMatchStartModelPanel->UpdateModel();
-			m_pMatchStartModelPanel->SetSkin( nSkin );
-		}
-
-		bool bForceDoors = false;
-		if ( bForceDoors || ( pMatchDesc && pMatchDesc->BUsesPostRoundDoors() ) )
-		{
-			if ( TFGameRules() && TFGameRules()->MapHasMatchSummaryStage() && ( bForceDoors || pMatchDesc->BUseMatchSummaryStage() ) )
+			bool bForceDoors = false;
+			if ( bForceDoors || ( pMatchDesc && pMatchDesc->BUsesPostRoundDoors() ) )
 			{
-				g_pClientMode->GetViewportAnimationController()->StartAnimationSequence( this, "HudMatchStatus_ShowMatchWinDoors", false );
-			}
-			else
-			{
-				g_pClientMode->GetViewportAnimationController()->StartAnimationSequence( this, "HudMatchStatus_ShowMatchWinDoors_NoOpen", false );
+				if ( TFGameRules() && TFGameRules()->MapHasMatchSummaryStage() && ( bForceDoors || pMatchDesc->BUseMatchSummaryStage() ) )
+				{
+					g_pClientMode->GetViewportAnimationController()->StartAnimationSequence( this, "HudMatchStatus_ShowMatchWinDoors", false );
+				}
+				else
+				{
+					g_pClientMode->GetViewportAnimationController()->StartAnimationSequence( this, "HudMatchStatus_ShowMatchWinDoors_NoOpen", false );
+				}
 			}
 		}
 	}


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
This PR adds null pointer checks for pMatchDesc and m_pMatchStartModelPanel to prevent rare crashes with the casual doors fix. This also improves the code formatting.