### PR TITLE
[TF2] Changed player-dropped ammo boxes to be more dynamic

### DIFF
--- a/src/game/server/tf/tf_ammo_pack.cpp
+++ b/src/game/server/tf/tf_ammo_pack.cpp
@@ -351,11 +351,11 @@ void CTFAmmoPack::PackTouch( CBaseEntity *pOther )
 	GiveAmmo( ceil( iMaxSecondary * m_flAmmoRatio ), TF_AMMO_SECONDARY );
 
 	// Do not scale building gibs
-	if (GetOwnerEntity() && !GetOwnerEntity()->IsBaseObject())
+	if ( GetOwnerEntity() && !GetOwnerEntity()->IsBaseObject() )
 	{
 		// Engineers drop their current metal amount, ammo packs with something other than 100 metal should give the metal amount
-		int iMetal = m_iAmmo[TF_AMMO_METAL] != 100 ? m_iAmmo[TF_AMMO_METAL] : pPlayer->GetMaxAmmo(TF_AMMO_METAL) * m_flAmmoRatio;
-		GiveAmmo(iMetal, TF_AMMO_METAL);
+		int iMetal = m_iAmmo[TF_AMMO_METAL] != 100 ? m_iAmmo[TF_AMMO_METAL] : ceil( pPlayer->GetMaxAmmo(TF_AMMO_METAL) * m_flAmmoRatio );
+		GiveAmmo( iMetal, TF_AMMO_METAL );
 	}
 
 	int iAmmoTaken = 0;


### PR DESCRIPTION
Currently, player-dropped ammo boxes always give 100 metal, unless it drops from an Engineer with less than 100 metal. Medium ammo boxes on the map give half the current Engineer's max metal instead. In a game mode like Mann vs. Machine or a map like Freaky Fair, this means player-dropped ammo boxes give 100 metal while map ammo boxes can give up to 300.

This PR changes this to also give half the Engineer's current metal, unless the player-dropped ammo box contains <100 metal (in which case it's an Engineer's leftover metal) then it simply gives the amount of metal in the box.

Note that this is less of a fix, and more of a gameplay change to make it consistent with ammo boxes on the map. An alternate version that scales Engineer-dropped ammo (while still giving less metal than if they dropped a box with full metal) is availabe at #1621 (which is the one I would recommend over this one, personally, but I don't know how important the original intent was). Building gibs use the same system as player-dropped ammo boxes, but still give the exact same metal as they did before (in both PRs).