### PR TITLE
[TF2] Add A Non full charge sound Check to tf_weapon_sniperrifle.cpp

### DIFF
--- a/src/game/shared/tf/tf_weapon_sniperrifle.cpp
+++ b/src/game/shared/tf/tf_weapon_sniperrifle.cpp
@@ -448,8 +448,8 @@ void CTFSniperRifle::PlayWeaponShootSound( void )
 		const CEconItemView* pItem = GetAttributeContainer()->GetItem();
 		// Fixes rifles with "sniper_full_charge_damage_bonus"
 		// playing an undefined "SPECIAL3" sound when not fully charged.
-		// Improvment By Bitl
-		if (flDamageBonus > 1.0f && (pItem && pItem->GetStaticData()->GetWeaponReplacementSound(GetTeamNumber(), SPECIAL3)))
+		// Improvement By Bitl
+		if ( flDamageBonus > 1.0f && ( pItem && pItem->GetStaticData()->GetWeaponReplacementSound( GetTeamNumber(), SPECIAL3 )))
 		{
 			WeaponSound( SPECIAL3 );
 			return;


### PR DESCRIPTION
This PR fixes any sniper rifle that is Not the Machina playing an empty sound if "sniper_full_charge_damage_bonus" is not 1
