### PR TITLE
[TF2] Fix spelled color cosmetics not changing colors in backpack after initialization of panel

### DIFF
--- a/src/game/client/econ/item_model_panel.cpp
+++ b/src/game/client/econ/item_model_panel.cpp
@@ -3149,7 +3149,7 @@ void CItemModelPanel::UpdatePanels( void )
 
 			if ( !bIsEconTool )
 			{
-				DrawPaintImage( iRGB0, iRGB1 );
+				SetupPaintData( iRGB0, iRGB1 );
 			}
 		}
 	}
@@ -3404,7 +3404,7 @@ void CItemModelPanel::SetModelIsHidden( bool bHideModel )
 	}
 }
 
-void CItemModelPanel::DrawPaintImage( int iRGB0, int iRGB1 )
+void CItemModelPanel::SetupPaintData( int iRGB0, int iRGB1 )
 {
 	if ( iRGB0 != 0 || iRGB1 != 0 )
 	{
@@ -3448,7 +3448,7 @@ void CItemModelPanel::OnTick()
 				int iRGB0 = m_ItemData.GetModifiedRGBValue( false ),
 					iRGB1 = m_ItemData.GetModifiedRGBValue( true );
 
-				DrawPaintImage( iRGB0, iRGB1 );
+				SetupPaintData( iRGB0, iRGB1 );
 			}
 		}
 	}

--- a/src/game/client/econ/item_model_panel.h
+++ b/src/game/client/econ/item_model_panel.h
@@ -292,7 +292,7 @@ private:
 
 	bool	bLoadingData = true;
 
-	void	DrawPaintImage( int iRGB0, int iRGB1 );
+	void	SetupPaintData( int iRGB0, int iRGB1 );
 
 	bool	UpdateSeriesLabel();
 	bool	UpdateMatchesLabel();


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

As the title explains, this PR adds the functionality mentioned within the attached issue.

In current TF2, it grabs the paint color at the frame the panel is loaded. Which results in a static image that doesn’t associate correctly for spelled items that keep changing colors.

This PR corrects that, making spelled cosmetics that cycle with colors now animate within the backpack. The new code only runs on items that have the spell every tick whilst running only once for everything else as originally intended.

Closes https://github.com/ValveSoftware/Source-1-Games/issues/7587

![SpelledCosmetics](https://github.com/user-attachments/assets/29c1205b-24bc-41d5-8727-d269af31f2dc)