### PR TITLE
Fix crash if bonemerging to a pending model

### DIFF
--- a/src/game/server/baseanimating.cpp
+++ b/src/game/server/baseanimating.cpp
@@ -1556,7 +1556,7 @@ void CBaseAnimating::GetBoneTransform( int iBone, matrix3x4_t &pBoneToWorld )
 		return;
 	}
 
-	CBoneCache *pcache = GetBoneCache( );
+	CBoneCache *pcache = GetBoneCache( pStudioHdr );
 
 	matrix3x4_t *pmatrix = pcache->GetCachedBone( iBone );
 
@@ -1941,26 +1941,30 @@ void CBaseAnimating::SetupBones( matrix3x4_t *pBoneToWorld, int boneMask )
 	CBaseAnimating *pParent = dynamic_cast< CBaseAnimating* >( GetMoveParent() );
 	if ( pParent )
 	{
-		// We're doing bone merging, so do special stuff here.
-		CBoneCache *pParentCache = pParent->GetBoneCache();
-		if ( pParentCache )
+		CStudioHdr* pParentHdr = pParent->GetModelPtr();
+		if ( pParentHdr )
 		{
-			BuildMatricesWithBoneMerge( 
-				pStudioHdr, 
-				GetAbsAngles(), 
-				adjOrigin, 
-				pos, 
-				q, 
-				pBoneToWorld, 
-				pParent, 
-				pParentCache );
-			
-			RemoveEFlags( EFL_SETTING_UP_BONES );
-			if (ai_setupbones_debug.GetBool())
+			// We're doing bone merging, so do special stuff here.
+			CBoneCache *pParentCache = pParent->GetBoneCache( pParentHdr );
+			if ( pParentCache )
 			{
-				DrawRawSkeleton( pBoneToWorld, boneMask, true, 0.11 );
+				BuildMatricesWithBoneMerge( 
+					pStudioHdr, 
+					GetAbsAngles(), 
+					adjOrigin, 
+					pos, 
+					q, 
+					pBoneToWorld, 
+					pParent, 
+					pParentCache );
+				
+				RemoveEFlags( EFL_SETTING_UP_BONES );
+				if (ai_setupbones_debug.GetBool())
+				{
+					DrawRawSkeleton( pBoneToWorld, boneMask, true, 0.11 );
+				}
+				return;
 			}
-			return;
 		}
 	}
 
@@ -2747,9 +2751,8 @@ void CBaseAnimating::UnlockStudioHdr()
 // Purpose: return the index to the shared bone cache
 // Output :
 //-----------------------------------------------------------------------------
-CBoneCache *CBaseAnimating::GetBoneCache( void )
+CBoneCache *CBaseAnimating::GetBoneCache( CStudioHdr* pStudioHdr )
 {
-	CStudioHdr *pStudioHdr = GetModelPtr( );
 	Assert(pStudioHdr);
 
 	CBoneCache *pcache = Studio_GetBoneCache( m_boneCacheHandle );
@@ -2846,7 +2849,7 @@ bool CBaseAnimating::TestHitboxes( const Ray_t &ray, unsigned int fContentsMask,
 	if ( !set || !set->numhitboxes )
 		return false;
 
-	CBoneCache *pcache = GetBoneCache( );
+	CBoneCache *pcache = GetBoneCache( pStudioHdr );
 
 	matrix3x4_t *hitboxbones[MAXSTUDIOBONES];
 	pcache->ReadCachedBonePointers( hitboxbones, pStudioHdr->numbones() );
@@ -3257,7 +3260,7 @@ bool CBaseAnimating::ComputeHitboxSurroundingBox( Vector *pVecWorldMins, Vector 
 	if ( !set || !set->numhitboxes )
 		return false;
 
-	CBoneCache *pCache = GetBoneCache();
+	CBoneCache *pCache = GetBoneCache( pStudioHdr );
 
 	// Compute a box in world space that surrounds this entity
 	pVecWorldMins->Init( FLT_MAX, FLT_MAX, FLT_MAX );
@@ -3297,7 +3300,7 @@ bool CBaseAnimating::ComputeEntitySpaceHitboxSurroundingBox( Vector *pVecWorldMi
 	if ( !set || !set->numhitboxes )
 		return false;
 
-	CBoneCache *pCache = GetBoneCache();
+	CBoneCache *pCache = GetBoneCache( pStudioHdr );
 	matrix3x4_t *hitboxbones[MAXSTUDIOBONES];
 	pCache->ReadCachedBonePointers( hitboxbones, pStudioHdr->numbones() );
 

--- a/src/game/server/baseanimating.h
+++ b/src/game/server/baseanimating.h
@@ -277,7 +277,7 @@ public:
 	void ReportMissingActivity( int iActivity );
 	virtual bool TestCollision( const Ray_t &ray, unsigned int fContentsMask, trace_t& tr );
 	virtual bool TestHitboxes( const Ray_t &ray, unsigned int fContentsMask, trace_t& tr );
-	class CBoneCache *GetBoneCache( void );
+	class CBoneCache *GetBoneCache( CStudioHdr* pStudioHdr );
 	void InvalidateBoneCache();
 	void InvalidateBoneCacheIfOlderThan( float deltaTime );
 	virtual int DrawDebugTextOverlays( void );

--- a/src/game/server/tf/tf_projectile_arrow.cpp
+++ b/src/game/server/tf/tf_projectile_arrow.cpp
@@ -342,7 +342,7 @@ bool CTFProjectile_Arrow::PositionArrowOnBone( mstudiobbox_t *pBox, CBaseAnimati
 	if ( pBox->bone < 0 || pBox->bone >= pStudioHdr->numbones() )	// Bone index must be valid.
 		return false;
 
-	CBoneCache *pCache = pOtherAnim->GetBoneCache();
+	CBoneCache *pCache = pOtherAnim->GetBoneCache( pStudioHdr );
 	if ( !pCache )
 		return false;
 

--- a/src/game/shared/tf/tf_weapon_jar.cpp
+++ b/src/game/shared/tf/tf_weapon_jar.cpp
@@ -638,7 +638,7 @@ bool CTFProjectile_Jar::PositionArrowOnBone( mstudiobbox_t *pBox, CBaseAnimating
 	if ( pBox->bone < 0 || pBox->bone >= pStudioHdr->numbones() )	// Bone index must be valid.
 		return false;
 
-	CBoneCache *pCache = pOtherAnim->GetBoneCache();
+	CBoneCache *pCache = pOtherAnim->GetBoneCache( pStudioHdr );
 	if ( !pCache )
 		return false;
 


### PR DESCRIPTION
If an entity is bonemerging to a parent whose model has not been loaded yet, this will cause a server crash. This has been a top cause of crashing on a specific community server across various maps.

Specifically this is caused by `CBaseAnimating::SetupBones` not checking if the model pointer is valid when attempting to fetch the parent's bone cache. This PR introduces a check for validity.

In addition, all call sites to `CBaseAnimating::GetBoneCache` are required now to pass the model pointer. This is consistent with the client (see `C_BaseAnimating::GetBoneCache`), and also prevents inefficiency, as `GetModelPtr()` is expensive.

<img width="871" height="638" alt="image" src="https://github.com/user-attachments/assets/86b38c19-49d6-41a0-8bae-797d4d685252" />
