### PR TITLE
[TF2] Add custom text handling for vote failed messages

### DIFF
--- a/src/game/client/hud_vote.cpp
+++ b/src/game/client/hud_vote.cpp
@@ -1187,6 +1187,8 @@ void CHudVote::MsgFunc_CallVoteFailed( bf_read &msg )
 
 	vote_create_failed_t nReason = (vote_create_failed_t)msg.ReadByte();
 	int nTime = msg.ReadShort();
+	char szCustomText[k_MAX_VOTE_NAME_LENGTH];
+	msg.ReadString( szCustomText, sizeof(szCustomText) );
 
 	// if we're already drawing a vote, do nothing
 	if ( ShouldDraw() )
@@ -1230,6 +1232,12 @@ void CHudVote::MsgFunc_CallVoteFailed( bf_read &msg )
 	g_pVGuiLocalize->ConvertANSIToUnicode( szTime, wszTime, sizeof( wszTime ) );
 
 	wchar_t wszHeaderString[k_MAX_VOTE_NAME_LENGTH];
+
+	if ( szCustomText[0] )
+	{
+		pFreeVotePanel->m_pCallVoteFailed->SetControlString( "FailedReason", szCustomText );
+		return;
+	}
 
 	switch( nReason )
 	{
@@ -1363,6 +1371,8 @@ void CHudVote::MsgFunc_VoteFailed( bf_read &msg )
 	pVotePanel->m_nVoteTeamIndex = nVoteTeamIndex;
 
 	vote_create_failed_t nReason = (vote_create_failed_t)msg.ReadByte();
+	char szCustomText[k_MAX_VOTE_NAME_LENGTH];
+	msg.ReadString( szCustomText, sizeof(szCustomText) );
 
 	// Visibility of this error is handled by OnThink()
 	pVotePanel->m_bVotingActive = false;
@@ -1371,19 +1381,26 @@ void CHudVote::MsgFunc_VoteFailed( bf_read &msg )
 	pVotePanel->m_flHideTime = gpGlobals->curtime + 5.f;
 	pVotePanel->m_nVoteIdx = -1;
 
-	switch ( nReason )
+	if ( szCustomText[0] )
 	{
-	case VOTE_FAILED_GENERIC:
-		pVotePanel->m_pVoteFailed->SetControlString( "FailedReason", "#GameUI_vote_failed" );
-		break;
+		pVotePanel->m_pVoteFailed->SetControlString( "FailedReason", szCustomText );
+	}
+	else
+	{
+		switch ( nReason )
+		{
+			case VOTE_FAILED_GENERIC:
+				pVotePanel->m_pVoteFailed->SetControlString( "FailedReason", "#GameUI_vote_failed" );
+				break;
 
-	case VOTE_FAILED_YES_MUST_EXCEED_NO:
-		pVotePanel->m_pVoteFailed->SetControlString( "FailedReason", "#GameUI_vote_failed_yesno" );
-		break;
+			case VOTE_FAILED_YES_MUST_EXCEED_NO:
+				pVotePanel->m_pVoteFailed->SetControlString( "FailedReason", "#GameUI_vote_failed_yesno" );
+				break;
 
-	case VOTE_FAILED_QUORUM_FAILURE:
-		pVotePanel->m_pVoteFailed->SetControlString( "FailedReason", "#GameUI_vote_failed_quorum" );
-		break;
+			case VOTE_FAILED_QUORUM_FAILURE:
+				pVotePanel->m_pVoteFailed->SetControlString( "FailedReason", "#GameUI_vote_failed_quorum" );
+				break;
+		}
 	}
 
 	IGameEvent *event = gameeventmanager->CreateEvent( "vote_failed" );

--- a/src/game/server/vote_controller.h
+++ b/src/game/server/vote_controller.h
@@ -138,8 +138,8 @@ public:
 	void			ListIssues( CBasePlayer *pForWhom );
 	bool			IsValidVoter( CBasePlayer *pWhom );
 	bool			CanTeamCastVote( int iTeam ) const;
-	void			SendVoteCreationFailedMessage( vote_create_failed_t nReason, CBasePlayer *pVoteCaller, int nTime = -1 );
-	void			SendVoteFailedToPassMessage( vote_create_failed_t nReason );
+	void			SendVoteCreationFailedMessage( vote_create_failed_t nReason, CBasePlayer *pVoteCaller, int nTime = -1, const char *pszCustomText = nullptr );
+	void			SendVoteFailedToPassMessage( vote_create_failed_t nReason, const char* pszCustomText = nullptr );
 	void			VoteChoice_Increment( int nVoteChoice );
 	void			VoteChoice_Decrement( int nVoteChoice );
 	int				GetVoteIssueIndexWithHighestCount( void );
@@ -160,9 +160,9 @@ public:
 	bool			HasIssue( const char *pszIssue );
 	bool			IsAVoteInProgress( void ) { return ( m_iActiveIssueIndex != INVALID_ISSUE ); }
 	int				GetVoteID() const { return m_nVoteIdx; }
+	void			ResetData(void);
 
 protected:
-	void			ResetData( void );
 	void			VoteControllerThink( void );
 	void			CheckForEarlyVoteClose( void );				// If everyone has voted (and changing votes is not allowed) then end early
 

--- a/src/game/shared/tf/tf_usermessages.cpp
+++ b/src/game/shared/tf/tf_usermessages.cpp
@@ -87,7 +87,7 @@ void RegisterUserMessages()
 	usermessages->Register( "CallVoteFailed", -1 );
 	usermessages->Register( "VoteStart", -1 );
 	usermessages->Register( "VotePass", -1 );
-	usermessages->Register( "VoteFailed", 6 );
+	usermessages->Register( "VoteFailed", -1 );
 	usermessages->Register( "VoteSetup", -1 );  // Initiates client-side voting UI
 
 	usermessages->Register( "PlayerBonusPoints", 3 );


### PR DESCRIPTION
Added support for optional custom text in `CallVoteFailed` and `VoteFailed` usermessages. Also added test commands for these via `test_vote_creation_failed` and `test_vote_pass_failed`.

If custom text is provided in the usermessage it will take priority over the `vote_create_failed_t` reason. Translation strings are also supported via the hashtag prefix.

<img width="383" height="180" alt="image" src="https://github.com/user-attachments/assets/33059a3c-fb93-4c26-8737-927117973dd6" />
