### PR TITLE
Stop a crash when prop_ragdoll has NULL modelname

### DIFF
--- a/src/game/server/baseentity.cpp
+++ b/src/game/server/baseentity.cpp
@@ -8510,7 +8510,7 @@ void CBaseEntity::SetCollisionBoundsFromModel()
 
 
 //------------------------------------------------------------------------------
-// Purpose: Create an NPC of the given type
+// Purpose: Create an entity of the given type
 //------------------------------------------------------------------------------
 void CC_Ent_Create( const CCommand& args )
 {

--- a/src/game/server/physics_prop_ragdoll.cpp
+++ b/src/game/server/physics_prop_ragdoll.cpp
@@ -283,6 +283,11 @@ CRagdollProp::~CRagdollProp( void )
 
 void CRagdollProp::Precache( void )
 {
+	if (GetModelName() == NULL_STRING)
+	{
+		Msg("%s at (%.3f, %.3f, %.3f) has no model name!\n", GetClassname(), GetAbsOrigin().x, GetAbsOrigin().y, GetAbsOrigin().z);
+		return;
+	}
 	PrecacheModel( STRING( GetModelName() ) );
 	BaseClass::Precache();
 }


### PR DESCRIPTION
This already exists for prop_physics and even prop_dynamic, but not prop_ragdoll.


# Description
**CBaseProp**s already default to "error.mdl" if we didn't provide a model name, while CPhysicsProp outright halts if you leave it undefined. **CRagdollProp** however, is an exception if you just `ent_create prop_ragdoll`.