### PR TITLE
CTFClassMenu: add key binds for selecting the random class

### DIFF
--- a/src/game/client/tf/vgui/tf_classmenu.cpp
+++ b/src/game/client/tf/vgui/tf_classmenu.cpp
@@ -875,7 +875,7 @@ void CTFClassMenu::OnKeyCodePressed( KeyCode code )
 {
 	m_KeyRepeat.KeyDown( code );
 
-	if ( code == KEY_0 || code == KEY_PAD_0 ) {
+	if ( code == KEY_BACKSPACE ) {
 		SelectClass( TF_CLASS_RANDOM  );
 		Go();
 	}


### PR DESCRIPTION
Adds keybinds for selecting the random class, this was requested in the [subreddit](https://www.reddit.com/r/tf2/comments/1oerhjr/comment/nl3n5az/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button).

**EDIT**: After revisions, this PR adds this via the `backspace` key now, not `0`, see first point of this [comment](https://github.com/ValveSoftware/source-sdk-2013/pull/1580#issuecomment-3447861908).

Video (can't really show it but I'm pressing `0`). 

https://github.com/user-attachments/assets/6e31a30d-a180-4d2a-84c6-22496e99db68

Note that I've also edited the `tf2_misc` vpk in `tf2_misc > resource > ui > classselection.res`: "Resource/UI/ClassSelection.res" > "random" to include:
```
		"labelText"			"0"	[$WIN32]
		"labelText"			""		[$X360]
```
for proper rendering, but this feature works without it.