### PR TITLE
Fix Entrance not getting using "mult_teleporter_recharge_rate"

### DIFF
--- a/src/game/server/tf/tf_obj_teleporter.cpp
+++ b/src/game/server/tf/tf_obj_teleporter.cpp
@@ -1166,6 +1166,12 @@ void CObjectTeleporter::TeleporterThink( void )
 			SetState( TELEPORTER_STATE_RECHARGING );
 
 			m_flCurrentRechargeDuration = (float)g_iTeleporterRechargeTimes[GetUpgradeLevel()];
+			if (!m_bWasMapPlaced)
+			{
+				CALL_ATTRIB_HOOK_FLOAT_ON_OTHER(GetBuilder(), m_flCurrentRechargeDuration, mult_teleporter_recharge_rate);
+			}
+			
+			m_flRechargeTime = gpGlobals->curtime + m_flCurrentRechargeDuration;
 			m_flMyNextThink = gpGlobals->curtime + m_flCurrentRechargeDuration;
 		}
 		break;


### PR DESCRIPTION
Fixes Entrance teleporters using the stock Recharge time and not calling `mult_teleporter_recharge_rate` to either speed up or slow down recharge times