### PR TITLE
Updated Weapon Extra Wearables and Body Groups  to be compatible with disguises

### DIFF
--- a/src/game/shared/tf/tf_item_wearable.cpp
+++ b/src/game/shared/tf/tf_item_wearable.cpp
@@ -553,6 +553,46 @@ bool CTFWearable::UpdateBodygroups( CBaseCombatCharacter* pOwner, int iState )
 		pTFOwner->m_Shared.SetDisguiseBody( iDisguiseBody );
 	}
 
+	//CEconEntity::UpdateBodygroups is broken for disguise weapons and wearables.
+	//Additionally it is missing most of the infrastructure needed to set up this function there. 
+	//As such, we set up the disguise weapon along with the other wearables since this is the only place 
+	//they are actually handled correctly.
+	if (pTFOwner->m_Shared.GetDisguiseWeapon())
+	{
+		CAttributeContainer* pCont = pTFOwner->m_Shared.GetDisguiseWeapon()->GetAttributeContainer();
+		if (!pCont)
+			return false;
+
+		CEconItemView* pItem = pCont->GetItem();
+		if (!pItem)
+			return false;
+
+		CTFPlayer* pDisguiseTarget = pTFOwner->m_Shared.GetDisguiseTarget();
+		if (!pDisguiseTarget)
+			return false;
+
+		const CEconItemDefinition* pItemDef = pItem->GetItemDefinition();
+		if (!pItemDef)
+			return false;
+
+		// Update our disguise bodygroup.
+		int iDisguiseBody = pTFOwner->m_Shared.GetDisguiseBody();
+
+		int iNumBodyGroups = pItemDef->GetNumModifiedBodyGroups(0); // we must use team 0
+		for (int i = 0; i < iNumBodyGroups; ++i)
+		{
+			int iBody = 0;
+			const char* pszBodyGroup = pItem->GetStaticData()->GetModifiedBodyGroup(0, i, iBody);
+			int iBodyGroup = pDisguiseTarget->FindBodygroupByName(pszBodyGroup);
+			if (iBodyGroup == -1)
+				continue;
+
+			::SetBodygroup(pDisguiseTarget->GetModelPtr(), iDisguiseBody, iBodyGroup, iState);
+		}
+
+		pTFOwner->m_Shared.SetDisguiseBody(iDisguiseBody);
+	}
+
 	CEconItemView *pItem = GetAttributeContainer() ? GetAttributeContainer()->GetItem() : NULL;
 	if ( pItem )
 	{		

--- a/src/game/shared/tf/tf_player_shared.cpp
+++ b/src/game/shared/tf/tf_player_shared.cpp
@@ -8369,6 +8369,7 @@ void CTFPlayerShared::DetermineDisguiseWeapon( bool bForcePrimary )
 	{
 		CTFWeaponBase *pLastDisguiseWeapon = m_hDisguiseWeapon;
 		CTFWeaponBase *pFirstValidWeapon = NULL;
+
 		// Cycle through the target's weapons and see if we have a match.
 		// Note that it's possible the disguise target doesn't have a weapon in the slot we want,
 		// for example if they have replaced it with an unlockable that isn't a weapon (wearable).
@@ -8472,6 +8473,7 @@ void CTFPlayerShared::DetermineDisguiseWeapon( bool bForcePrimary )
 			m_hDisguiseWeapon->m_bDisguiseWeapon = true;
 			m_hDisguiseWeapon->SetContextThink( &CTFWeaponBase::DisguiseWeaponThink, gpGlobals->curtime + 0.5, "DisguiseWeaponThink" );
 
+			m_hDisguiseWeapon->UpdateExtraWearables();
 
 			// Ammo/clip state is displayed to attached medics
 			m_iDisguiseAmmo = 0;

--- a/src/game/shared/tf/tf_weaponbase.cpp
+++ b/src/game/shared/tf/tf_weaponbase.cpp
@@ -980,7 +980,7 @@ void CTFWeaponBase::UpdateExtraWearables()
 				// Precaching may be needed here, because we allow virtually everything to be loaded on demand now.
 				pExtraWearableItem->PrecacheModel( pEconItemView->GetExtraWearableViewModel() );
 			}
-
+			pExtraWearableItem->SetDisguiseWearable(m_bDisguiseWeapon);
 			pExtraWearableItem->AddSpawnFlags( SF_NORESPAWN );
 			pExtraWearableItem->SetAlwaysAllow( true );
 			DispatchSpawn( pExtraWearableItem );
@@ -1006,6 +1006,7 @@ void CTFWeaponBase::UpdateExtraWearables()
 				pExtraWearableItem->PrecacheModel( pEconItemView->GetExtraWearableModel() );
 			}
 
+			pExtraWearableItem->SetDisguiseWearable(m_bDisguiseWeapon);
 			pExtraWearableItem->AddSpawnFlags( SF_NORESPAWN );
 			pExtraWearableItem->SetAlwaysAllow( true );
 			DispatchSpawn( pExtraWearableItem );


### PR DESCRIPTION
# Description

This commit solves one of the bugs related to missing wearables and body groups for spy disguises: https://github.com/ValveSoftware/Source-1-Games/issues/275 (at least a partial fix for this issue)

Particularly this solves wearables for weapons that have "extraWearables". Upon pressing last disguise on the relevant item slot, The spy will receive the wearable until he switches his class disguise even if he switches disguise weapons. This version of the fix increases the skill ceiling of spy while reducing code blast radius.

This fix also solves bad body group settings for weapons like the quickfix and vaccinator in its second revision. In the medigun case this results in correct backpacks being placed for all mediguns for disguised spies. 


Tested and confirmed:
* The QuickFix
* Battalions Back up
* Buff Banner
* Thermal thruster (Only inactive state, but this allows for additional valid disguises so is an improvement)
* Councheror
* Vaccinator
* Base Jumper



Before fix:
<img width="3440" height="1440" alt="Screenshot (2)" src="https://github.com/user-attachments/assets/0f8c014e-7175-43cd-9c30-d87b3b4d1259" />

After fix:
<img width="3440" height="1440" alt="Screenshot (10)" src="https://github.com/user-attachments/assets/d9622341-7ee9-47fe-9593-c1d73de443e2" />
<img width="3440" height="1440" alt="Screenshot (12)" src="https://github.com/user-attachments/assets/d3b000fc-25fd-458c-9e9c-cd63797c8239" />
<img width="3440" height="1440" alt="Screenshot (11)" src="https://github.com/user-attachments/assets/00efaa1d-fcf3-4aa5-8068-3d7df3c60ea0" />
