### PR TITLE
all games: Add parameter for getpos/spec_pos to copy output to clipboard

### DIFF
--- a/src/game/client/view.cpp
+++ b/src/game/client/view.cpp
@@ -45,6 +45,8 @@
 #include "ScreenSpaceEffects.h"
 #include "sourcevr/isourcevirtualreality.h"
 #include "client_virtualreality.h"
+#include "fmtstr.h"
+#include "vgui/ISystem.h"
 
 #if defined( REPLAY_ENABLED )
 #include "replay/ireplaysystem.h"
@@ -1275,30 +1277,46 @@ static void GetPos( const CCommand &args, Vector &vecOrigin, QAngle &angles )
 	}
 }
 
-CON_COMMAND( spec_pos, "dump position and angles to the console" )
+CON_COMMAND( spec_pos, "dump position and angles to the console ( 1 = to clipboard )" )
 {
 	Vector vecOrigin;
 	QAngle angles;
 	GetPos( args, vecOrigin, angles );
-	Warning( "spec_goto %.1f %.1f %.1f %.1f %.1f\n", vecOrigin.x, vecOrigin.y, 
-		vecOrigin.z, angles.x, angles.y );
+
+	bool bClip = ( args.ArgC() >= 2 && Q_atoi( args[ 1 ] ) == 1 );
+
+	CFmtStr fmtCommand(
+		"spec_goto %.1f %.1f %.1f %.1f %.1f",
+		vecOrigin.x, vecOrigin.y, vecOrigin.z, angles.x, angles.y
+	);
+
+	Warning( "%s\n", fmtCommand.String() );
+	if ( bClip )
+	{
+		vgui::system()->SetClipboardText( fmtCommand.String(), fmtCommand.Length() );
+	}
 }
 
-CON_COMMAND( getpos, "dump position and angles to the console" )
+CON_COMMAND( getpos, "dump position and angles to the console ( 1 = to clipboard, 2 = exact pos, 3 = all )" )
 {
 	Vector vecOrigin;
 	QAngle angles;
 	GetPos( args, vecOrigin, angles );
 
-	const char *pCommand1 = "setpos";
-	const char *pCommand2 = "setang";
-	if ( args.ArgC() == 2 && atoi( args[1] ) == 2 )
-	{
-		pCommand1 = "setpos_exact";
-		pCommand2 = "setang_exact";
-	}
+	int  nParm  = ( args.ArgC() >= 2 ) ? Q_atoi( args[ 1 ] ) : 0;
+	bool bClip  = ( nParm == 1 || nParm == 3 );
+	bool bExact = ( nParm == 2 || nParm == 3 );
 
-	Warning( "%s %f %f %f;", pCommand1, vecOrigin.x, vecOrigin.y, vecOrigin.z );
-	Warning( "%s %f %f %f\n", pCommand2, angles.x, angles.y, angles.z );
+	CFmtStr fmtCommand(
+		"%s %f %f %f;%s %f %f %f",
+		bExact ? "setpos_exact" : "setpos", vecOrigin.x, vecOrigin.y, vecOrigin.z,
+		bExact ? "setang_exact" : "setang", angles.x, angles.y, angles.z
+	);
+
+	Warning( "%s\n", fmtCommand.String() );
+	if ( bClip )
+	{
+		vgui::system()->SetClipboardText( fmtCommand.String(), fmtCommand.Length() );
+	}
 }
 


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
Adds an overload to `getpos` and `spec_pos` ConCommands so the returned commands get automatically copied to the user's clipboard if desired, akin to `getposcopy` family of ConCommands added in Source 2 codebase around October.