### PR TITLE
[TF2] Improved closest hitbox detection for arrow projectiles

### DIFF
--- a/src/game/server/tf/tf_projectile_arrow.cpp
+++ b/src/game/server/tf/tf_projectile_arrow.cpp
@@ -822,7 +822,7 @@ void CTFProjectile_Arrow::ArrowTouch( CBaseEntity *pOther )
 
 		// Intense, but extremely accurate:
 		AngleVectors( GetAbsAngles(), &forward );
-		start = GetAbsOrigin() + forward*16;
+		start = GetAbsOrigin();
 		for ( int i = 0; i < set->numhitboxes; i++ )
 		{
 			mstudiobbox_t *pbox = set->pHitbox( i );
@@ -832,8 +832,21 @@ void CTFProjectile_Arrow::ArrowTouch( CBaseEntity *pOther )
 			Ray_t ray;
 			ray.Init( start, position );
 			trace_t tr;
-			IntersectRayWithBox( ray, position+pbox->bbmin, position+pbox->bbmax, 0.f, &tr );
-			float dist = tr.endpos.DistTo( start );
+			IntersectRayWithOBB( ray, position, angles, pbox->bbmin, pbox->bbmax, 0.f, &tr );
+			
+			float dist;
+
+			if ( vel.LengthSqr() != 0 )
+			{
+				// We want to calculate closest distance of the arrows trajectory to a hitbox
+				// Instead of just the closest distance of the arrows position to a hitbox
+				// For better hit detection
+				dist = ( tr.endpos - start ).Cross( vel ).Length() / vel.Length();
+			}
+			else
+			{
+				dist = tr.endpos.DistTo( start ); // Fall back to old method if first method fails
+			}
 
 			if ( dist < closest_dist )
 			{


### PR DESCRIPTION
This PR includes a bug fix from https://github.com/ValveSoftware/source-sdk-2013/pull/634

The old method uses the direct distance from the arrow to a hitbox to determine which is closest.
The new method uses the distance from the trajectory the arrow is traveling in to the hitbox.

The old method often led to scenarios where an arrow would visually be moving towards one hitbox, but end up hitting a completely different one that it was technically closer to. 
This new method fixes that with more visually consistent hitbox detection.

**Old Method**

https://github.com/user-attachments/assets/5348fa2e-5a9f-4304-98f8-c1e367c77bc9

**New Method**

https://github.com/user-attachments/assets/006a6b78-2049-437b-aa9a-7a9122d97b2c


