### PR TITLE
[TF2] Improved huntsman arrow hitbox selection (no raycast approach)

### DIFF
--- a/src/game/server/tf/tf_projectile_arrow.cpp
+++ b/src/game/server/tf/tf_projectile_arrow.cpp
@@ -816,26 +816,38 @@ void CTFProjectile_Arrow::ArrowTouch( CBaseEntity *pOther )
 	if ( !closest_box )
 	{
 		// Locate the hitbox closest to our point of impact on the collision box.
-		Vector position, start, forward, origin;
-		QAngle angles;
-		float closest_dist = 99999;
+		Vector forward, impact_pos;
+		float closest_dist = FLT_MAX;
 
 		// Intense, but extremely accurate:
 		AngleVectors( GetAbsAngles(), &forward );
-		origin = GetAbsOrigin();
+		impact_pos = GetAbsOrigin();
+
 		for ( int i = 0; i < set->numhitboxes; i++ )
 		{
 			mstudiobbox_t *pbox = set->pHitbox( i );
 
-			pAnimOther->GetBonePosition( pbox->bone, position, angles );
+			Vector origin, center;
+			QAngle angles;
 
-			start = origin + (position - origin).Dot(forward) * forward;
+			pAnimOther->GetBonePosition( pbox->bone, origin, angles );
 
-			Ray_t ray;
-			ray.Init( start, position );
-			trace_t tr;
-			IntersectRayWithOBB( ray, position, angles, pbox->bbmin, pbox->bbmax, 0.f, &tr );
-			float dist = tr.endpos.DistTo( start );
+			matrix3x4_t mat;
+			AngleMatrix( angles, origin, mat );
+
+			VectorTransform( ( pbox->bbmin + pbox->bbmax ) * 0.5f, mat, center );
+
+			Vector proj = impact_pos + forward * ( center - impact_pos ).Dot( forward );
+
+			Vector point;
+			VectorITransform( proj, mat, point );
+
+			CalcClosestPointOnAABB( pbox->bbmin, pbox->bbmax, point, point );
+
+			Vector surface_point;
+			VectorTransform( point, mat, surface_point );
+
+			float dist = proj.DistToSqr( surface_point );
 
 			if ( dist < closest_dist )
 			{


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description

fixes ValveSoftware/Source-1-Games/issues/5904

supersedes #634

alternative: #1593 (simpler solution)

this pr's solution:
\- find point on the arrow's trajectory line that's closest to the hitbox centre
\- from that trajectory point, find distance to closest point on the hitbox's surface
\- no intersection tests (a lot cheaper)
<img height="256" alt="image" src="https://github.com/user-attachments/assets/14e5f4c9-38c6-4eae-987b-81a9ef6da303" />

solution in #1593 (cross product):
\- from the arrow's impact point, raycast to hitbox origin
\- from that raycast's intersection point, find perpendicular distance to arrow's trajectory line
<img height="256" alt="image" src="https://github.com/user-attachments/assets/53bfa877-bb80-4855-9b71-668d4aab3673" />

solution in a4f7b4f (projection):
\- finds point on the trajectory line that's closest to the hitbox origin
\- from that trajectory point, raycast to hitbox origin (to get raycast distance)
<img height="256" alt="image" src="https://github.com/user-attachments/assets/7bf8ddb4-cbdc-4730-9ce0-14b88aff6862" />

original behaviour:
\- shift arrow's impact point 16 units forward
\- from that point, raycast to hitbox origin (to get raycast distance)
\- this can easily give unintuitive results (frustrating to both the user and the victim)
\- bug: hitboxes are treated as axis-aligned boxes rather than oriented boxes!!!
<img height="256" alt="image" src="https://github.com/user-attachments/assets/f8770d14-c430-48da-b753-6d678489bcee" />
