### PR TITLE
Fix mounting of custom content in gameinfo

### DIFF
--- a/game/mod_hl2mp/gameinfo.txt
+++ b/game/mod_hl2mp/gameinfo.txt
@@ -42,7 +42,7 @@
 			// folder.
 			//
 			// Note that this folder is scanned only when the game is booted.
-			game+mod			mod_hl2mp/custom/*
+			game+mod+custom_mod	|gameinfo_path|custom/*
 
 			// Now search loose files.  We'll set the directory containing the gameinfo.txt file
 			// as the first "mod" search path (after any user customizations).  This is also the one

--- a/game/mod_tf/gameinfo.txt
+++ b/game/mod_tf/gameinfo.txt
@@ -32,9 +32,9 @@
 			// folder.
 			//
 			// Note that this folder is scanned only when the game is booted.
-			game+mod	mod_tf/custom/*
+			game+mod+custom_mod	|gameinfo_path|custom/*
 			// Enable this if you want to load your TF custom content.
-			//game+mod	|appid_440|tf/custom/*
+			//game+mod+custom_mod	|appid_440|tf/custom/*
 
 			// Now search loose files.  We'll set the directory containing the gameinfo.txt file
 			// as the first "mod" search path (after any user customizations).  This is also the one


### PR DESCRIPTION
There is two issues with how the `custom` folder is mounted in the SDK currently:
1. The custom folder is using the hardcoded mod's directory name. Not only is this less maintainable, external tools cannot resolve the path correctly. This was an issue observed in Hammer.
2. TF2 uses `custom_mod` pathid to only mount custom HUDs are that are installed in a folder with this path id. Right now custom HUDs do not work as there is no `custom_mod` pathid unlike live TF

The PR addresses both of these issues for TF2 and HL2MP