### PR TITLE
[Audio] Fix ordering of hitsound calls in CBaseHLBludgeonWeapon::Swing() and play melee hitsound in CBaseHLBludgeonWeapon::Hit()

### DIFF
--- a/src/game/server/basebludgeonweapon.cpp
+++ b/src/game/server/basebludgeonweapon.cpp
@@ -178,10 +178,6 @@ void CBaseHLBludgeonWeapon::Hit( trace_t &traceHit, Activity nHitActivity, bool 
 		// Play hit sound
 		WeaponSound( MELEE_HIT );
 	}
-	else {
-		// Play hit world sound
-		WeaponSound( MELEE_HIT_WORLD );
-	}
 
 	// Apply an impact effect
 	ImpactEffect( traceHit );


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
This PR properly fixes melee weapon hit sounds in _Half-Life 2_ and derivative mods by adding a missing `WeaponSound( MELEE_HIT )` call at the end of the hit target entity check in `CBaseHLBludgeonWeapon::Hit()`, and changes the ordering of the swing `WeaponSound` call in `CBaseHLBludgeonWeapon::Swing()` to be placed within the miss conditional block.

- Original, unfixed codepath in live Half-Life 2 and Team Fortress 2 SDK (for reference):

https://github.com/user-attachments/assets/7582d0f1-f39e-4510-81b1-54f28d34da3a

- Fix in PR:

https://github.com/user-attachments/assets/1d1a54b8-f088-466c-995f-0b6a84eed29f

## Note
This exact hitsound fix is only _partially_ present in live HL2 exclusively for the player stunstick ent (`weapon_stunstick_player`). The regular stunstick (`weapon_stunstick`) and crowbar/mattpipe (`weapon_crowbar`) do not have this change, because the fix that's included is in the wrong place!

https://github.com/user-attachments/assets/951f3663-6d4b-46c2-95e2-e05010dbab0b