### PR TITLE
Mark network state changes for player condition vars

### DIFF
--- a/src/game/shared/tf/tf_player_shared.cpp
+++ b/src/game/shared/tf/tf_player_shared.cpp
@@ -1030,46 +1030,55 @@ void CTFPlayerShared::Spawn( void )
 //-----------------------------------------------------------------------------
 // Purpose:
 //-----------------------------------------------------------------------------
-template < typename tIntType >
+template < typename tType >
 class CConditionVars
 {
 public:
-	CConditionVars( tIntType& nPlayerCond, tIntType& nPlayerCondEx, tIntType& nPlayerCondEx2, tIntType& nPlayerCondEx3, tIntType& nPlayerCondEx4, ETFCond eCond )
+	template < typename t0, typename t1, typename t2, typename t3, typename t4 >
+	CConditionVars( CTFPlayer* pOuter, ETFCond eCond, t0& nPlayerCond, t1& nPlayerCondEx, t2& nPlayerCondEx2, t3& nPlayerCondEx3, t4& nPlayerCondEx4 )
 	{
+		m_pOuter = pOuter;
+
 		if ( eCond >= 128 )
 		{
 			Assert( eCond < 128 + 32 );
-			m_pnCondVar = &nPlayerCondEx4;
-			m_nCondBit = eCond - 128; 
+			m_pnCondVar = ( tType* )&nPlayerCondEx4;
+			m_nCondBit = eCond - 128;
 		}
 		else if ( eCond >= 96 )
 		{
 			Assert( eCond < 96 + 32 );
-			m_pnCondVar = &nPlayerCondEx3;
+			m_pnCondVar = ( tType* )&nPlayerCondEx3;
 			m_nCondBit = eCond - 96;
 		}
-		else if( eCond >= 64 )
+		else if ( eCond >= 64 )
 		{
-			Assert( eCond < (64 + 32) );
-			m_pnCondVar = &nPlayerCondEx2;
+			Assert( eCond < ( 64 + 32 ) );
+			m_pnCondVar = ( tType* )&nPlayerCondEx2;
 			m_nCondBit = eCond - 64;
 		}
 		else if ( eCond >= 32 )
 		{
-			Assert( eCond < (32 + 32) );
-			m_pnCondVar = &nPlayerCondEx;
+			Assert( eCond < ( 32 + 32 ) );
+			m_pnCondVar = ( tType* )&nPlayerCondEx;
 			m_nCondBit = eCond - 32;
 		}
 		else
 		{
-			m_pnCondVar = &nPlayerCond;
+			m_pnCondVar = ( tType* )&nPlayerCond;
 			m_nCondBit = eCond;
 		}
 	}
 
-	tIntType& CondVar() const
+	const int& CondVar() const
 	{
-		return *m_pnCondVar;
+		return m_pnCondVar->m_Value;
+	}
+
+	int& CondVarForModify()
+	{
+		m_pOuter->NetworkStateChanged( m_pnCondVar );
+		return m_pnCondVar->m_Value;
 	}
 
 	int CondBit() const
@@ -1078,9 +1087,13 @@ public:
 	}
 
 private:
-	tIntType *m_pnCondVar;
+	CTFPlayer* m_pOuter;
+	tType* m_pnCondVar;
 	int m_nCondBit;
 };
+
+#define CONDITION_VARS( name, cond ) \
+CConditionVars< decltype( m_nPlayerCond ) > name( m_pOuter, cond, m_nPlayerCond, m_nPlayerCondEx, m_nPlayerCondEx2, m_nPlayerCondEx3, m_nPlayerCondEx4 )
 
 //-----------------------------------------------------------------------------
 // Purpose: Add a condition and duration
@@ -1113,14 +1126,14 @@ void CTFPlayerShared::AddCond( ETFCond eCond, float flDuration /* = PERMANENT_CO
 
 	// Which bitfield are we tracking this condition variable in? Which bit within
 	// that variable will we track it as?
-	CConditionVars<int> cPlayerCond( m_nPlayerCond.m_Value, m_nPlayerCondEx.m_Value, m_nPlayerCondEx2.m_Value, m_nPlayerCondEx3.m_Value, m_nPlayerCondEx4.m_Value, eCond );
+	CONDITION_VARS( cPlayerCond, eCond );
 
 	// See if there is an object representation of the condition.
 	bool bAddedToExternalConditionList = m_ConditionList.Add( eCond, flDuration, m_pOuter, pProvider );
 	if ( !bAddedToExternalConditionList )
 	{
 		// Set the condition bit for this condition.
-		cPlayerCond.CondVar() |= cPlayerCond.CondBit();
+		cPlayerCond.CondVarForModify() |= cPlayerCond.CondBit();
 
 		// Flag for gamecode to query
 		m_ConditionData[eCond].m_bPrevActive = ( m_ConditionData[eCond].m_flExpireTime != 0.f ) ? true : false;
@@ -1155,14 +1168,14 @@ void CTFPlayerShared::RemoveCond( ETFCond eCond, bool ignore_duration )
 	if ( !InCond( eCond ) )
 		return;
 
-	CConditionVars<int> cPlayerCond( m_nPlayerCond.m_Value, m_nPlayerCondEx.m_Value, m_nPlayerCondEx2.m_Value, m_nPlayerCondEx3.m_Value, m_nPlayerCondEx4.m_Value, eCond );
+	CONDITION_VARS( cPlayerCond, eCond );
 
 	// If this variable is handled by the condition list, abort before doing the
 	// work for the condition flags.
 	if ( m_ConditionList.Remove( eCond, ignore_duration ) )
 		return;
 
-	cPlayerCond.CondVar() &= ~cPlayerCond.CondBit();
+	cPlayerCond.CondVarForModify() &= ~cPlayerCond.CondBit();
 	OnConditionRemoved( eCond );
 
 	if ( m_ConditionData[ eCond ].m_nPreventedDamageFromCondition )
@@ -1198,7 +1211,7 @@ bool CTFPlayerShared::InCond( ETFCond eCond ) const
 	if ( eCond < 32 && m_ConditionList.InCond( eCond ) )
 		return true;
 
-	CConditionVars<const int> cPlayerCond( m_nPlayerCond.m_Value, m_nPlayerCondEx.m_Value, m_nPlayerCondEx2.m_Value, m_nPlayerCondEx3.m_Value, m_nPlayerCondEx4.m_Value, eCond );
+	CONDITION_VARS( cPlayerCond, eCond );
 	return (cPlayerCond.CondVar() & cPlayerCond.CondBit()) != 0;
 }
 
@@ -1212,7 +1225,7 @@ bool CTFPlayerShared::WasInCond( ETFCond eCond ) const
 	// assert. And this comment).
 	Assert( eCond >= 32 && eCond < TF_COND_LAST );
 
-	CConditionVars<const int> cPlayerCond( m_nOldConditions, m_nOldConditionsEx, m_nOldConditionsEx2, m_nOldConditionsEx3, m_nOldConditionsEx4, eCond );
+	CONDITION_VARS( cPlayerCond, eCond );
 	return (cPlayerCond.CondVar() & cPlayerCond.CondBit()) != 0;
 }
 
@@ -1225,8 +1238,8 @@ void CTFPlayerShared::ForceRecondNextSync( ETFCond eCond )
 	// Please check if you hit the assert. (And then remove the assert. And this comment).
 	Assert(eCond >= 32 && eCond < TF_COND_LAST);
 
-	CConditionVars<int> playerCond( m_nForceConditions, m_nForceConditionsEx, m_nForceConditionsEx2, m_nForceConditionsEx3, m_nForceConditionsEx4, eCond );
-	playerCond.CondVar() |= playerCond.CondBit();
+	CONDITION_VARS( cPlayerCond, eCond );
+	cPlayerCond.CondVarForModify() |= cPlayerCond.CondBit();
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
While investigating other prediction issues (https://github.com/ValveSoftware/source-sdk-2013/pull/1608) I noticed that there would be inconsistent prediction errors with player conditions such as `m_nPlayerCondEx3`, where the client correctly computed the value but not the server. It turns out this is because the server does not mark modified player condition variables as changed for networking due to an oversight. I'm unsure how this worked in the first place...

This PR addresses that by informing the entity that the condition var has changed when it's modified.

Note that this also fixes conditions vars not being networked when running TF2 with the singleplayer networking optimizations (`cl_localnetworkbackdoor`)

