### PR TITLE
[TF2] Fix high melee firing speed not working correctly

### DIFF
--- a/src/game/shared/tf/tf_weaponbase_melee.cpp
+++ b/src/game/shared/tf/tf_weaponbase_melee.cpp
@@ -271,7 +271,8 @@ void CTFWeaponBaseMelee::PlaySwingSound( void )
 //-----------------------------------------------------------------------------
 void CTFWeaponBaseMelee::Swing( CTFPlayer *pPlayer )
 {
-	if ( m_flSmackTime>=m_flNextPrimaryAttack )
+	// A previous smack could be pending, so do the smack before we forget about it
+	if ( m_flSmackTime >= m_flNextPrimaryAttack )
 	{
 		Smack();
 	}


### PR DESCRIPTION
Fixes https://github.com/ValveSoftware/Source-1-Games/issues/6223

I'm a bit concerned if this fix will be working correctly if `m_flNextPrimaryAttack` becomes too high (loss of resolution).
Maybe it does not matter...

Suggestions welcomed
