### PR TITLE
Add SetTarget input to tf_glow to allow an easy way to change its glow target at runtime

### DIFF
--- a/src/game/server/tf/tf_glow.cpp
+++ b/src/game/server/tf/tf_glow.cpp
@@ -22,6 +22,7 @@ public:
 	void InputEnable( inputdata_t &inputdata );
 	void InputDisable( inputdata_t &inputdata );
 	void InputSetGlowColor( inputdata_t &inputdata );
+	void InputSetTarget( inputdata_t &inputdata );
 
 private:
 	CNetworkVar( int, m_iMode );
@@ -39,6 +40,7 @@ BEGIN_DATADESC( CTFGlow )
 	DEFINE_INPUTFUNC( FIELD_VOID, "Enable", InputEnable ),
 	DEFINE_INPUTFUNC( FIELD_VOID, "Disable", InputDisable ),
 	DEFINE_INPUTFUNC( FIELD_COLOR32, "SetGlowColor", InputSetGlowColor ),
+	DEFINE_INPUTFUNC( FIELD_STRING, "SetTarget", InputSetTarget )
 END_DATADESC()
 
 //-----------------------------------------------------------------------------
@@ -87,6 +89,16 @@ void CTFGlow::InputDisable( inputdata_t &inputdata )
 void CTFGlow::InputSetGlowColor( inputdata_t &inputdata )
 {
 	m_glowColor = inputdata.value.Color32(); // clients will take action
+}
+
+//-----------------------------------------------------------------------------
+void CTFGlow::InputSetTarget( inputdata_t &inputdata )
+{
+	CBaseEntity *pEnt = gEntList.FindEntityByName( nullptr, inputdata.value.String() );
+	if ( pEnt )
+	{
+		m_hTarget = pEnt;
+	}
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Currently, this cannot be done through AddOutput. Another method of achieving this is through using VScript by setting the m_hTarget through its netprop, which can be inconvenient as it requires getting the target entity's handle to then assign.