### PR TITLE
[ALL] Add Convar to Remove print from having cheats on for Achievements

### DIFF
--- a/src/game/shared/achievementmgr.cpp
+++ b/src/game/shared/achievementmgr.cpp
@@ -48,6 +48,7 @@
 #endif
 
 ConVar	cc_achievement_debug( "achievement_debug", "0", FCVAR_CHEAT | FCVAR_REPLICATED, "Turn on achievement debug msgs." );
+ConVar  achievement_show_cheat_message("achievement_show_cheat_message", "1", FCVAR_REPLICATED, "Show message when achievements are disabled due to cheats.");
 
 #ifdef CSTRIKE_DLL
 //=============================================================================
@@ -1109,7 +1110,10 @@ bool CAchievementMgr::CheckAchievementsEnabled()
 			// on Steam public
 			if ( developer.GetInt() == 0 || ( k_EUniverseInvalid == GetUniverse() ) || ( k_EUniversePublic == GetUniverse() ) )
 			{
-				Msg( "Achievements disabled: cheats turned on in this app session.\n" );
+				if ( achievement_show_cheat_message.GetBool() )
+				{
+					Msg("Achievements disabled: cheats turned on in this app session.\n");
+				}
 				return false;
 			}
 #endif


### PR DESCRIPTION
Adds a Convar that disables the `"Achievements disabled: cheats turned on in this app session."` message from showing up. useful for people messing with the SDK or server owners who have to turn cheats on and have their consoles being spammed by this message.