### PR TITLE
[TF2] Map prefix check bug on Workshop maps

### DIFF
--- a/src/game/client/tf/vgui/tf_mapinfomenu.cpp
+++ b/src/game/client/tf/vgui/tf_mapinfomenu.cpp
@@ -489,11 +489,11 @@ void CTFMapInfoMenu::LoadMapPage()
 
 			if( !g_pVGuiLocalize->Find( mapInfoKey ) )
 			{
-				if ( StringHasPrefix( m_szMapName, "vsh_" ) )
+				if ( MapHasPrefix( m_szMapName, "vsh_" ) )
 				{
 					pszDescription = "#default_vsh_description";
 				}
-				else if ( StringHasPrefix( m_szMapName, "zi_" ) )
+				else if ( MapHasPrefix( m_szMapName, "zi_" ) )
 				{
 					pszDescription = "#default_zi_description";
 				}

--- a/src/game/shared/tf/tf_gamerules.cpp
+++ b/src/game/shared/tf/tf_gamerules.cpp
@@ -980,7 +980,7 @@ static bool BIsCvarIndicatingHolidayIsActive( int iCvarValue, /*EHoliday*/ int e
 #ifdef GAME_DLL
 bool IsCustomGameMode( const char *pszMapName )
 {
-	return ( StringHasPrefix( pszMapName, "vsh_" ) || StringHasPrefix( pszMapName, "zi_" ) );
+	return ( MapHasPrefix( pszMapName, "vsh_" ) || MapHasPrefix( pszMapName, "zi_" ) );
 }
 
 bool IsCustomGameMode()
@@ -3516,7 +3516,7 @@ void CTFGameRules::Precache( void )
 		CMerasmus::PrecacheMerasmus();
 	}
 
-	if ( StringHasPrefix( STRING( gpGlobals->mapname ), "mvm_" ) )
+	if ( MapHasPrefix( STRING( gpGlobals->mapname ), "mvm_" ) )
 	{
 		CTFPlayer::PrecacheMvM();
 	}
@@ -4303,7 +4303,7 @@ void CTFGameRules::Activate()
 		tf_gamemode_mvm.SetValue( 1 );
 		m_nGameType.Set( TF_GAMETYPE_MVM );
 	}
-	else if ( StringHasPrefix( STRING( gpGlobals->mapname ), "sd_" ) )
+	else if ( MapHasPrefix( STRING( gpGlobals->mapname ), "sd_" ) )
 	{
 		m_bPlayingSpecialDeliveryMode.Set( true );
 		tf_gamemode_sd.SetValue( 1 );

--- a/src/game/shared/util_shared.h
+++ b/src/game/shared/util_shared.h
@@ -693,4 +693,11 @@ const char		   *UTIL_GetActiveOperationString();
 
 const char *GetCleanMapName( const char *pszUnCleanMapName, char (&pszTmp)[256] );
 
+inline bool	MapHasPrefix( const char *pszUnCleanMapName, const char *prefix )
+{ 
+	char maptmp[256];
+	const char *pszCleanMapName = GetCleanMapName( pszUnCleanMapName, maptmp );
+
+	return StringHasPrefix(pszCleanMapName, prefix);
+}
 #endif // UTIL_SHARED_H


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description

tl;dr - some map prefix checks don't account for the `workshop/` prefix, which leads to problems. This PR fixes that.

When TF2 maps are loaded directly from the workshop via `map workshop/<entryid>`, the mapname has a different format:
```cs
koth_trainsawlaser_v3 //normal
workshop/koth_trainsawlaser_v3.ugc3566434696 //workshop
```
While most map prefix checks _do_ account for this, there's a few exceptions that don't, which leads to the following observable bugs:
- Special Delivery maps don't get recognized as Special Delivery, and the game treats them as normal CTF.
- `CTFPlayer::PrecacheMvM();` never gets triggered, therefore some MvM assets never get loaded/cached. Namely, footstep sounds.
- `IsCustomGameMode()` check for VSH and ZI fails, meaning `server_custom.cfg` never gets loaded and the `autoteam` command still works (it's meant to be disabled in those gamemodes).

Because maps are usually playtested _before_ being uploaded to the workshop, very often these bugs don't get caught by the mappers.