### PR TITLE
[TF] Revised/reworked Gas Passer spawnroom fixes to only take effect before a game/round starts

### DIFF
--- a/src/game/shared/tf/tf_weapon_jar_gas.cpp
+++ b/src/game/shared/tf/tf_weapon_jar_gas.cpp
@@ -366,6 +366,20 @@ bool CTFGasManager::ShouldCollide( CBaseEntity *pEnt ) const
 
 	if ( pEnt->GetTeamNumber() == GetTeamNumber() )
 		return false;
+	
+	bool bIsBeforeRound = ( TFGameRules()->State_Get() == GR_STATE_PREGAME ||
+		TFGameRules()->State_Get() == GR_STATE_PREROUND ||
+		TFGameRules()->InSetup() ||
+		TFGameRules()->IsInWaitingForPlayers() );
+
+	if ( bIsBeforeRound )
+	{
+		if ( PointsCrossRespawnRoomVisualizer( GetInitialPosition(), pEnt->GetAbsOrigin() ) )
+			return false;
+
+		if ( PointInRespawnRoom( pEnt, pEnt->GetAbsOrigin() ) )
+			return false;
+	}
 
 	if ( TFGameRules() && TFGameRules()->IsTruceActive() )
 		return false;


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
This PR revises the Gas Passer fixes in #1485, as the PR has been proven to be not effective on all maps and may nerf the weapon when using it against players in respawn rooms after a round starts.

This new version of the fix prevents new gas points from spawning in respawn rooms before the game begins. This also adds new checks in ShouldCollide to only prevent covering players with gas before the game begins. After the game starts, the gas passer can be thrown into respawn rooms and spread normally, like the original pre-10/23 patch behavior. 

This also includes a debug command where you can see the individual gas points.

red = client
blue = server (where the respawn room fix is applied)

pre-round:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/7ec9eaf9-fb55-4dcf-9cee-c01d56ebac8f" />

in round:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/966d9f0d-1c78-4a17-b11b-f4daf57ca3ba" />
