### PR TITLE
[TF2] Fix airblast projectile deflection trajectory colliding with projectiles

### DIFF
--- a/src/game/shared/tf/tf_weaponbase.cpp
+++ b/src/game/shared/tf/tf_weaponbase.cpp
@@ -5904,6 +5904,9 @@ public:
 		if ( pEntity->IsBaseObject() )
 			return false;
 
+		if ( pEntity->IsBaseProjectile() )
+			return false;
+
 		if ( pEntity->IsCombatItem() )
 			return false;
 


### PR DESCRIPTION
Fixes https://github.com/ValveSoftware/Source-1-Games/issues/5528

Whenever a Pyro airblasts a projectile, the game does a trace from the Pyro's view to determine what surface he's aiming at, and redirects the projectile there. However, this trace can actually collide with projectiles, including the same projectile that is being deflected, which can result in the deflect sending the projectile in an unexpected direction instead of where the Pyro is actually aiming at. [Video demonstration of the bug here.](https://www.youtube.com/watch?v=Sz9nDnYfYOk)

Fixed by filtering out projectiles in `CTraceFilterDeflection`.