### PR TITLE
Fix accidental 40-50% damage nerf to Righteous Bison by reverting projectile code

### DIFF
--- a/src/game/shared/tf/tf_projectile_energy_ring.cpp
+++ b/src/game/shared/tf/tf_projectile_energy_ring.cpp
@@ -113,6 +113,21 @@ CTFProjectile_EnergyRing *CTFProjectile_EnergyRing::Create( CTFWeaponBaseGun *pL
 	Vector vecForward, vecRight, vecUp;
 	AngleVectors( vecAngles, &vecForward, &vecRight, &vecUp );
 
+	CTFRaygun* pRaygun = assert_cast<CTFRaygun*>(pLauncher);
+
+	if (pRaygun && pRaygun->GetWeaponID() == TF_WEAPON_RAYGUN)
+	{
+		pRing = static_cast<CTFProjectile_EnergyRing*>(CTFBaseProjectile::Create("tf_projectile_energy_ring", vecOrigin, vecAngles, pOwner,
+			1200.f, g_sModelIndexRing,
+			ENERGY_RING_DISPATCH_EFFECT, pScorer, bCritical, vColor1, vColor2));
+	}
+	else
+	{
+		pRing = static_cast<CTFProjectile_EnergyRing*>(CBaseEntity::Create("tf_projectile_energy_ring", vecOrigin, vecAngles, pOwner));
+	}
+
+
+
 	pRing = static_cast<CTFProjectile_EnergyRing*>( CBaseEntity::Create( "tf_projectile_energy_ring", vecOrigin, vecAngles, pOwner ) );
 	if ( !pRing )
 		return NULL;

--- a/src/game/shared/tf/tf_weapon_raygun.cpp
+++ b/src/game/shared/tf/tf_weapon_raygun.cpp
@@ -61,7 +61,7 @@ CTFRaygun::CTFRaygun()
 #ifdef GAME_DLL
 	// Goofyness to preserve demos.  Old demos wont have this set on the client
 	// so we'll know to use the old code path.
-	m_bUseNewProjectileCode = true;
+	m_bUseNewProjectileCode = false;
 #endif
 	m_flIrradiateTime = 0.f;
 	m_bEffectsThinking = false;


### PR DESCRIPTION
During the Meet your Match update, the righteous bison was changed to be a single shot projectile. This change was not popular and we intended to issue a full revert in Jungle Inferno. Unfortunately, The Jungle Inferno update did not revert the bison to its previous projectile logic. The new hitbox did not have the same hit detection as the previous version and shots that would hit up to 4 times might only hit 2. This changed the weapon from 2 shotting some classes and close range to 4 shotting them, (as in requiring shotting a full clip to kill mid and low health targets). This is the best damage case, and the bison simply does not damage at long range. 

**Implementation:**

This change takes the projectile code saved for old demos and applies back to  tf_projectile_energy_ring.cpp server code. 

**Testing and Rationale:** 

This change will be highly welcome. It is frequently request by members of the community at all levels. In its current state the bison is widely regarded to be one of the worst weapons in the game. 


For balancing, this bug fix seems fine. I tested against some bots in close quarters:  The shotgun will still be better in most circumstances and when your using the bison  you're not actively using the rocket launcher (reloading is good). I also ran testing on the crit boost case, and the previous bison still seemed fine, it will almost always be better to use crit rockets. the previous projectile logic appears to only crit boost the first 2 hits which prevents it from out damaging crit rockets.   

