### PR TITLE
vgui_controls: Fix TextEntry horizontal scrolling when removing selected text

### DIFF
--- a/src/vgui2/vgui_controls/TextEntry.cpp
+++ b/src/vgui2/vgui_controls/TextEntry.cpp
@@ -3140,7 +3140,7 @@ void TextEntry::DeleteSelected()
 	_cursorPos = x0;
 
 	// scroll left if we need to
-	if ( _horizScrollingAllowed && ( _cursorPos < _currentStartIndex ) )
+	if ( _cursorPos < _currentStartIndex )
 	{
 		_currentStartIndex = _cursorPos;
 	}


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
This PR makes horizontal scroll update if needed when deleting selected text in text entry fields. This caused input to register off-screen until the cursor position catched up with the scroll start index.

Can be reproduced in developer console's command input field, however GameUI needs to be recompiled for changes to take effect.

Before:

[vgui_TextEntry_horiz_scroll_fix_before.webm](https://github.com/user-attachments/assets/2c61579a-4be0-4db7-b3ad-51bcffdc881f)

After:

[vgui_TextEntry_horiz_scroll_fix_after.webm](https://github.com/user-attachments/assets/4f10d635-0e8b-47d0-9d13-5ed373f9d15f)
