### PR TITLE
[ALL] Add more functionality to Input<name>() callback in VScript

### DIFF
--- a/src/game/server/baseentity.cpp
+++ b/src/game/server/baseentity.cpp
@@ -4430,10 +4430,15 @@ bool CBaseEntity::AcceptInput( const char *szInputName, CBaseEntity *pActivator,
 
 							g_pScriptVM->SetValue( "activator", ( pActivator ) ? ScriptVariant_t( pActivator->GetScriptInstance() ) : SCRIPT_VARIANT_NULL );
 							g_pScriptVM->SetValue( "caller", ( pCaller ) ? ScriptVariant_t( pCaller->GetScriptInstance() ) : SCRIPT_VARIANT_NULL );
+							g_pScriptVM->SetValue( "input_value", Value.String() );
 
 							if( CallScriptFunction( szScriptFunctionName, &functionReturn ) )
 							{
 								bCallInputFunc = functionReturn;
+								// Allow reassignment of activator and caller of the input
+								IScriptVM *pVM = g_pScriptVM;
+								pVM->IfHas<HSCRIPT>		( m_ScriptScope, "activator",	[&](HSCRIPT value) { data.pActivator = ToEnt(value); } );
+								pVM->IfHas<HSCRIPT>		( m_ScriptScope, "caller",		[&](HSCRIPT value) { data.pCaller = ToEnt(value); } );
 							}
 						}
 
@@ -4446,6 +4451,7 @@ bool CBaseEntity::AcceptInput( const char *szInputName, CBaseEntity *pActivator,
 						{
 							g_pScriptVM->ClearValue( "activator" );
 							g_pScriptVM->ClearValue( "caller" );
+							g_pScriptVM->ClearValue( "input_value" );
 						}
 					}
 					else if ( dmap->dataDesc[i].flags & FTYPEDESC_KEY )


### PR DESCRIPTION
adds new functionality to Input<name>() in vscript to

- read the parameters of an input, via the input_value variable.

- reassigning the activator and caller of the input

<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
This PR aims to add more functionality to the `Input<name>()` callback.

This PR adds the following functionality:
- a new variable `input_value` that stores the parameter of the input.
- `activator` and `caller` can be reassigned within the function.

Example:
```nut
local temp = SpawnEntityFromTable("info_target", {targetname = "entity_1"})
local test_ent = SpawnEntityFromTable("info_target", {targetname = "entity_2"})
test_ent.ValidateScriptScope()
test_ent.GetScriptScope().Inputrunscriptcode <- function()
{
	printf("Input Value: %s\n", input_value)
	printf("Initial Activator: %s\n", activator.GetName())
	activator = self
	caller = self
	return true
}

test_ent.AcceptInput("runscriptcode", "printf(`Current Activator: %s`, activator.GetName())", temp, temp)
temp.Destroy()
test_ent.Destroy()

/* Console output:
] script_execute input_remap_test
Input Value: printf(`Current Activator: %s`, activator.GetName())
Initial Activator: entity_1
Current Activator: entity_2
*/
```