### PR TITLE
Fix CancelPending input causing a crash when a logic_relay fires this to itself

### DIFF
--- a/src/game/server/logicrelay.cpp
+++ b/src/game/server/logicrelay.cpp
@@ -115,6 +115,10 @@ void CLogicRelay::InputCancelPending( inputdata_t &inputdata )
 	{
 		g_EventQueue.CancelEvents( this );
 	}
+	else
+	{
+		Warning("Entity %s - (%s) is attempting to CancelPending itself. This is not allowed!\n", this->GetEntityName(), this->GetClassname());
+	}
 
 	// Stop waiting; allow another Trigger.
 	m_bWaitForRefire = false;


### PR DESCRIPTION
Check that the input caller is not the logic_relay itself as this will cause I/O issues that will lead to a crash.