### PR TITLE
fix: memory leak in server browser blacklist check

### DIFF
--- a/src/common/ServerBrowser/blacklisted_server_manager.cpp
+++ b/src/common/ServerBrowser/blacklisted_server_manager.cpp
@@ -43,7 +43,7 @@ void CBlacklistedServerManager::Reset( void )
 //-----------------------------------------------------------------------------
 int CBlacklistedServerManager::LoadServersFromFile( const char *pszFilename, bool bResetTimes )
 {
-	KeyValues *pKV = new KeyValues( "serverblacklist" );
+	KeyValuesAD pKV( "serverblacklist" );
 	if ( !pKV->LoadFromFile( g_pFullFileSystem, pszFilename, "MOD" ) )
 		return 0;
 
@@ -74,8 +74,6 @@ int CBlacklistedServerManager::LoadServersFromFile( const char *pszFilename, boo
 			++count;
 		}
 	}
-
-	pKV->deleteThis();
 
 	return count;
 }


### PR DESCRIPTION
If we fail to load from file, the early return causes a memory leak.

If these conditions are right:
https://github.com/ValveSoftware/source-sdk-2013/blob/148eccb89de2564eb90cb93d190d673671352084/src/game/client/tf/clientmode_tf.cpp#L1766-L1769
We'd want to check if we should prompt the user to add the server to the blacklist where we'll call the `LoadServersFromFile` function (this also gets called if we add the server to the blacklist via the dialog).

Validated by running Frog Fortress 2, entering a server (`map ctf_2fort`) then quickly disconnecting.