### PR TITLE
[VScript] Add ClientPrintEx (Formatting localized strings)

### DIFF
--- a/src/game/server/vscript_server.cpp
+++ b/src/game/server/vscript_server.cpp
@@ -1897,7 +1897,7 @@ static int Script_GetFrameCount( void )
 	return gpGlobals->framecount;
 }
 
-static void Script_ClientPrint( HSCRIPT hPlayer, int iDest, const char *pText )
+static void DoClientPrintEx( HSCRIPT hPlayer, int iDest, const char *pText, const char *pTextParam1 = (const char *)0, const char *pTextParam2 = (const char *)0, const char *pTextParam3 = (const char *)0, const char *pTextParam4 = (const char *)0 )
 {
 	CBaseEntity *pBaseEntity = ToEnt( hPlayer );
 	if ( pBaseEntity )
@@ -1905,13 +1905,18 @@ static void Script_ClientPrint( HSCRIPT hPlayer, int iDest, const char *pText )
 		CBasePlayer *pPlayer = dynamic_cast<CBasePlayer*>( pBaseEntity );
 		if ( pPlayer )
 		{
-			ClientPrint( pPlayer, iDest, pText );
+			ClientPrint( pPlayer, iDest, pText, pTextParam1, pTextParam2, pTextParam3, pTextParam4 );
 		}
 	}
 	else
 	{
-		UTIL_ClientPrintAll( iDest, pText );
+		UTIL_ClientPrintAll( iDest, pText, pTextParam1, pTextParam2, pTextParam3, pTextParam4 );
 	}
+}
+
+static void Script_ClientPrint( HSCRIPT hPlayer, int iDest, const char *pText )
+{
+	DoClientPrintEx( hPlayer, iDest, pText );
 }
 
 static void ScriptEmitAmbientSoundOn( const char *soundname, float volume, int soundlevel, int pitch, HSCRIPT entity )
@@ -2564,6 +2569,7 @@ bool VScriptServerInit()
 				ScriptRegisterFunctionNamed( g_pScriptVM, Script_GetFrameCount, "GetFrameCount", "Returns the engines current frame count" );
 
 				ScriptRegisterFunctionNamed( g_pScriptVM, Script_ClientPrint, "ClientPrint", "Print a client message" );
+				ScriptRegisterFunction( g_pScriptVM, DoClientPrintEx, SCRIPT_ALIAS( "ClientPrintEx", "Print a client message with extra format parameters" ) );
 				ScriptRegisterFunctionNamed( g_pScriptVM, ScriptEmitAmbientSoundOn, "EmitAmbientSoundOn", "Play named ambient sound on an entity." );
 				ScriptRegisterFunctionNamed( g_pScriptVM, ScriptStopAmbientSoundOn, "StopAmbientSoundOn", "Stop named ambient sound on an entity." );
 				ScriptRegisterFunctionNamed( g_pScriptVM, Script_SetFakeClientConVarValue, "SetFakeClientConVarValue", "Sets a USERINFO client ConVar for a fakeclient" );

--- a/src/game/server/vscript_server.nut
+++ b/src/game/server/vscript_server.nut
@@ -29,6 +29,11 @@ function EntFire( target, action, value = null, delay = 0.0, activator = null )
 	DoEntFire( target.tostring(), action.tostring(), value.tostring(), delay, activator, caller ); 
 }
 
+function ClientPrintEx( player, destination, text, text_param1 = null, text_param2 = null, text_param3 = null, text_param4 = null )
+{
+	DoClientPrintEx( player, destination, text, text_param1, text_param2, text_param3, text_param4 );
+}
+
 function __ReplaceClosures( script, scope )
 {
 	if ( !scope )


### PR DESCRIPTION
# Description
Closes [ValveSoftware/Source-1-Games/7594](https://github.com/ValveSoftware/Source-1-Games/issues/7594)

This PR adds `ClientPrintEx`, a duplicate of `ClientPrint` with four optional parameters for formatting localized strings.

```
ClientPrintEx(null, 3, "#Msg_KillStreakEnd", "Scout Boss", "Saxton Hale", "(24)")
ClientPrintEx(null, 3, "#Item_Named", "Heavy", "Minigun", "Sasha")
ClientPrintEx(null, 3, "#tf_zi_ui_infect_msg", "Engineer", "Spy and his cohorts")
```
<img width="475" height="84" alt="image" src="https://github.com/user-attachments/assets/b6a7c923-5ff9-41ef-a519-7a9a9e3f4887" />

Note that the `tf_zi_ui_infect_msg` and it's sibling language entries need to be modified to use `%s1` and `%s2` instead of just `%s` to format properly.
