### PR TITLE
tier1: Fix bad thread locking code in CUtlSymbolTableMT

### DIFF
--- a/src/public/tier1/utlsymbol.h
+++ b/src/public/tier1/utlsymbol.h
@@ -194,9 +194,11 @@ public:
 
 	CUtlSymbol Find( const char* pString ) const
 	{
-		m_lock.LockForRead();
+		// CUtlSymbolTable::Find() writes to m_pUserSearchString,
+		// so this needs to be a write lock.
+		m_lock.LockForWrite();
 		CUtlSymbol result = CUtlSymbolTable::Find( pString );
-		m_lock.UnlockRead();
+		m_lock.UnlockWrite();
 		return result;
 	}
 


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description

`CUtlSymbolTableMT::Find()` currently performs a read lock, despite calling `CUtlSymbolTable::Find()` which writes to the member variable `m_pUserSearchString` and relies on that value remaining unchanged for the remainder of the function.

This was actually the cause of a nasty recurring bug in the original retail version of [G String](https://store.steampowered.com/app/1224600/G_String/), where if one thread looked up `$basetexture` while another thread was performing a specific material var lookup, all subsequently drawn model materials would have their base texture set to null, causing them to fall back to the default white texture. Strictly speaking that bug is probably also possible in TF2, but does not appear to happen nearly as often, if at all.
