### PR TITLE
[TF2] Updated armory controls to mimic December 2021 Workshop dialog QOL update

### DIFF
--- a/src/game/client/tf/vgui/charinfo_armory_subpanel.h
+++ b/src/game/client/tf/vgui/charinfo_armory_subpanel.h
@@ -112,8 +112,6 @@ private:
 	armory_filters_t				m_CurrentFilter;
 	armory_filters_t				m_OldFilter;
 	int								m_iFilterPage;
-	CExButton						*m_pNextPageButton;
-	CExButton						*m_pPrevPageButton;
 	CUtlVector<item_definition_index_t>	m_FilteredItemList;
 	CUtlVector<item_definition_index_t>	m_CustomFilteredList;
 


### PR DESCRIPTION
This pull request adds support for the armory (Mann Co. Catalog) mimicking the following features from the Workshop dialog, which gained them in the [December 17, 2021 patch](https://www.teamfortress.com/post.php?id=102740):

- Previous/next buttons now have support for wrapping around to the first/last page
- Added skip previous/next buttons, which skip several pages at once (commands: `prevpageskip`, `nextpageskip`)
  - Controlled by `tf_armory_page_skip`; default value is 10
- Added skip to start/end buttons, which bring you to the first/last page (commands: `skiptostart`, `skiptoend`)

Additionally, I've modified the .res file responsible for this menu with support for the new button layout and minor consistency fixes, [expanded_armory_controls_res.zip](https://github.com/user-attachments/files/21825210/expanded_armory_controls_res.zip).

<img width="1387" height="741" alt="expanded_armory_controls" src="https://github.com/user-attachments/assets/491cea6c-7de0-4c03-918e-e601981af849" />