### PR TITLE
[TF2] Fix Client Crashes from Invalid Banners Index's

### DIFF
--- a/src/game/shared/tf/tf_weapon_buff_item.cpp
+++ b/src/game/shared/tf/tf_weapon_buff_item.cpp
@@ -317,7 +317,6 @@ void CTFBuffItem::CreateBanner()
 		C_TFBuffBanner* pBanner = new C_TFBuffBanner;
 		if ( !pBanner )
 			return;
-		
 		//Assert( iBuffType > 0 );
 		//Assert( iBuffType <= ARRAYSIZE(BannerModels) );
 		pBanner->m_nSkin = 0;


### PR DESCRIPTION
Fixes a client crash from trying to create banner models out of range of the banner models array.