### PR TITLE
[TF] Allow airblast_pushback_scale to work when airblasting physics objects.

### DIFF
--- a/src/game/shared/tf/tf_weaponbase.cpp
+++ b/src/game/shared/tf/tf_weaponbase.cpp
@@ -18,7 +18,6 @@
 #include "tf_gcmessages.h"
 
 #include "tf_weapon_wrench.h"
-#include "tf_weapon_flamethrower.h"
 
 #include "passtime_convars.h"
 

--- a/src/game/shared/tf/tf_weaponbase.cpp
+++ b/src/game/shared/tf/tf_weaponbase.cpp
@@ -18,6 +18,7 @@
 #include "tf_gcmessages.h"
 
 #include "tf_weapon_wrench.h"
+#include "tf_weapon_flamethrower.h"
 
 #include "passtime_convars.h"
 
@@ -5932,6 +5933,7 @@ bool CTFWeaponBase::DeflectEntity( CBaseEntity *pTarget, CTFPlayer *pOwner, Vect
 			Vector vecDir = pTarget->WorldSpaceCenter() - vecEye;
 			VectorNormalize( vecDir );
 			float flVel = 50.0f * CTFWeaponBase::DeflectionForce( pTarget->CollisionProp()->OBBSize(), 90, 12.0f );
+			CALL_ATTRIB_HOOK_FLOAT( flVel, airblast_pushback_scale );
 			pPhysicsObject->ApplyForceOffset( vecDir * flVel, vecEye );
 		}
 		return true;
@@ -5962,6 +5964,7 @@ bool CTFWeaponBase::DeflectEntity( CBaseEntity *pTarget, CTFPlayer *pOwner, Vect
 		pPhysicsObject->GetVelocity( &vecVel, &angularimp );
 	}
 	float flVel = vecVel.Length();
+	CALL_ATTRIB_HOOK_FLOAT( flVel, airblast_pushback_scale );
 	vecVel = flVel * vecDir;
 	if ( pPhysicsObject )
 	{


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
When airblasting a physics object, it pushes it at a set force. This is a problem for flamethrowers that use the airblast_pushback_scale attribute. With this change, airblast_pushback_scale now effects how far the airblast pushes physics props.