### PR TITLE
Add a new spawnflag to point_viewcontrol to toggle invulnerability of the viewer

### DIFF
--- a/src/game/server/triggers.cpp
+++ b/src/game/server/triggers.cpp
@@ -3242,8 +3242,11 @@ void CTriggerCamera::Disable( void )
 		{
 			((CBasePlayer*)m_hPlayer.Get())->GetActiveWeapon()->RemoveEffects( EF_NODRAW );
 		}
-		//return the player to previous takedamage state
-		m_hPlayer->m_takedamage = m_nOldTakeDamage;
+		// return the player to previous takedamage state if the camera has enabled invulnerability
+		if ( !HasSpawnFlags( SF_CAMERA_PLAYER_NO_INVULN ) )
+		{
+			m_hPlayer->m_takedamage = m_nOldTakeDamage;
+		}
 	}
 
 	m_state = USE_OFF;


### PR DESCRIPTION
This will allow creators to decide whether or not the player is allowed to take damage while using a point_viewcontrol. However, this still creates the issue of the player's current view entity not being reset by default and needs an explicit call for Disable or resetting the view entity back to the player. If pulled in conjunction with my other pull request at #1634, this handling can be done a bit better as it removes the IsAlive check from the Disable function so it could be disabled immediately on death instead of needing to wait until the player has respawned (if they are allowed to).