### PR TITLE
[TF2] Prevent cyoa_pda_open 1 from forcing Sniper to unzoom

### DIFF
--- a/src/game/shared/tf/tf_player_shared.cpp
+++ b/src/game/shared/tf/tf_player_shared.cpp
@@ -12113,7 +12113,7 @@ bool CTFPlayer::CanAttack( int iCanAttackFlags )
 
 	Assert( pRules );
 
-	if ( IsViewingCYOAPDA() )
+	if ( IsViewingCYOAPDA()  && !m_Shared.InCond( TF_COND_ZOOMED ) )
 		return false;
 
 	if ( m_Shared.HasPasstimeBall() ) 


### PR DESCRIPTION
Resolves [ValveSoftware/Source-1-Games#7350](https://github.com/ValveSoftware/Source-1-Games/issues/7350)

While the Sniper is zoomed in with his sniper rifle, setting  `cyoa_pda_open` to 1 will immediately force him to unzoom. This can be abused to skip the short unzoom delay and other movement penalties that occur after firing a zoomed-in shot. This change will prevent this behavior from happening.