### PR TITLE
[TF2] Fix that allows chat filters to properly load on level start

### DIFF
--- a/src/game/client/hud_basechat.cpp
+++ b/src/game/client/hud_basechat.cpp
@@ -37,11 +37,8 @@
 ConVar hud_saytext_time( "hud_saytext_time", "12", 0 );
 ConVar cl_showtextmsg( "cl_showtextmsg", "1", 0, "Enable/disable text messages printing on the screen." );
 ConVar cl_chatfilters( "cl_chatfilters", "63", FCVAR_CLIENTDLL | FCVAR_ARCHIVE, "Stores the chat filter settings " );
-ConVar cl_chatfilter_version( "cl_chatfilter_version", "0", FCVAR_CLIENTDLL | FCVAR_ARCHIVE | FCVAR_HIDDEN, "Stores the chat filter version" );
 ConVar cl_mute_all_comms("cl_mute_all_comms", "1", FCVAR_ARCHIVE, "If 1, then all communications from a player will be blocked when that player is muted, including chat messages.");
 ConVar cl_enable_text_chat( "cl_enable_text_chat", "1", FCVAR_ARCHIVE, "Enable text chat in this game" );
-
-const int kChatFilterVersion = 1;
 
 Color g_ColorBlue( 153, 204, 255, 255 );
 Color g_ColorRed( 255, 63, 63, 255 );
@@ -1686,36 +1683,9 @@ void CBaseHudChat::LevelInit( const char *newmap )
 {
 	Clear();
 
-	//=============================================================================
-	// HPE_BEGIN:
-	// [pfreese] initialize new chat filters to defaults. We do this because
-	// unused filter bits are zero, and we might want them on for new filters that
-	// are added.
-	//
-	// Also, we have to do this here instead of somewhere more sensible like the 
-	// c'tor or Init() method, because cvars are currently loaded twice: once
-	// during initialization from the local file, and later (after HUD elements
-	// have been construction and initialized) from Steam Cloud remote storage.
-	//=============================================================================
+	m_iFilterFlags = cl_chatfilters.GetInt();
 
-	switch ( cl_chatfilter_version.GetInt() )
-	{
-	case 0:
-		m_iFilterFlags |= CHAT_FILTER_ACHIEVEMENT;
-		// fall through
-	case kChatFilterVersion:
-		break;
-	}
-
-	if ( cl_chatfilter_version.GetInt() != kChatFilterVersion )
-	{
-		cl_chatfilters.SetValue( m_iFilterFlags );
-		cl_chatfilter_version.SetValue( kChatFilterVersion );
-	}
-
-	//=============================================================================
-	// HPE_END
-	//=============================================================================
+	SetFilterFlag(m_iFilterFlags);
 }
 
 void CBaseHudChat::LevelShutdown( void )


### PR DESCRIPTION
This is a one file fix for the in-game chat filters. Currently they "work" if you open the chat filter window at least once. This is reset however on game close and you will need to do this every single time you open the game.

This fix allows the CVAR cl_chatfilters to be read on level start instead of only being read when the chatfilter panel renders the checkboxes.

This fix also removes the CVAR cl_chatfilter_version as it is dead code and has not done anything since its implementation (except cause chat filters to not work).

Please consider this fix as Chat Filters currently are functionally broken unless you know the work around (which I would like to stop doing). Most people think the chat filters are broken due to how they are currently not read on level start.