### PR TITLE
[TF2] Fix `dmg_from_sentry_reduced` ignoring Sentry rockets

### DIFF
--- a/src/game/shared/tf/tf_gamerules.cpp
+++ b/src/game/shared/tf/tf_gamerules.cpp
@@ -7293,12 +7293,27 @@ float CTFGameRules::ApplyOnDamageAliveModifyRules( const CTakeDamageInfo &info, 
 		CALL_ATTRIB_HOOK_FLOAT_ON_OTHER( pVictim, flRealDamage, mult_dmgtaken );
 		CALL_ATTRIB_HOOK_FLOAT_ON_OTHER( pVictim->GetActiveTFWeapon(), flRealDamage, mult_dmgtaken_active );
 
-		if ( info.GetInflictor() && info.GetInflictor()->IsBaseObject() )
+		if ( info.GetInflictor() )
 		{
-			CObjectSentrygun* pSentry = dynamic_cast<CObjectSentrygun*>( info.GetInflictor() );
-			if ( pSentry )
+			if ( info.GetInflictor()->IsBaseObject() )
 			{
-				CALL_ATTRIB_HOOK_FLOAT_ON_OTHER( pVictim, flRealDamage, dmg_from_sentry_reduced );
+				CObjectSentrygun* pSentry = dynamic_cast<CObjectSentrygun*>( info.GetInflictor() );
+				if ( pSentry )
+				{
+					CALL_ATTRIB_HOOK_FLOAT_ON_OTHER( pVictim, flRealDamage, dmg_from_sentry_reduced );
+				}
+			}
+			else
+			{
+				CTFProjectile_SentryRocket* pSentryRocket = dynamic_cast<CTFProjectile_SentryRocket*>( info.GetInflictor() );
+				if ( pSentryRocket && pSentryRocket->GetOwnerEntity() )
+				{
+					CObjectSentrygun* pSentry = dynamic_cast<CObjectSentrygun*>( pSentryRocket->GetOwnerEntity() );
+					if ( pSentry )
+					{
+						CALL_ATTRIB_HOOK_FLOAT_ON_OTHER( pVictim, flRealDamage, dmg_from_sentry_reduced );
+					}
+				}
 			}
 		}
 


### PR DESCRIPTION
Fixed sentry rockets getting ignored by the `dmg_from_sentry_reduced`, as code used to only check if inflictor was sentrygun.
And as and extra check, only apply attribute if the owner of the rocket is a sentry.
This works because the scorer is set to players instead