### PR TITLE
Allow exceeding t-junction limit in VBSP

### DIFF
--- a/src/utils/vbsp/faces.cpp
+++ b/src/utils/vbsp/faces.cpp
@@ -584,6 +584,9 @@ FixFaceEdges
 
 ==================
 */
+int g_numprimitives_overflow = 0;
+int g_numprimindices_overflow = 0;
+
 void FixFaceEdges (face_t **pList, face_t *f)
 {
 	int		p1, p2;
@@ -673,6 +676,17 @@ void FixFaceEdges (face_t **pList, face_t *f)
 			inIndices.AddToTail( i );
 		}
 		Triangulate_r( outIndices, inIndices, poly );
+
+		// maps with heavy use of detail brushes can overflow primitives
+		// but thats OK, the maps will still work without them
+		if ( ( g_numprimitives + 1 ) > MAX_MAP_PRIMITIVES
+			|| ( g_numprimindices + outIndices.Count() ) > MAX_MAP_PRIMINDICES )
+		{
+			g_numprimitives_overflow++;
+			g_numprimindices_overflow += outIndices.Count();
+			return;
+		}
+
 		dprimitive_t &newPrim = g_primitives[g_numprimitives];
 		f->firstPrimID = g_numprimitives;
 		g_numprimitives++;
@@ -683,10 +697,7 @@ void FixFaceEdges (face_t **pList, face_t *f)
 		newPrim.vertCount = 0;
 		newPrim.type = PRIM_TRILIST;
 		g_numprimindices += newPrim.indexCount;
-		if ( g_numprimitives > MAX_MAP_PRIMITIVES || g_numprimindices > MAX_MAP_PRIMINDICES )
-		{
-			Error("Too many t-junctions to fix up! (%d prims, max %d :: %d indices, max %d)\n", g_numprimitives, MAX_MAP_PRIMITIVES, g_numprimindices, MAX_MAP_PRIMINDICES );
-		}
+
 		for ( i = 0; i < outIndices.Count(); i++ )
 		{
 			g_primindices[newPrim.firstIndex + i] = outIndices[i];
@@ -784,6 +795,15 @@ face_t *FixTjuncs (node_t *headnode, face_t *pLeafFaceList)
 	return pLeafFaceList;
 }
 
+void EndTjuncs()
+{
+	if ( g_numprimindices_overflow > 0 || g_numprimitives_overflow > 0 )
+	{
+		Warning( "Exceeded max t-junctions fixup limit! (%d/%d primitives, %d/%d indices)\n",
+			g_numprimitives + g_numprimitives_overflow, MAX_MAP_PRIMITIVES,
+			g_numprimindices + g_numprimindices_overflow, MAX_MAP_PRIMINDICES );
+	}
+}
 
 //========================================================
 

--- a/src/utils/vbsp/vbsp.cpp
+++ b/src/utils/vbsp/vbsp.cpp
@@ -858,6 +858,8 @@ void ProcessModels (void)
 		}
 	}
 
+	EndTjuncs();
+
 	// Turn the skybox into a cubemap in case we don't build env_cubemap textures.
 	Cubemap_CreateDefaultCubemaps();
 	EndBSPFile ();

--- a/src/utils/vbsp/vbsp.h
+++ b/src/utils/vbsp/vbsp.h
@@ -558,6 +558,7 @@ extern	int	firstmodelface;
 void MakeFaces (node_t *headnode);
 void MakeDetailFaces (node_t *headnode);
 face_t *FixTjuncs( node_t *headnode, face_t *pLeafFaceList );
+void EndTjuncs();
 
 face_t	*AllocFace (void);
 void FreeFace (face_t *f);


### PR DESCRIPTION
A problem that many modern maps have to deal with is the dreaded `Too many t-junctions to fix up!` error. T-junctions are formed to avoid visual seams in touching geometry. The limit is typically hit by heavy usage of `func_detail` geometry touching the world, or water brushes. Many modern TF2 maps tend to hit this error due to higher density of brush detail. 

In VBSP, the limit is dictated by `MAX_MAP_PRIMITIVES` and `MAX_MAP_PRIMINDICES` which are both 65536. ("Primitives" is what the fixed up geometry is called internally). Unfortunately, the BSP format stores primitive indexes as unsigned 16-bit integers, which means that these limits cannot be raised without modifying the BSP format, and therefore breaking backwards compatibility.

Rather than a fatal error when hitting the limit, this PR modifies the behavior to issue a warning and continue compiling. In practice, this doesn't appear to have significant side effects, and it's certainly better than having to reduce `func_detail` usage or convert them to entities etc. This is also better than using `-notjunc` or `-nodetailcracks` parameters, as this allows most of the seams to remain fixed.

Note: [VBSP++](https://ficool2.github.io/HammerPlusPlus-Website/tools.html) implements this change, and it has been battle-tested publicly on many maps.