### PR TITLE
[TF2] Fixed on-hit attributes not triggering on friendly disguises

### DIFF
--- a/src/game/shared/tf/tf_weaponbase.cpp
+++ b/src/game/shared/tf/tf_weaponbase.cpp
@@ -5030,7 +5030,7 @@ void CTFWeaponBase::ApplyOnHitAttributes( CBaseEntity *pVictimBaseEntity, CTFPla
 		}
 
 		// On hit attributes don't work when you shoot disguised spies
-		if ( pVictim->m_Shared.InCond( TF_COND_DISGUISED ) )
+		if ( pVictim->m_Shared.InCond( TF_COND_DISGUISED ) && pVictim->m_Shared.GetDisguiseTeam() != pVictim->GetTeamNumber() )
 			return;
 	}
 


### PR DESCRIPTION
Fixed many on-hit attributes preventing being triggered by a disguise of the Spy's same team. For example, hitting a RED Spy disguised as a RED Scout with the Übersaw results in no ÜberCharge being given despite (visually) hitting an enemy player. This fix applies to:
* The Baby Face's Blaster's boost
* The Pretty Boy's Pocket Pistol's health on hit
* The Eviction Notice's speed boost on hit
* The Übersaw's ÜberCharge on hit
* The Blutsauger's health on hit

Intended to fix https://github.com/ValveSoftware/Source-1-Games/issues/7609.

This fix compliments #1480, which fixes the Widowmaker's metal returned on hit not applying to friendly disguises.