### PR TITLE
Fix robots making human fall damage pain sounds

### DIFF
--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -15147,7 +15147,16 @@ void CTFPlayer::PainSound( const CTakeDamageInfo &info )
 			TFPlayerClassData_t *pData = GetPlayerClass()->GetData();
 			if ( pData )
 			{
-				EmitSound( pData->GetDeathSound( DEATH_SOUND_GENERIC ) );
+				int nDeathSound = DEATH_SOUND_GENERIC;
+				if ( TFGameRules() && TFGameRules()->IsMannVsMachineMode() && GetTeamNumber() == TF_TEAM_PVE_INVADERS )
+				{
+					nDeathSound = DEATH_SOUND_GENERIC_MVM;
+					if ( IsMiniBoss() )
+					{
+						nDeathSound = DEATH_SOUND_GENERIC_GIANT_MVM;
+					}
+				}
+				EmitSound( pData->GetDeathSound( nDeathSound ) );
 			}
 		}
 		return;


### PR DESCRIPTION
> This is a resubmission of #1185, which closed because of a deleted fork. I am the original author.

Hi. This fixes a bug where MvM bots will make human pain sounds when taking fall damage. If my memory is correct, this has been a bug since Meet Your Match.

This basically just copies the behavior of `CTFPlayer::DeathSound`, where invaders make robot death sounds and giants make no sounds at all.