### PR TITLE
[ALL]? Add DevMsg's for returns in CBaseCombatWeapon::WeaponSound

### DIFF
--- a/src/game/shared/basecombatweapon_shared.cpp
+++ b/src/game/shared/basecombatweapon_shared.cpp
@@ -1909,12 +1909,18 @@ void CBaseCombatWeapon::WeaponSound( WeaponSound_t sound_type, float soundtime /
 	// If we have some sounds from the weapon classname.txt file, play a random one of them
 	const char *shootsound = GetShootSound( sound_type );
 	if ( !shootsound || !shootsound[0] )
+	{
+		DevMsg("No shoot sound for weapon %s\n", GetClassname());
 		return;
-
+	}
+	
 	CSoundParameters params;
 	
-	if ( !GetParametersForSound( shootsound, params, NULL ) )
+	if ( !GetParametersForSound(shootsound, params, NULL) )
+	{
+		DevMsg("No parameters for shoot sound %s\n", shootsound);
 		return;
+	}
 
 	if ( params.play_to_owner_only )
 	{


### PR DESCRIPTION
Adds some DevMsg's to Warn Players/Developers about missing shoot sounds
an example of this is in TF2 when adding "sniper_full_charge_damage_bonus" to a non Machina Rifle. Code tried to play "Special3" But for other Rifles, they dont have this sound defined, leading to a null sound in CBaseCombatWeapon::WeaponSound.
