### PR TITLE
[TF2] Fix logo spinner from breaking after prolonged rotation

### DIFF
--- a/src/game/client/tf/vgui/tf_controls.cpp
+++ b/src/game/client/tf/vgui/tf_controls.cpp
@@ -2215,6 +2215,7 @@ void CTFLogoPanel::PaintTFLogo( float flAngle, const Color& color ) const
 void CTFLogoPanel::Paint()
 {
 	m_flOffsetAngle += gpGlobals->frametime * m_flVelocity;
+	m_flOffsetAngle = fmodf( m_flOffsetAngle, 360.f );
 	PaintTFLogo( m_flOffsetAngle, GetFgColor() );
 	BaseClass::Paint();
 }


### PR DESCRIPTION
# Description
This PR fixes the issue where the matchmaking queue spinner can become distorted or stop rotating after queuing for a prolonged amount of time by making sure the angle never surpasses 360 degrees.