### PR TITLE
[TF2] Fixed melee range not being extended while charging

### DIFF
--- a/src/game/shared/tf/tf_weaponbase_melee.cpp
+++ b/src/game/shared/tf/tf_weaponbase_melee.cpp
@@ -25,7 +25,7 @@
 
 ConVar tf_weapon_criticals_melee( "tf_weapon_criticals_melee", "1", FCVAR_REPLICATED | FCVAR_NOTIFY, "Controls random crits for melee weapons. 0 - Melee weapons do not randomly crit. 1 - Melee weapons can randomly crit only if tf_weapon_criticals is also enabled. 2 - Melee weapons can always randomly crit regardless of the tf_weapon_criticals setting." );
 
-ConVar tf_shield_charge_melee_range("tf_shield_charge_melee_range", "128", FCVAR_REPLICATED | FCVAR_NOTIFY, "The range of a melee attack performed during a shield charge. Set to 0 for no change.");
+ConVar tf_shield_charge_melee_range("tf_shield_charge_melee_range", "0", FCVAR_REPLICATED | FCVAR_NOTIFY, "The range of a melee attack performed during a shield charge. Set to 0 for no change.");
 
 //=============================================================================
 //

--- a/src/game/shared/tf/tf_weaponbase_melee.cpp
+++ b/src/game/shared/tf/tf_weaponbase_melee.cpp
@@ -166,12 +166,12 @@ bool CTFWeaponBaseMelee::Holster( CBaseCombatWeapon *pSwitchingTo )
 int	CTFWeaponBaseMelee::GetSwingRange( void )
 {
 	CTFPlayer *pOwner = ToTFPlayer( GetOwner() );
-	if (pOwner && pOwner->m_Shared.InCond(TF_COND_SHIELD_CHARGE))
+	if ( pOwner && pOwner->m_Shared.InCond( TF_COND_SHIELD_CHARGE ) )
 	{
 		// mvm bots that can attack while charging
 		return 128;
 	}
-	else if (IsCurrentAttackDuringDemoCharge() && tf_shield_charge_melee_range.GetInt())
+	else if ( IsCurrentAttackDuringDemoCharge() && tf_shield_charge_melee_range.GetInt() > 0 )
 	{
 		return tf_shield_charge_melee_range.GetInt();
 	}

--- a/src/game/shared/tf/tf_weaponbase_melee.cpp
+++ b/src/game/shared/tf/tf_weaponbase_melee.cpp
@@ -25,7 +25,7 @@
 
 ConVar tf_weapon_criticals_melee( "tf_weapon_criticals_melee", "1", FCVAR_REPLICATED | FCVAR_NOTIFY, "Controls random crits for melee weapons. 0 - Melee weapons do not randomly crit. 1 - Melee weapons can randomly crit only if tf_weapon_criticals is also enabled. 2 - Melee weapons can always randomly crit regardless of the tf_weapon_criticals setting." );
 
-ConVar tf_shield_charge_range_extend("tf_shield_charge_range_extend", "1", FCVAR_REPLICATED | FCVAR_NOTIFY, "Controls whether Demoman's shield charges extend melee range.\n0 - Attacks started during a charge will not have their melee range modified. 1 - Attacks started during a charge will have an extended melee range.");
+ConVar tf_shield_charge_melee_range("tf_shield_charge_melee_range", "128", FCVAR_REPLICATED | FCVAR_NOTIFY, "The range of a melee attack performed during a shield charge. Set to 0 for no change.");
 
 //=============================================================================
 //
@@ -166,10 +166,9 @@ bool CTFWeaponBaseMelee::Holster( CBaseCombatWeapon *pSwitchingTo )
 int	CTFWeaponBaseMelee::GetSwingRange( void )
 {
 	CTFPlayer *pOwner = ToTFPlayer( GetOwner() );
-	int shield_charge_range_extend = tf_shield_charge_range_extend.GetInt();
-	if ( pOwner && ( pOwner->m_Shared.InCond( TF_COND_SHIELD_CHARGE ) || ( IsCurrentAttackDuringDemoCharge() && shield_charge_range_extend ) ) )
+	if ( pOwner && ( pOwner->m_Shared.InCond( TF_COND_SHIELD_CHARGE ) || ( IsCurrentAttackDuringDemoCharge() && tf_shield_charge_melee_range.GetInt() ) ) )
 	{
-		return 128;
+		return tf_shield_charge_melee_range.GetInt();
 	}
 	else
 	{
@@ -203,10 +202,10 @@ void CTFWeaponBaseMelee::PrimaryAttack()
 
 	pPlayer->EndClassSpecialSkill();
 
+	m_bCurrentAttackIsDuringDemoCharge = pPlayer->m_Shared.GetNextMeleeCrit() != MELEE_NOCRIT;
+
 	// Swing the weapon.
 	Swing( pPlayer );
-
-	m_bCurrentAttackIsDuringDemoCharge = pPlayer->m_Shared.GetNextMeleeCrit() != MELEE_NOCRIT;
 
 	if ( pPlayer->m_Shared.GetNextMeleeCrit() == MELEE_MINICRIT )
 	{

--- a/src/game/shared/tf/tf_weaponbase_melee.cpp
+++ b/src/game/shared/tf/tf_weaponbase_melee.cpp
@@ -168,7 +168,14 @@ int	CTFWeaponBaseMelee::GetSwingRange( void )
 	CTFPlayer *pOwner = ToTFPlayer( GetOwner() );
 	if ( pOwner && ( pOwner->m_Shared.InCond( TF_COND_SHIELD_CHARGE ) || ( IsCurrentAttackDuringDemoCharge() && tf_shield_charge_melee_range.GetInt() ) ) )
 	{
-		return tf_shield_charge_melee_range.GetInt();
+		if (tf_shield_charge_melee_range.GetInt())
+		{
+			return tf_shield_charge_melee_range.GetInt();
+		}
+		else
+		{
+			return 128;
+		}
 	}
 	else
 	{

--- a/src/game/shared/tf/tf_weaponbase_melee.cpp
+++ b/src/game/shared/tf/tf_weaponbase_melee.cpp
@@ -166,16 +166,14 @@ bool CTFWeaponBaseMelee::Holster( CBaseCombatWeapon *pSwitchingTo )
 int	CTFWeaponBaseMelee::GetSwingRange( void )
 {
 	CTFPlayer *pOwner = ToTFPlayer( GetOwner() );
-	if ( pOwner && ( pOwner->m_Shared.InCond( TF_COND_SHIELD_CHARGE ) || ( IsCurrentAttackDuringDemoCharge() && tf_shield_charge_melee_range.GetInt() ) ) )
+	if (pOwner && pOwner->m_Shared.InCond(TF_COND_SHIELD_CHARGE))
 	{
-		if (tf_shield_charge_melee_range.GetInt())
-		{
-			return tf_shield_charge_melee_range.GetInt();
-		}
-		else
-		{
-			return 128;
-		}
+		// mvm bots that can attack while charging
+		return 128;
+	}
+	else if (IsCurrentAttackDuringDemoCharge() && tf_shield_charge_melee_range.GetInt())
+	{
+		return tf_shield_charge_melee_range.GetInt();
 	}
 	else
 	{

--- a/src/game/shared/tf/tf_weaponbase_melee.cpp
+++ b/src/game/shared/tf/tf_weaponbase_melee.cpp
@@ -25,6 +25,8 @@
 
 ConVar tf_weapon_criticals_melee( "tf_weapon_criticals_melee", "1", FCVAR_REPLICATED | FCVAR_NOTIFY, "Controls random crits for melee weapons. 0 - Melee weapons do not randomly crit. 1 - Melee weapons can randomly crit only if tf_weapon_criticals is also enabled. 2 - Melee weapons can always randomly crit regardless of the tf_weapon_criticals setting." );
 
+ConVar tf_shield_charge_range_extend("tf_shield_charge_range_extend", "1", FCVAR_REPLICATED | FCVAR_NOTIFY, "Controls whether Demoman's shield charges extend melee range.\n0 - Attacks started during a charge will not have their melee range modified. 1 - Attacks started during a charge will have an extended melee range.");
+
 //=============================================================================
 //
 // TFWeaponBase Melee tables.
@@ -164,7 +166,8 @@ bool CTFWeaponBaseMelee::Holster( CBaseCombatWeapon *pSwitchingTo )
 int	CTFWeaponBaseMelee::GetSwingRange( void )
 {
 	CTFPlayer *pOwner = ToTFPlayer( GetOwner() );
-	if ( pOwner && pOwner->m_Shared.InCond( TF_COND_SHIELD_CHARGE ) )
+	int shield_charge_range_extend = tf_shield_charge_range_extend.GetInt();
+	if ( pOwner && ( pOwner->m_Shared.InCond( TF_COND_SHIELD_CHARGE ) || ( IsCurrentAttackDuringDemoCharge() && shield_charge_range_extend ) ) )
 	{
 		return 128;
 	}


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

This pull request attempts to fix the broken intended mechanic of extending the range of melee attacks while charging with one of Demoman's shields not applying to attacks that begun in the middle of the charge's duration.

Within the GetSwingRange() function, there is a check whether the player is charging or not that extends the range of the melee attack to 128 hammer units if they are. However, before this function is called, the start of the attack ends any ongoing charge, so this check almost always fails unless the attack was started before the charge was.
I tried adding an additional condition to that check that activates when a charge was ended 250ms ago or sooner. I understand the implementation might not be ideal, so any criticism and/or improvements are welcome.