### PR TITLE
[TF2] Fix team skins for tf_projectile_rocket

### DIFF
--- a/src/game/server/tf/tf_projectile_rocket.cpp
+++ b/src/game/server/tf/tf_projectile_rocket.cpp
@@ -52,6 +52,8 @@ void CTFProjectile_Rocket::Spawn()
 {
 	SetModel( ROCKET_MODEL );
 	BaseClass::Spawn();
+	CTFPlayer* pTFOwner = ToTFPlayer(GetOwnerPlayer());
+	m_nSkin = ( pTFOwner -> GetTeamNumber() == TF_TEAM_BLUE ) ? 1 : 0;
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
`tf_projectile_rocket` has no proper full support for team-based skingroups. When a rocket is fired, it will always be skin 0, the RED team skin. This would be considered fully-intended behaviour since no rocket model never uses team skins in the vanilla game (outside of clientside content mods and potentially custom maps changing the model with `SetModel`). However, this would only be the case were it not for the method `CTFProjectile_Rocket::Deflected`, which changes the team skin when the rocket is airblasted to the skingroup of the team that the deflector belongs to. 
As a result, the lack of team skin setting when the rocket is spawned is possibly erroneous.

This pull request fixes this discrepancy by adding the team skin support when the rocket is spawned.