### PR TITLE
[TF2] fix: cleanup collect on rest logic

### DIFF
--- a/src/game/server/tf/entity_currencypack.cpp
+++ b/src/game/server/tf/entity_currencypack.cpp
@@ -189,41 +189,25 @@ void CCurrencyPack::ComeToRest( void )
 		TFGameRules()->DistributeCurrencyAmount( m_nAmount );
 		m_bTouched = true;
 		UTIL_Remove( this );
-
 		return;
 	}
 
 	// See if we've come to rest in a trigger_hurt
-	for ( int i = 0; i < ITriggerHurtAutoList::AutoList().Count(); i++ )
+	if ( IsTakingTriggerHurtDamageAtPoint( GetAbsOrigin() ) )
 	{
-		CTriggerHurt *pTrigger = static_cast<CTriggerHurt*>( ITriggerHurtAutoList::AutoList()[i] );
-		if ( !pTrigger->m_bDisabled )
-		{
-			Vector vecMins, vecMaxs;
-			pTrigger->GetCollideable()->WorldSpaceSurroundingBounds( &vecMins, &vecMaxs );
-			if ( IsPointInBox( GetCollideable()->GetCollisionOrigin(), vecMins, vecMaxs ) )
-			{
-				TFGameRules()->DistributeCurrencyAmount( m_nAmount );
-
-				m_bTouched = true;
-				UTIL_Remove( this );
-			}
-		}
+		TFGameRules()->DistributeCurrencyAmount(m_nAmount);
+		m_bTouched = true;
+		UTIL_Remove(this);
+		return;
 	}
 
 	// Or a func_respawnroom (robots can drop money in their own spawn)
-	for ( int i = 0; i < IFuncRespawnRoomAutoList::AutoList().Count(); i++ )
+	if ( PointInRespawnRoom( NULL, GetAbsOrigin() ) )
 	{
-		CFuncRespawnRoom *pRespawnRoom = static_cast<CFuncRespawnRoom *>( IFuncRespawnRoomAutoList::AutoList()[ i ] );
-		Vector vecMins, vecMaxs;
-		pRespawnRoom->GetCollideable()->WorldSpaceSurroundingBounds( &vecMins, &vecMaxs );
-		if ( IsPointInBox( GetCollideable()->GetCollisionOrigin(), vecMins, vecMaxs ) )
-		{
-			TFGameRules()->DistributeCurrencyAmount( m_nAmount );
-
-			m_bTouched = true;
-			UTIL_Remove( this );
-		}
+		TFGameRules()->DistributeCurrencyAmount(m_nAmount);
+		m_bTouched = true;
+		UTIL_Remove(this);
+		return;
 	}
 }
 


### PR DESCRIPTION
Use the provided utility functions for trigger_hurt and respawn room to determine the relevance of the trigger, rather than doing a broader, incorrect bounds check. This takes into consideration all the relevant conditions for each respective trigger to be valid, and checks if the currency's point is truly within the trigger.

This fixes an error where some maps with more complex geometry for their triggers will cause a currency pickup, which was exacerbated by #618, which added respawn room to the logic.