### PR TITLE
Fix tf_point_weapon_mimic not using Fire Sound

### DIFF
--- a/src/game/server/tf/player_vs_environment/tf_point_weapon_mimic.cpp
+++ b/src/game/server/tf/player_vs_environment/tf_point_weapon_mimic.cpp
@@ -14,6 +14,7 @@ public:
 	CTFPointWeaponMimic();
 	~CTFPointWeaponMimic();
 	virtual void Spawn();
+	virtual void Precache();
 
 	void InputFireOnce( inputdata_t& inputdata );
 	void InputFireMultiple( inputdata_t& inputdata );
@@ -99,13 +100,21 @@ CTFPointWeaponMimic::~CTFPointWeaponMimic()
 void CTFPointWeaponMimic::Spawn()
 {
 	BaseClass::Spawn();
+	Precache();
+	ChangeTeam( TF_TEAM_BLUE );
+}
 
+void CTFPointWeaponMimic::Precache()
+{
+	if( m_pzsFireSound )
+	{
+		PrecacheScriptSound( m_pzsFireSound );
+	}
+	
 	if( m_pzsModelOverride )
 	{
 		PrecacheModel( m_pzsModelOverride );
 	}
-
-	ChangeTeam( TF_TEAM_BLUE );
 }
 
 
@@ -149,7 +158,6 @@ void CTFPointWeaponMimic::Fire()
 {
 	Assert( m_nWeaponType >= 0 && m_nWeaponType < WEAPON_TYPES );
 
-	PrecacheScriptSound( m_pzsFireSound );
 	EmitSound( m_pzsFireSound );
 	switch( m_nWeaponType )
 	{


### PR DESCRIPTION
This simply adds an EmitSound to Fire that uses `m_pzsFireSound` (which is defined, but not used anywhere) before the switch case for picking the right weapon type.

I have read and agree to the terms for making this pull request.