### PR TITLE
Add `C_BaseEntity::CanGlow` to opt-out of glowing for Sentry Gun shield

### DIFF
--- a/src/game/client/c_baseentity.h
+++ b/src/game/client/c_baseentity.h
@@ -1449,6 +1449,10 @@ public:
 
 	void TrackAngRotation( bool bTrack );
 
+#ifdef GLOWS_ENABLE
+	virtual bool CanGlow() const { return true; }
+#endif // GLOWS_ENABLE
+
 private:
 	friend void OnRenderStart();
 

--- a/src/game/client/glow_outline_effect.cpp
+++ b/src/game/client/glow_outline_effect.cpp
@@ -319,7 +319,7 @@ void CGlowObjectManager::GlowObjectDefinition_t::DrawModel()
 
 		while ( pAttachment != NULL )
 		{
-			if ( !g_GlowObjectManager.HasGlowEffect( pAttachment ) && pAttachment->ShouldDraw() )
+			if ( !g_GlowObjectManager.HasGlowEffect( pAttachment ) && pAttachment->ShouldDraw() && pAttachment->CanGlow() )
 			{
 				pAttachment->DrawModel( STUDIO_RENDER );
 			}

--- a/src/game/client/glow_outline_effect.h
+++ b/src/game/client/glow_outline_effect.h
@@ -128,6 +128,7 @@ private:
 				   ( m_nSplitScreenSlot == GLOW_FOR_ALL_SPLIT_SCREEN_SLOTS || m_nSplitScreenSlot == nSlot ) && 
 				   ( m_bRenderWhenOccluded || m_bRenderWhenUnoccluded ) && 
 				   m_hEntity->ShouldDraw() && 
+				   m_hEntity->CanGlow() &&
 				   !m_hEntity->IsDormant();
 		}
 

--- a/src/game/client/tf/c_obj_sentrygun.h
+++ b/src/game/client/tf/c_obj_sentrygun.h
@@ -38,6 +38,7 @@ public:
 	static C_SentrygunShield* Create( const char* pszModelName );
 
 	virtual void ClientThink();
+	virtual bool CanGlow() const OVERRIDE { return false; }
 
 	void StartFadeOut( float flDuration );
 


### PR DESCRIPTION
This fix was requested from me by a community member reporting bugs for [CastingEssentials Next](https://github.com/drunderscore/CastingEssentialsNext).

Before (caused by 57a8b64)
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/f89f685b-32d0-44ed-9fbe-9cd0ef1bd32c" />
After
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/35af82a2-7123-4431-8067-52a2acaf0b5f" />
