### PR TITLE
[TF2] Fixed Pomson colliding with teammates at close range

### DIFF
--- a/src/game/shared/tf/tf_projectile_energy_ring.cpp
+++ b/src/game/shared/tf/tf_projectile_energy_ring.cpp
@@ -256,11 +256,11 @@ void CTFProjectile_EnergyRing::ProjectileTouch( CBaseEntity *pOther )
 
 	if ( bCombatEntity )
 	{
-		// Bison projectiles shouldn't collide with friendly things
-		if ((ShouldPenetrate() && (pOther->InSameTeam(this) || (gpGlobals->curtime - m_flLastHitTime) < tf_bison_tick_time.GetFloat())) || // Bison
-			(!ShouldPenetrate() && pOther->InSameTeam(this) && !CanCollideWithTeammates())) // Pomson
+		// Bison projectiles shouldn't collide with friendly things, Pomson should only collide after default no-collision period is over
+		if ((ShouldPenetrate() && (pOther->InSameTeam(this) || (gpGlobals->curtime - m_flLastHitTime) < tf_bison_tick_time.GetFloat())) ||
+			(!ShouldPenetrate() && pOther->InSameTeam(this) && !CanCollideWithTeammates()))
 		{
-			return; //Pass through
+			return;
 		}
 
 		m_flLastHitTime = gpGlobals->curtime;


### PR DESCRIPTION
The Pomson 6000 currently immediately collides with teammates, which makes it absolutely unusable near any teammate. This fix simply makes it behave like other projectiles, such as rockets, which pass through teammates for a short duration after being fired. Does not affect the behaviour on enemy players, nor does it affect the Bison.

Demonstration of how it works with this fix: https://www.youtube.com/watch?v=NR5eppSOFgk

Partially fixes https://github.com/ValveSoftware/Source-1-Games/issues/2592