### PR TITLE
[TF2] Fix being able to pick up tier 1 magic spells without a spellbook equipped.

### DIFF
--- a/src/game/server/tf/halloween/spell/tf_spell_pickup.cpp
+++ b/src/game/server/tf/halloween/spell/tf_spell_pickup.cpp
@@ -69,10 +69,10 @@ bool CSpellPickup::ItemCanBeTouchedByPlayer( CBasePlayer *pPlayer )
 	if ( IsDisabled() )
 		return false;
 
-	// Dont let them pick up new spells if they already have a spell unless its a tier 1 spell
 	CTFPlayer *pTFPlayer = ToTFPlayer( pPlayer );
-	if ( pTFPlayer && m_nTier == 0 )
+	if ( pTFPlayer )
 	{
+		// Check for spellbook regardless of tier
 		CTFSpellBook *pSpellBook = dynamic_cast< CTFSpellBook* >( pTFPlayer->GetEntityForLoadoutSlot( LOADOUT_POSITION_ACTION ) );
 		if ( !pSpellBook )
 		{
@@ -81,7 +81,8 @@ bool CSpellPickup::ItemCanBeTouchedByPlayer( CBasePlayer *pPlayer )
 			return false;
 		}
 		
-		if ( pSpellBook->HasASpellWithCharges() )
+		// Only check for existing charges on tier 0 spells
+		if ( m_nTier == 0 && pSpellBook->HasASpellWithCharges() )
 		{
 			return false;
 		}


### PR DESCRIPTION
Fixes: https://github.com/ValveSoftware/Source-1-Games/issues/7641

This PR prevents players from being able to pick up tier 1 magic spells if they don't have a spellbook equipped, this behavior already exists for tier 0 magic spells but not tier 1 currently.

With this fix, attempting to pick up a tier 1 magic spell without a spellbook equipped will notify you to equip a spellbook in your action slot before picking it up.