### PR TITLE
matsys_controls: Fix model panels not encoding pose parameter values

### DIFF
--- a/src/vgui2/matsys_controls/mdlpanel.cpp
+++ b/src/vgui2/matsys_controls/mdlpanel.cpp
@@ -586,7 +586,9 @@ bool CMDLPanel::SetPoseParameterByName( const char *pszName, float fValue )
 		const mstudioposeparamdesc_t &Pose = studioHdr.pPoseParameter( i );
 		if ( V_strcasecmp( pszName, Pose.pszName() ) == 0 )
 		{
-			m_PoseParameters[ i ] = fValue;
+			float ctlValue;
+			Studio_SetPoseParameter( &studioHdr, i, fValue, ctlValue );
+			m_PoseParameters[ i ] = ctlValue;
 			return true;
 		}
 	}


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
This issue caused Mutated Milk and Self-Aware Beauty Mark to not render properly in the TF loadout screen and 3D class portrait on the HUD.

These weapons override the player model's pose parameters to values declared in the econ item schema. 

`CTFPlayerModelPanel::SwitchHeldItemTo` would attempt to apply these values by calling `CMDLPanel::SetPoseParameterByName`, however that function wasn't setting them correctly since it would use the passed in ranged values directly without prior conversion to an encoded 0..1 value.

This PR addresses this by calling `Studio_SetPoseParameter` to encode the value, then using that to set the pose parameter.

| Before | After |
|--------|--------|
| <img width="624" height="515" alt="scout_before" src="https://github.com/user-attachments/assets/7de9f337-f35a-4973-aba7-8924f60bcf04" /> | <img width="606" height="521" alt="scout_after" src="https://github.com/user-attachments/assets/b89a68b4-591b-480f-8f15-fbe9f8401f2f" /> |
| <img width="555" height="519" alt="sniper_before" src="https://github.com/user-attachments/assets/304b23a5-4a80-4eb4-bde4-256b58d8eaaf" /> | <img width="572" height="528" alt="sniper_after" src="https://github.com/user-attachments/assets/7a0dad33-4544-4768-8101-5bcf1003f9f4" /> |

Partially resolves https://github.com/ValveSoftware/source-1-games/issues/3518