### PR TITLE
[TF2] Fix TFBot crash related to moving control points

### DIFF
--- a/src/game/server/tf/bot/behavior/scenario/capture_point/tf_bot_capture_point.cpp
+++ b/src/game/server/tf/bot/behavior/scenario/capture_point/tf_bot_capture_point.cpp
@@ -95,7 +95,7 @@ ActionResult< CTFBot >	CTFBotCapturePoint::Update( CTFBot *me, float interval )
 			if ( controlPointAreas->Count() == 0 )
 			{
 				Assert( controlPointAreas->Count() );
-				Continue(); // this control point has no nav areas for bot to move around
+				return Continue(); // this control point has no nav areas for bot to move around
 			}
 
 			// move to a random spot on this control point


### PR DESCRIPTION
The failsafe for not having any nav areas found for a control point while a bot is capturing it does not work correctly, causing a crash.

Affects maps like tow_tetsudo (workshop/3481396928).
