### PR TITLE
[TF2] Changed player-dropped ammo boxes to be more dynamic (alternate method)

### DIFF
--- a/src/game/server/tf/tf_ammo_pack.cpp
+++ b/src/game/server/tf/tf_ammo_pack.cpp
@@ -353,9 +353,11 @@ void CTFAmmoPack::PackTouch( CBaseEntity *pOther )
 	// Do not scale building gibs
 	if ( GetOwnerEntity() && !GetOwnerEntity()->IsBaseObject() )
 	{
-		// Scale current metal amount to match map ammo boxes, unless it contains an Engineer's leftover metal
-		int iMetal = m_iAmmo[TF_AMMO_METAL] == 100 ? pPlayer->GetMaxAmmo(TF_AMMO_METAL) : m_iAmmo[TF_AMMO_METAL];
-		GiveAmmo( ceil( iMetal * m_flAmmoRatio), TF_AMMO_METAL );
+		int iMetalRatio = pPlayer->GetMaxAmmo(TF_AMMO_METAL) / 200;
+
+		// Scale metal given
+		int iMetal = m_iAmmo[TF_AMMO_METAL] == 100 ? ceil( pPlayer->GetMaxAmmo(TF_AMMO_METAL) * m_flAmmoRatio ) : ceil( m_iAmmo[TF_AMMO_METAL] * iMetalRatio );
+		GiveAmmo( iMetal, TF_AMMO_METAL );
 	}
 
 	int iAmmoTaken = 0;


### PR DESCRIPTION
Alternate version of #1620. The exact same thing applies to normal player-dropped ammo boxes, but Engineer-dropped ammo boxes with <100 metal give a bit more metal based on the max metal of the player picking it up. This prevents situations where a 90 metal ammo box gives 90 metal, while one with full metal would give 300 metal (compared to the other PR).

This PR scales the metal from an ammo box based on the current max metal of the Engineer that picked it up. I.e., an ammo box containing 90 metal is picked up by an Engineer with 600 max metal gives 270 metal instead of 90. An ammo box with 100 metal in that same situation gives 300 metal.