### PR TITLE
[TF2] Crusader's Crossbow arrow healing is now affected by mult_health_fromhealers (used by Back Scratcher)

### DIFF
--- a/src/game/server/tf/tf_projectile_arrow.cpp
+++ b/src/game/server/tf/tf_projectile_arrow.cpp
@@ -1220,6 +1220,7 @@ void CTFProjectile_HealingBolt::ImpactTeamPlayer( CTFPlayer *pOther )
 
 	// Scale this if needed
 	CALL_ATTRIB_HOOK_FLOAT_ON_OTHER( pOther, flHealth, mult_healing_from_medics );
+	CALL_ATTRIB_HOOK_FLOAT_ON_OTHER( pOther, flHealth, mult_health_fromhealers );
 
 	CTFWeaponBase *pActiveWeapon = pOther->GetActiveTFWeapon();
 	if ( pActiveWeapon )


### PR DESCRIPTION
Added an extra `CALL_ATTRIB_HOOK_FLOAT_ON_OTHER` for the specified attrib. I don't really know if this is the best approach, but there is pretty much no reason why you would have both attributes. One reduces healing from Medics and one reduces it from Medic + other healing sources, so if both effects are applied they would affect each other.

From testing, it reduces healing just fine.

Intended to fix https://github.com/ValveSoftware/Source-1-Games/issues/7521