### PR TITLE
CTFStorePreviewItemPanel: use https instead http to avoid redirect

### DIFF
--- a/src/game/client/tf/vgui/store/v2/tf_store_preview_item2.cpp
+++ b/src/game/client/tf/vgui/store/v2/tf_store_preview_item2.cpp
@@ -768,7 +768,7 @@ void CTFStorePreviewItemPanel2::OnCommand( const char *command )
 				ELanguage iLang = PchLanguageToELanguage( uilanguage );
 
 				char szURL[512];
-				Q_snprintf( szURL, sizeof(szURL), "http://wiki.teamfortress.com/scripts/itemredirect.php?id=%d&lang=%s", pItem->GetItemDefIndex(), GetLanguageICUName( iLang ) );
+				Q_snprintf( szURL, sizeof(szURL), "https://wiki.teamfortress.com/scripts/itemredirect.php?id=%d&lang=%s", pItem->GetItemDefIndex(), GetLanguageICUName( iLang ) );
 				steamapicontext->SteamFriends()->ActivateGameOverlayToWebPage( szURL );
 
 				C_CTF_GameStats.Event_Catalog( IE_ARMORY_BROWSE_WIKI, NULL, pItem );


### PR DESCRIPTION
Accessing the link auto redirects (via 301) to https, but this can be avoided completely.
The similar has been done in https://github.com/ValveSoftware/source-sdk-2013/pull/1498/commits/12c68fb1653011d617fc48838c2f58a6f36cb32c.