### PR TITLE
vgui_controls: Prevent buffer overrun in TextImage::GetText

### DIFF
--- a/src/vgui2/vgui_controls/TextImage.cpp
+++ b/src/vgui2/vgui_controls/TextImage.cpp
@@ -245,7 +245,14 @@ void TextImage::GetText(char *buffer, int bufferSize)
 //-----------------------------------------------------------------------------
 void TextImage::GetText(wchar_t *buffer, int bufLenInBytes)
 {
-	wcsncpy(buffer, _utext, bufLenInBytes / sizeof(wchar_t));
+	if ( !_textLen )
+	{
+		buffer[ 0 ] = L'\0';
+		return;
+	}
+	int iTerminator = Min( ( int )_textLen, ( bufLenInBytes / ( int )sizeof( wchar_t ) ) - 1 );
+	wcsncpy( buffer, _utext, iTerminator );
+	buffer[ iTerminator ] = L'\0';
 
 	if ( m_bAllCaps )
 	{


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
In the original implementation if the destination buffer is smaller than the source text length it would fill available space without terminating the string leading to client crash or memory corruption. This PR fixes this by ensuring NULL termination taken from TextEntry's GetText version.