### PR TITLE
[HL2MP] Fix nullptr crash with `hl2mp_allow_pickup` on useable items

### DIFF
--- a/src/game/shared/hl2mp/weapon_physcannon.cpp
+++ b/src/game/shared/hl2mp/weapon_physcannon.cpp
@@ -798,6 +798,13 @@ void CPlayerPickupController::Use( CBaseEntity *pActivator, CBaseEntity *pCaller
 			return;
 		}
 
+		// Stop holding when object doesn't exist anymore
+		if (!pPhys)
+		{
+			Shutdown();
+			return;
+		}
+
 #if STRESS_TEST
 		vphysics_objectstress_t stress;
 		CalculateObjectStress( pPhys, pAttached, &stress );


### PR DESCRIPTION
Holding an item (like a health kit) and using it (e.g. healing) will free the object from memory, but player will still be holding it, pressing attack1 will then crash the game.

https://github.com/user-attachments/assets/a3d0611c-5223-4428-be27-9f08398c6817

Fix:
 - Check if pPhys still exists, if not, stop holding.
