### PR TITLE
tf: Update recent rifles tracer rounds fix to check for spectated client's cl_flipviewmodels

### DIFF
--- a/src/game/shared/tf/tf_player_shared.cpp
+++ b/src/game/shared/tf/tf_player_shared.cpp
@@ -37,6 +37,7 @@
 // Client specific.
 #ifdef CLIENT_DLL
 #include "c_tf_player.h"
+#include "c_baseviewmodel.h"
 #include "c_te_effect_dispatch.h"
 #include "c_tf_fx.h"
 #include "soundenvelope.h"
@@ -196,8 +197,6 @@ ConVar tf_afterburn_debug( "tf_afterburn_debug", "0", FCVAR_REPLICATED | FCVAR_C
 
 #ifdef CLIENT_DLL
 ConVar tf_colorblindassist( "tf_colorblindassist", "0", FCVAR_CLIENTDLL | FCVAR_ARCHIVE, "Setting this to 1 turns on colorblind mode." );
-
-extern ConVar cl_flipviewmodels;
 
 extern ConVar cam_idealdist;
 extern ConVar cam_idealdistright;
@@ -10058,7 +10057,7 @@ void CTFPlayer::GetHorriblyHackedRailgunPosition( const Vector& vStart, Vector *
 
 #ifdef CLIENT_DLL
 	// Flips the horizontal position.
-	if ( cl_flipviewmodels.GetBool() )
+	if ( TeamFortress_ShouldFlipClientViewModel() )
 	{
 		vRight *= -1;
 	}


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
This PR updates the fix from f3d6634f452ee1a6ca569444335589aa2397398e (https://github.com/ValveSoftware/source-sdk-2013/pull/1244) so in observer mode the tracers origin gets reoriented based on spectated client's flipped viewmodels setting by checking for `TeamFortress_ShouldFlipClientViewModel`  from 20877e40d8dc7ead02a126ecfd20e4ba33f80456 (https://github.com/ValveSoftware/source-sdk-2013/pull/1439) instead of getting the ConVar value directly.

Without this the tracers would come from the wrong side if the local client's and spectator target's flipped viewmodels setting doesn't match.