### PR TITLE
Fix eureka effect menu reopening

### DIFF
--- a/src/game/shared/tf/tf_weapon_wrench.cpp
+++ b/src/game/shared/tf/tf_weapon_wrench.cpp
@@ -87,7 +87,7 @@ LINK_ENTITY_TO_CLASS( tf_wearable_robot_arm, CTFWearableRobotArm );
 // Purpose:
 //-----------------------------------------------------------------------------
 CTFWrench::CTFWrench()
-	: m_bReloadDown( false )
+	: m_flNextReloadTime( 0.f )
 {}
 
 
@@ -218,9 +218,9 @@ void CTFWrench::ItemPostFrame()
 	}
 
 	// Just pressed reload?
-	if ( pOwner->m_nButtons & IN_RELOAD && !m_bReloadDown )
+	if ( pOwner->m_afButtonPressed & IN_RELOAD && gpGlobals->curtime >= m_flNextReloadTime )
 	{
-		m_bReloadDown = true;
+		m_flNextReloadTime = gpGlobals->curtime + 0.5f;
 		int iAltFireTeleportToSpawn = 0;
 		CALL_ATTRIB_HOOK_INT( iAltFireTeleportToSpawn, alt_fire_teleport_to_spawn );
 		if ( iAltFireTeleportToSpawn )
@@ -232,10 +232,6 @@ void CTFWrench::ItemPostFrame()
 				pTeleportMenu->WantsToTeleport();
 			}
 		}
-	}
-	else if ( !(pOwner->m_nButtons & IN_RELOAD) && m_bReloadDown )
-	{
-		m_bReloadDown = false;
 	}
 }
 #endif

--- a/src/game/shared/tf/tf_weapon_wrench.h
+++ b/src/game/shared/tf/tf_weapon_wrench.h
@@ -55,7 +55,7 @@ public:
 
 
 private:
-	bool				m_bReloadDown;
+	float				m_flNextReloadTime;
 	CTFWrench( const CTFWrench & ) {}
 };
 


### PR DESCRIPTION
Attempt to fix a bug where rapidly pressing Reload + 1 reopens the Eureka Effect menu.

**without fix:**

https://github.com/user-attachments/assets/cb729b37-81b1-4453-8b0c-e0dbe890d6f4

**with fix:**

https://github.com/user-attachments/assets/f0065939-f5b5-4bd0-b6f6-a9b31e455bf7



