### PR TITLE
[HL2MP] Lag Compensation Fix

### DIFF
--- a/src/game/server/hl2mp/hl2mp_player.cpp
+++ b/src/game/server/hl2mp/hl2mp_player.cpp
@@ -144,8 +144,6 @@ CHL2MP_Player::CHL2MP_Player() : m_PlayerAnimState( this )
 {
 	m_angEyeAngles.Init();
 
-	m_iLastWeaponFireUsercmd = 0;
-
 	m_flNextModelChangeTime = 0.0f;
 	m_flNextTeamChangeTime = 0.0f;
 
@@ -651,8 +649,6 @@ void CHL2MP_Player::FireBullets ( const FireBulletsInfo_t &info )
 		modinfo.m_iPlayerDamage = modinfo.m_flDamage = pWeapon->GetHL2MPWpnData().m_iPlayerDamage;
 	}
 
-	NoteWeaponFired();
-
 	BaseClass::FireBullets( modinfo );
 
 	// Move other players back to history positions based on local player's lag
@@ -669,24 +665,10 @@ void CHL2MP_Player::OnMyWeaponFired( CBaseCombatWeapon* weapon )
 	TheNextBots().OnWeaponFired( this, weapon );
 }
 
-void CHL2MP_Player::NoteWeaponFired( void )
-{
-	Assert( m_pCurrentCommand );
-	if( m_pCurrentCommand )
-	{
-		m_iLastWeaponFireUsercmd = m_pCurrentCommand->command_number;
-	}
-}
-
 extern ConVar sv_maxunlag;
 
 bool CHL2MP_Player::WantsLagCompensationOnEntity( const CBasePlayer *pPlayer, const CUserCmd *pCmd, const CBitVec<MAX_EDICTS> *pEntityTransmitBits ) const
 {
-	// No need to lag compensate at all if we're not attacking in this command and
-	// we haven't attacked recently.
-	if ( !( pCmd->buttons & IN_ATTACK ) && (pCmd->command_number - m_iLastWeaponFireUsercmd > 5) )
-		return false;
-
 	// If this entity hasn't been transmitted to us and acked, then don't bother lag compensating it.
 	if ( pEntityTransmitBits && !pEntityTransmitBits->Get( pPlayer->entindex() ) )
 		return false;

--- a/src/game/server/hl2mp/hl2mp_player.h
+++ b/src/game/server/hl2mp/hl2mp_player.h
@@ -93,8 +93,6 @@ public:
 	void GiveAllItems( void );
 	void GiveDefaultItems( void );
 
-	void NoteWeaponFired( void );
-
 	void ResetAnimation( void );
 	void SetPlayerModel( void );
 	void SetPlayerTeamModel( void );
@@ -148,7 +146,6 @@ private:
 	CNetworkQAngle( m_angEyeAngles );
 	CPlayerAnimState   m_PlayerAnimState;
 
-	int m_iLastWeaponFireUsercmd;
 	int m_iModelType;
 	CNetworkVar( int, m_iSpawnInterpCounter );
 	CNetworkVar( int, m_iPlayerSoundType );


### PR DESCRIPTION
This commit removes 2 checks for CHL2MP_Player::WantsLagCompensationOnEntity. The checks are problematic for 2 reasons:
1. The IN_ATTACK check will not work for the shotgun's secondary attack.
2. Any weapon with a delayed trace attack will not lag compensate (the shotgun delays its attacks while reloading and holding the attack button).

Even if these problems didn't exist, trying to early out with these checks wouldn't help anything because the function is only called in CLagCompensationManager::StartLagCompensation, which is only called in weapon attack functions where an attack button would've most likely been pressed.

sv_showlagcompensation is enabled in the following gameplay footage
Before:

https://github.com/user-attachments/assets/09acfe53-6f33-405b-a434-3fcc07ab652a

After:

https://github.com/user-attachments/assets/7345bc2e-b583-4b57-ab5b-83fa897d4bb7
