### PR TITLE
[TF2] Make Killfeed use the Assisters team color if applicable instead of always using the Killers team color

### DIFF
--- a/src/game/client/tf/hud_basedeathnotice.cpp
+++ b/src/game/client/tf/hud_basedeathnotice.cpp
@@ -151,17 +151,22 @@ void CHudBaseDeathNotice::Paint()
 
 		wchar_t victim[256]=L"";
 		wchar_t killer[256]=L"";
+		wchar_t	assister[256]=L"";
 
+		const wchar_t *plus = L"+";
 		// TEMP - print the death icon name if we don't have a material for it
 
 		g_pVGuiLocalize->ConvertANSIToUnicode( msg.Victim.szName, victim, sizeof( victim ) );
 		g_pVGuiLocalize->ConvertANSIToUnicode( msg.Killer.szName, killer, sizeof( killer ) );
+		g_pVGuiLocalize->ConvertANSIToUnicode( msg.Assister.szName, assister, sizeof( assister ) );
 
 		int iVictimTextWide = UTIL_ComputeStringWidth( m_hTextFont, victim ) + xSpacing;
 		int iDeathInfoTextWide= msg.wzInfoText[0] ? UTIL_ComputeStringWidth( m_hTextFont, msg.wzInfoText ) + xSpacing : 0;
 		int iDeathInfoEndTextWide= msg.wzInfoTextEnd[0] ? UTIL_ComputeStringWidth( m_hTextFont, msg.wzInfoTextEnd ) + xSpacing : 0;
 
 		int iKillerTextWide = killer[0] ? UTIL_ComputeStringWidth( m_hTextFont, killer ) + xSpacing : 0;
+		int iAssisterTextWide = assister[0] ? UTIL_ComputeStringWidth( m_hTextFont, assister ) + xSpacing : 0;
+		int iPlusTextWide = assister[0] ? UTIL_ComputeStringWidth( m_hTextFont, plus ) + xSpacing : 0;
 		int iLineTall = m_flLineHeight;
 		int iTextTall = surface()->GetFontTall( m_hTextFont );
 		int iconWide = 0, iconTall = 0, iDeathInfoOffset = 0, iVictimTextOffset = 0, iconActualWide = 0;
@@ -234,7 +239,7 @@ void CHudBaseDeathNotice::Paint()
 			iconPostVictimWide *= flScale;
 		}
 
-		int iTotalWide = iKillerTextWide + iconWide + iVictimTextWide + iDeathInfoTextWide + iDeathInfoEndTextWide + ( xMargin * 2 );
+		int iTotalWide = iKillerTextWide + iPlusTextWide + iAssisterTextWide + iconWide + iVictimTextWide + iDeathInfoTextWide + iDeathInfoEndTextWide + ( xMargin * 2 );
 		iTotalWide += iconPrekillerWide + iconPostkillerWide + iPreKillerTextWide + iconPostVictimWide;
 
 		int y = yStart + ( ( iLineTall + m_flLineSpacing ) * i );				
@@ -269,6 +274,14 @@ void CHudBaseDeathNotice::Paint()
 			// Draw killer's name
 			DrawText( x, yText, m_hTextFont, GetTeamColor( msg.Killer.iTeam, msg.bLocalPlayerInvolved ), killer );
 			x += iKillerTextWide;
+		}
+
+		if ( assister[0] )
+		{
+			DrawText( x, yText, m_hTextFont, GetTeamColor( msg.Killer.iTeam == msg.Assister.iTeam ? msg.Assister.iTeam : TEAM_UNASSIGNED, msg.bLocalPlayerInvolved ), plus );
+			x += iPlusTextWide;
+			DrawText( x, yText, m_hTextFont, GetTeamColor( msg.Assister.iTeam, msg.bLocalPlayerInvolved ), assister );
+			x += iAssisterTextWide;
 		}
 
 		// prekiller text

--- a/src/game/client/tf/hud_basedeathnotice.h
+++ b/src/game/client/tf/hud_basedeathnotice.h
@@ -54,6 +54,7 @@ struct DeathNoticeItem
 
 	DeathNoticePlayer	Killer;
 	DeathNoticePlayer   Victim;
+	DeathNoticePlayer	Assister;
 	char		szIcon[32];		// name of icon to display
 	wchar_t		wzInfoText[32];	// any additional text to display next to icon
 	wchar_t		wzInfoTextEnd[32];	// any additional text to display next to victim name

--- a/src/game/client/tf/tf_hud_deathnotice.cpp
+++ b/src/game/client/tf/tf_hud_deathnotice.cpp
@@ -866,12 +866,13 @@ void CTFHudDeathNotice::OnGameEvent( IGameEvent *event, int iDeathNoticeMsg )
 			if ( pszAssisterName && (ePyroVisionHack == kHorriblePyroVisionHack_KillAssisterType_CustomName_First ||
 									 ePyroVisionHack == kHorriblePyroVisionHack_KillAssisterType_LocalizationString_First) )
 			{
-				std::swap( pszKillerName, pszAssisterName );
+				Q_strncpy( msg.Killer.szName, pszAssisterName, ARRAYSIZE( msg.Killer.szName ) );
+				pszAssisterName = pszKillerName;
 			}
 
-			char szKillerBuf[MAX_PLAYER_NAME_LENGTH*2];
-			Q_snprintf( szKillerBuf, ARRAYSIZE(szKillerBuf), "%s + %s", pszKillerName, pszAssisterName );
-			Q_strncpy( msg.Killer.szName, szKillerBuf, ARRAYSIZE( msg.Killer.szName ) );
+			msg.Assister.iTeam = ( iAssisterID > 0 ? g_PR->GetTeam( iAssisterID ) : msg.Killer.iTeam );
+			Q_strncpy( msg.Assister.szName, pszAssisterName, ARRAYSIZE( msg.Assister.szName ) );
+
 			if ( iLocalPlayerIndex == iAssisterID )
 			{
 				msg.bLocalPlayerInvolved = true;
@@ -1307,9 +1308,8 @@ void CTFHudDeathNotice::OnGameEvent( IGameEvent *event, int iDeathNoticeMsg )
 		const char *assister_name = ( iAssisterID > 0 ? g_PR->GetPlayerName( iAssisterID ) : NULL );
 		if ( assister_name )
 		{
-			char szKillerBuf[MAX_PLAYER_NAME_LENGTH*2];
-			Q_snprintf( szKillerBuf, ARRAYSIZE(szKillerBuf), "%s + %s", msg.Killer.szName, assister_name );
-			Q_strncpy( msg.Killer.szName, szKillerBuf, ARRAYSIZE( msg.Killer.szName ) );
+			msg.Assister.iTeam = g_PR->GetTeam( iAssisterID );
+			Q_strncpy( msg.Assister.szName, assister_name, ARRAYSIZE( msg.Assister.szName ) );
 		}
 	}
 	//else if ( FStrEq( "throwable_hit", pszEventName ) )


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
Currently the Killfeed will always color both the Killer and Assister in the team color of the Killer even if the Assister is on a different team.
This PR aims to change that by storing the Assisters name and team seperately from the Killer and drawing the + in a neutral color if the teams are different.

# Before:

https://github.com/user-attachments/assets/bedddd64-83d0-4c7c-a5df-e91cbcb3dfc1

# After:

https://github.com/user-attachments/assets/90a8c91a-0be5-4697-bedb-98c81e8f6d6d

