### PR TITLE
[TF] Implement debug command for the Gas Passer's gas.

### DIFF
--- a/src/game/shared/tf/tf_weapon_jar_gas.cpp
+++ b/src/game/shared/tf/tf_weapon_jar_gas.cpp
@@ -32,6 +32,7 @@
 #include "func_respawnroom.h"
 #endif
 
+ConVar	tf_debug_gas("tf_debug_gas", "0", FCVAR_CHEAT | FCVAR_REPLICATED, "Visualize the gas particles.");
 
 IMPLEMENT_NETWORKCLASS_ALIASED( TFJarGas, DT_TFWeaponJarGas )
 
@@ -398,6 +399,12 @@ void CTFGasManager::OnCollide( CBaseEntity *pEnt, int iPointIndex )
 }
 #endif // GAME_DLL
 
+void DebugGas( const Vector& vStart, const Vector& vEnd, const Vector& vMin, const Vector& vMax, const Color& color )
+{
+	NDebugOverlay::Line( vStart, vEnd, 255, 255, 0, false, 0.0f );
+	NDebugOverlay::SweptBox( vStart, vEnd, vMin, vMax, vec3_angle, color.r(), color.g(), color.b(), color.a(), 0.0f );
+}
+
 //-----------------------------------------------------------------------------
 // Purpose:
 //-----------------------------------------------------------------------------
@@ -606,6 +613,23 @@ void CTFGasManager::Update()
 		}
 	}
 #endif // CLIENT_DLL
+
+	if ( tf_debug_gas.GetBool() )
+	{
+#ifdef GAME_DLL
+		Color color(0, 0, 255, 100);
+#else
+		Color color(255, 0, 0, 100);
+#endif
+		FOR_EACH_VEC( GetPointVec(), i )
+		{
+			float flRadius = GetRadius( GetPointVec()[i] );
+			Vector vMins = flRadius * Vector(-1, -1, -1);
+			Vector vMaxs = flRadius * Vector(1, 1, 1);
+
+			DebugGas( GetPointVec()[i]->m_vecPrevPosition, GetPointVec()[i]->m_vecPosition, vMins, vMaxs, color );
+		}
+	}
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
This command, tf_debug_gas, allows you to visualize the various points of the Gas Passer's gas effect, much like tf_debug_flamethrower.

Moved from #1568 into its own PR,