### PR TITLE
[TF2] Fix for collection checklists incorrectly marking some items as 'owned'

### DIFF
--- a/src/game/shared/econ/econ_item_description.cpp
+++ b/src/game/shared/econ/econ_item_description.cpp
@@ -2817,6 +2817,11 @@ void CEconItemDescription::Generate_CollectionDesc( const CLocalizationProvider 
 	if ( !pItemDef )
 		return;
 
+
+	// Adding a check for if the collection we are browsing contains cosmetics or decorated weapons.
+	// We can handle decorated weapons the same as cosmetics, since they have proper schema entries
+	bool bIsHatOrDecorated = false;
+
 	// For War Painted items (not War Paints themselves) we want highlight the row of the
 	// War Paint itself in the collection.  Look up our corresponding War Paint's item def
 	// and use that as our own if there is one.
@@ -2824,6 +2829,8 @@ void CEconItemDescription::Generate_CollectionDesc( const CLocalizationProvider 
 	if ( GetPaintKitDefIndex( pEconItem, &nPaintkitDefindex ) )
 	{
 		auto pPaintkitItemDef = GetItemSchema()->GetPaintKitItemDefinition( nPaintkitDefindex );
+		if (pPaintkitItemDef == NULL) 
+			bIsHatOrDecorated = true;
 		pItemDef = pPaintkitItemDef ? pPaintkitItemDef : pItemDef;
 	}
 
@@ -2885,7 +2892,7 @@ void CEconItemDescription::Generate_CollectionDesc( const CLocalizationProvider 
 							return &vecItemsWithDefindex;
 
 						uint32 unPaintkitDefidnex = 0;
-						if ( GetPaintKitDefIndex( pItemDef, &unPaintkitDefidnex ) )
+						if ( GetPaintKitDefIndex( pItemDef, &unPaintkitDefidnex ) && !bIsHatOrDecorated )
 						{
 							auto& vecItemsWithPaintkit = pLocalInv->GetItemsWithPaintkitDefindex( unPaintkitDefidnex );
 							if ( !vecItemsWithPaintkit.IsEmpty() )


### PR DESCRIPTION
Resolved issue where collections containing decorated weapons (skins from Gun Mettle, Tough Break) would report some items as 'owned' when player did not actually have them. This is a side effect from an additional check/pass added to support collections with War Paints.

Several decorated weapons from the Tough Break Update share the same paintkit index number, resulting in all instances of a skin (ie. Top Shelf, Boneyard) being marked as 'owned' if the player owned at least one of the items.
<img width="762" height="573" alt="image" src="https://github.com/user-attachments/assets/d98ba228-13b4-4e23-a34f-45330a33b0c2" />

A check has been added to ensure that collections with decorated weapons do not go through the additional check needed for War Paint collections.
<img width="774" height="588" alt="image" src="https://github.com/user-attachments/assets/7ff005ef-13e5-42b4-bdaf-bf62d8c9424c" />
