### PR TITLE
[TF2] Fix the B.A.S.E. Jumpers parachute not using half of its animations

### DIFF
--- a/src/game/shared/tf/tf_weapon_parachute.cpp
+++ b/src/game/shared/tf/tf_weapon_parachute.cpp
@@ -41,12 +41,13 @@ CTFParachute::CTFParachute()
 //-----------------------------------------------------------------------------
 void CTFParachute::CreateBanner()
 {
+#ifdef CLIENT_DLL
 	if ( m_hBannerEntity )
 		return;
 
 	BaseClass::CreateBanner();
 
-#ifdef CLIENT_DLL
+
 	if ( m_hBannerEntity )
 	{
 		m_iParachuteAnimState = EParachuteRetracted_Idle;


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
Due to an oversight the B.A.S.E. Jumpers parachute doesn't use its deployed_idle and retract animations,
this PR fixes the oversight and also reworks the code that handles the animations for it to make it always able to switch between animations.

# Before

https://github.com/user-attachments/assets/a6b37eb7-34a6-47e1-93d8-47662f518be8

# After

https://github.com/user-attachments/assets/7e77d994-2f11-4dee-b0bf-816e581e43ce

