### PR TITLE
Fix point_viewcontrol locking the player's view

### DIFF
--- a/src/game/shared/teamplayroundbased_gamerules.cpp
+++ b/src/game/shared/teamplayroundbased_gamerules.cpp
@@ -2879,6 +2879,7 @@ void CTeamplayRoundBasedRules::RoundRespawn( void )
 
 		if ( pPlayer )
 		{
+			pPlayer->SetViewEntity( pPlayer ); // Additionally reset the view entity for the player
 			pPlayer->ResetPerRoundStats();
 		}
 	}

--- a/src/game/shared/tf/tf_gamerules.cpp
+++ b/src/game/shared/tf/tf_gamerules.cpp
@@ -14949,17 +14949,6 @@ void CTFGameRules::RoundRespawn( void )
 	{
 		m_bHasSpawnedSoccerBall[i] = false;
 	}
-	
-	// Reset the player's view entity as they would no longer be using a camera at this point
-	for ( int i = 0; i < MAX_PLAYERS; i++ )
-	{
-		CBasePlayer *pPlayer = UTIL_PlayerByIndex(i);
-		
-		if ( pPlayer )
-		{
-			pPlayer->SetViewEntity( pPlayer );
-		}
-	}
 
 	// remove any buildings, grenades, rockets, etc. the player put into the world
 	RemoveAllProjectilesAndBuildings();


### PR DESCRIPTION
For the sake of keeping compatibility, the camera will be reset on a new round. This also fixes the camera when point_viewcontrol is killed.

Additional changes are to remove the IsAlive check in Disable as that doesn't seem to be necessary and must be worked around with VScript to disable the point_viewcontrol on a player while they are dead.