### PR TITLE
vgui_controls: Restore default locale initialization in VGui_InitInterfacesList

### DIFF
--- a/src/vgui2/vgui_controls/controls.cpp
+++ b/src/vgui2/vgui_controls/controls.cpp
@@ -40,6 +40,13 @@ bool VGui_InitInterfacesList( const char *moduleName, CreateInterfaceFn *factory
 	strncpy(g_szControlsModuleName, moduleName, sizeof(g_szControlsModuleName));
 	g_szControlsModuleName[sizeof(g_szControlsModuleName) - 1] = 0;
 
+	// initialize our locale (must be done for every vgui dll/exe)
+	// "" makes it use the default locale, required to make iswprint() work correctly in different languages
+	setlocale( LC_CTYPE, "" );
+	setlocale( LC_TIME, "" );
+	setlocale( LC_COLLATE, "" );
+	setlocale( LC_MONETARY, "" );
+
 	// NOTE: Vgui expects to use these interfaces which are defined in tier3.lib
 	if ( !g_pVGui || !g_pVGuiInput || !g_pVGuiPanel || 
 		 !g_pVGuiSurface || !g_pVGuiSchemeManager || !g_pVGuiSystem )


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
Moved from https://github.com/ValveSoftware/source-sdk-2013/pull/1241

Some time between SDK update in 2015 and 2025 this piece of code was removed which caused some Unicode functions to not work properly in non-English alphabet languages.

An example of this being an issue is in the PR linked above; it contains code which will find a match case-insensitivily in two wide strings (`wszFilterBuf` and `wszDisplayText`):
```cpp
			// Find a match
			bool bMatch = false;
			const wchar_t *pwchLetter = wszDisplayText;
			while ( *pwchLetter != L'\0' )
			{
				const wchar_t *pwchSearch = pwchLetter;
				const wchar_t *pwchTest = wszFilterBuf;
				while ( *pwchTest != L'\0' )
				{
					if ( *pwchSearch == L'\0' )
						break;
					if ( towlower( *pwchSearch ) != towlower( *pwchTest ) )
						break;
					++pwchSearch; ++pwchTest;
				}
				if ( *pwchTest == L'\0' )
				{
					bMatch = true;
					break;
				}
				++pwchLetter;
			}
```
Without setting the locales, passing a Polish accent character like `Ł`  into `towlower` fails to convert it to lowercase version `ł`, returning uppercase `Ł` instead.

This makes the  ``if ( towlower( *pwchSearch ) != towlower( *pwchTest ) )`` statement incorrectly fail when comparing `Ł` and `ł`, `Ą` and `ą`, etc.

Restoring behavior from old SDK versions fixes this.