### PR TITLE
tf: Change Halloween Spell attribute text to be blue during Full Moons instead of remaining grayed out

### DIFF
--- a/src/game/shared/econ/econ_item_description.cpp
+++ b/src/game/shared/econ/econ_item_description.cpp
@@ -3697,7 +3697,8 @@ void CEconItemDescription::AddAttributeDescription( const CLocalizationProvider 
 	}
 	// They can also be from Halloween spells. These are intended to expire after Halloween in any
 	// event, but for display purposes they'll appear in grey unless the holiday is active.
-	else if ( pAttribDef->GetUserGenerationType() == kUserGeneratedAttributeType_HalloweenSpell && !EconHolidays_IsHolidayActive( kHoliday_Halloween, CRTime::RTime32TimeCur() ) )
+	else if ( pAttribDef->GetUserGenerationType() == kUserGeneratedAttributeType_HalloweenSpell &&
+	!(EconHolidays_IsHolidayActive(kHoliday_Halloween, CRTime::RTime32TimeCur()) || EconHolidays_IsHolidayActive(kHoliday_FullMoon, CRTime::RTime32TimeCur())) )
 	{
 		eDefaultAttribColor = ATTRIB_COL_ITEMSET_MISSING;
 	}


### PR DESCRIPTION
Fixes: https://github.com/ValveSoftware/Source-1-Games/issues/7691 
When a Full Moon is active, the Halloween Spell attribute text remains grayed out even though spells activate during a Full Moon.
