### PR TITLE
[TF2] Disposable Sentry only plays denial sound when not a bUsefulhit

### DIFF
--- a/src/game/shared/tf/tf_weapon_wrench.cpp
+++ b/src/game/shared/tf/tf_weapon_wrench.cpp
@@ -121,17 +121,17 @@ void CTFWrench::OnFriendlyBuildingHit( CBaseObject *pObject, CTFPlayer *pPlayer,
 
 	CDisablePredictionFiltering disabler;
 
-	if ( pObject->IsDisposableBuilding() )
+	if ( bUsefulHit )
 	{
-		CSingleUserRecipientFilter singleFilter( pPlayer );
-		EmitSound( singleFilter, pObject->entindex(), "Player.UseDeny" );
+		// play success sound
+		WeaponSound( SPECIAL1 );
 	}
 	else
 	{
-		if ( bUsefulHit )
+		if ( pObject->IsDisposableBuilding() )
 		{
-			// play success sound
-			WeaponSound( SPECIAL1 );
+			CSingleUserRecipientFilter singleFilter( pPlayer );
+			EmitSound( singleFilter, pObject->entindex(), "Player.UseDeny" );
 		}
 		else
 		{


### PR DESCRIPTION
This pull request slightly shifts around parts of the code so that if any Engineer melee hits a friendly Disposable Sentry, and it is a "bUsefulHit", it will play the traditional sound rather than the denial sound.

In most cases, this does not change anything, but in the case of wrench boosting a constructing Disposable Sentry, hitting it will no longer give the denial sound, as the hit is doing something (speeding up construction) and is classed as useful.