### PR TITLE
vgui_controls: Prevent use-after-free for m_pResourcePathID when LoadControlSettings for BuildGroup

### DIFF
--- a/src/vgui2/vgui_controls/BuildGroup.cpp
+++ b/src/vgui2/vgui_controls/BuildGroup.cpp
@@ -987,7 +987,8 @@ void BuildGroup::LoadControlSettings(const char *controlResourceName, const char
 	m_pResourceName = new char[strlen(controlResourceName) + 1];
 	strcpy(m_pResourceName, controlResourceName);
 
-	if (pathID)
+	// set path id only if it is not the same to prevent use-after-free
+	if (pathID && pathID != m_pResourcePathID)
 	{
 		delete [] m_pResourcePathID;
 		m_pResourcePathID = new char[strlen(pathID) + 1];


### PR DESCRIPTION
# Description

Catched by ASAN when use VGUI Build Mode in HL2:DM with opened FIND SERVERS & CREATE SERVER.

Invoked with same `m_pResourcePathID`
in https://github.com/ValveSoftware/source-sdk-2013/blob/b2705ba55b3b802b86ef2b2dbf97939c9d4fb685/src/vgui2/vgui_controls/BuildGroup.cpp#L1157
or
https://github.com/ValveSoftware/source-sdk-2013/blob/b2705ba55b3b802b86ef2b2dbf97939c9d4fb685/src/vgui2/vgui_controls/BuildGroup.cpp#L1161