### PR TITLE
[TF2] Allow null caller on team_control_point's SetOwner input

### DIFF
--- a/src/game/server/team_control_point.cpp
+++ b/src/game/server/team_control_point.cpp
@@ -336,11 +336,6 @@ void CTeamControlPoint::InputSetOwner( inputdata_t &input )
 
 	Assert( iCapTeam >= 0 && iCapTeam < GetNumberOfTeams() );
 
-	Assert( input.pCaller );
-
-	if ( !input.pCaller )
-		return;
-
 	if ( GetOwner() == iCapTeam )
 		return;
 
@@ -349,7 +344,7 @@ void CTeamControlPoint::InputSetOwner( inputdata_t &input )
 		// must be done before setting the owner
 		HandleScoring( iCapTeam );
 
-		if ( input.pCaller->IsPlayer() )
+		if ( input.pCaller && input.pCaller->IsPlayer() )
 		{
 			int iCappingPlayer = input.pCaller->entindex();
 			InternalSetOwner( iCapTeam, true, 1, &iCappingPlayer );


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

`team_control_point` has a SetOwner input for manually changing a point's ownership to a specified team. This input will credit a player for capturing the point if that player is the caller. If the calling entity is not a player, no credit is given.

However, there is an additional guard and assert against null callers which unexpectedly prevents the point from changing ownership at all. Given that nothing happens with the caller unless that caller is a player, these checks don't appear to serve any purpose beyond what the IsPlayer check already achieves.

This PR removes the guard and assert, incorporating the null-check alongside the IsPlayer check.

An easy way to test this PR is to use the following command in console on a koth map. Do not use `ent_fire` as that sets you as the caller.

`script Entities.FindByClassname(null, "team_control_point").AcceptInput("SetOwner", "3", null, null)`