### PR TITLE
[TF2] Add visual timer for vote duration

### DIFF
--- a/src/game/client/hud_vote.cpp
+++ b/src/game/client/hud_vote.cpp
@@ -1472,9 +1472,19 @@ void CHudVote::MsgFunc_VoteStart( bf_read &msg )
 	char szParam1[k_MAX_VOTE_NAME_LENGTH] = { 0 };
 	msg.ReadString( szParam1, sizeof(szParam1) );
 
-	pVotePanel->m_bIsYesNoVote = msg.ReadByte();
+	pVotePanel->m_bIsYesNoVote = msg.ReadOneBit();
 	int iTargetEntIndex = msg.ReadByte();
 
+	// Duration of the vote
+	// Only set this if it exists, compatibility for plugins that don't send it
+	float flDuration = 0.f;
+	if ( msg.GetNumBytesLeft() )
+	{
+		flDuration = msg.ReadFloat();
+	}
+
+	pVotePanel->m_flStartTime = gpGlobals->curtime;
+	pVotePanel->m_flEndTime = gpGlobals->curtime + flDuration;
 	pVotePanel->m_flHideTime = -1.f;
 	pVotePanel->m_flVoteResultCycleTime = -1.f;
 	pVotePanel->m_bPlayerVoted = pVotePanel->m_iVoteCallerIdx == GetLocalPlayerIndex() && !sv_vote_holder_may_vote_no.GetBool();
@@ -1504,6 +1514,8 @@ void CHudVote::MsgFunc_VoteStart( bf_read &msg )
 	pVotePanel->m_pVoteActive->SetControlVisible( "Option2CountLabel", pVotePanel->m_bIsYesNoVote );
 	pVotePanel->m_pVoteActive->SetControlVisible( "Divider1", pVotePanel->m_bIsYesNoVote );
 	pVotePanel->m_pVoteActive->SetControlVisible( "Divider2", pVotePanel->m_bIsYesNoVote );
+
+	pVotePanel->m_pVoteActive->SetControlVisible( "TimeRemainingProgressBar", !!flDuration );
 
 	// Display vote caller's name
 	wchar_t wszCallerName[MAX_PLAYER_NAME_LENGTH];
@@ -1970,6 +1982,12 @@ void CHudVotePanel::ApplySchemeSettings( vgui::IScheme *pScheme )
 
 	LoadControlSettings( "Resource/UI/VoteHud.res" );
 
+	m_pTimerProgressBar = FindControl< CircularProgressBar >( "TimeRemainingProgressBar", true );
+	if ( m_pTimerProgressBar )
+	{
+		m_pTimerProgressBar->SetProgressDirection( CircularProgressBar::PROGRESS_CCW );
+	}
+
 	m_pVoteActiveIssueLabel->GetPos( m_nVoteActiveIssueLabelX, m_nVoteActiveIssueLabelY );
 }
 
@@ -1988,6 +2006,8 @@ void CHudVotePanel::Init( void )
 	m_iVoteCallerIdx = -1;
 	m_nVoteTeamIndex = 0;
 	m_nVoteIdx = -1;
+	m_flStartTime = 0;
+	m_flEndTime = 0;
 
 	ListenForGameEvent( "vote_changed" );
 	ListenForGameEvent( "vote_options" );
@@ -2164,6 +2184,11 @@ void CHudVotePanel::OnThink()
 				m_pVoteActive->SetVisible( true );
 				pLocalPlayer->EmitSound("Vote.Created");
 			}
+		}
+
+		if ( m_pTimerProgressBar && m_pTimerProgressBar->IsVisible() )
+		{
+			m_pTimerProgressBar->SetProgress( 1.0f - ( ( gpGlobals->curtime - m_flStartTime ) / ( m_flEndTime - m_flStartTime ) ) );
 		}
 	}
 

--- a/src/game/client/hud_vote.h
+++ b/src/game/client/hud_vote.h
@@ -18,6 +18,7 @@
 #include <vgui_controls/Button.h>
 #include <networkstringtabledefs.h>
 #include "vgui_avatarimage.h"
+#include <vgui_controls/CircularProgressBar.h>
 
 extern INetworkStringTable *g_pStringTableServerMapCycle;
 
@@ -167,6 +168,7 @@ protected:
 	EditablePanel		*m_pVoteFailed;
 	EditablePanel		*m_pVotePassed;
 	EditablePanel		*m_pCallVoteFailed;
+	vgui::CircularProgressBar *m_pTimerProgressBar;
 
 	CUtlStringList		m_VoteSetupChoices;
 
@@ -189,6 +191,8 @@ protected:
 	int					m_iVoteCallerIdx;
 	int					m_nVoteTeamIndex;			// If defined, only players on this team will see/vote on the issue
 	int					m_nVoteIdx;
+	float				m_flStartTime;
+	float				m_flEndTime;
 
 	friend CHudVote;
 };

--- a/src/game/server/vote_controller.cpp
+++ b/src/game/server/vote_controller.cpp
@@ -586,7 +586,7 @@ bool CVoteController::CreateVote( int iEntIndex, const char *pszTypeString, cons
 
 				// Now the vote handling and UI
 				m_nPotentialVotes = pCurrentIssue->CountPotentialVoters();
-				m_acceptingVotesTimer.Start( sv_vote_timer_duration.GetFloat() + random->RandomFloat( -1.f, 1.f ) );
+				m_acceptingVotesTimer.Start( sv_vote_timer_duration.GetFloat() );
 
 #ifndef _DEBUG
 				// Force the vote holder to agree with a Yes/No vote
@@ -607,6 +607,7 @@ bool CVoteController::CreateVote( int iEntIndex, const char *pszTypeString, cons
 					WRITE_STRING( pCurrentIssue->GetDetailsString() );
 					WRITE_BOOL( pCurrentIssue->IsYesNoVote() );
 					WRITE_BYTE( ( pCurrentIssue->m_hPlayerTarget ) ? pCurrentIssue->m_hPlayerTarget->entindex() : 0 );
+					WRITE_FLOAT( sv_vote_timer_duration.GetFloat() );
 				MessageEnd();
 
 				if ( !bDedicatedServer )


### PR DESCRIPTION
# Description
Closes [#ValveSoftware/Source-1-Games/5209](https://github.com/ValveSoftware/Source-1-Games/issues/5209#issue-1916377368)

This PR adds a timer to the vote panel, displaying how much time is left before the vote is concluded.
It also fixes a bug where `m_bIsYesNoVote` was reading a byte in the user message when it should've been reading a bit and removes the 1 second variance as it seems counter intuitive to this PR.

The modified votehud.res file can be downloaded [here](https://github.com/user-attachments/files/23249107/modified_vote_panel.zip).

https://github.com/user-attachments/assets/53c47510-abda-4c6b-85a5-d3ffb37279a4

