### PR TITLE
[TF2] Remove the restriction to inspect upgrade on your teammates during MVM

### DIFF
--- a/src/game/client/tf/tf_hud_inspectpanel.cpp
+++ b/src/game/client/tf/tf_hud_inspectpanel.cpp
@@ -171,12 +171,6 @@ void CHudInspectPanel::UserCmd_InspectTarget( void )
 			// Inspect a player
 			else if ( pTargetPlayer && ( pTargetPlayer->GetTeamNumber() != TF_TEAM_PVE_INVADERS ) )
 			{
-				if ( !GetClientModeTFNormal()->BIsFriendOrPartyMember( pTargetPlayer ) )
-				{
-					internalCenterPrint->Print( "#TF_Invalid_Inspect_Target" );
-					return;
-				}
-				
 				pUpgradePanel->InspectUpgradesForPlayer( pTargetPlayer );
 			}
 			// Inspect self


### PR DESCRIPTION
I don't see any good reason why the restriction is there.