### PR TITLE
[TF2] Fixed Exorcism not working properly for the Stickybomb launcher and Ullapool Caber's explosion kills

### DIFF
--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -11490,14 +11490,11 @@ void CTFPlayer::CheckSpellHalloweenDeathGhosts( const CTakeDamageInfo &info, CTF
 		CALL_ATTRIB_HOOK_INT_ON_OTHER( pWeapon, iHalloweenDeathGhosts, halloween_death_ghosts );
 		if ( iHalloweenDeathGhosts > 0 )
 		{
-			if ( pTFVictim->GetTeam()->GetTeamNumber() == TF_TEAM_BLUE )
-			{
-				DispatchParticleEffect( "halloween_player_death_blue", pTFVictim->GetAbsOrigin() + Vector( 0, 0, 32 ), vec3_angle );
-			}
-			else if ( pTFVictim->GetTeam()->GetTeamNumber() == TF_TEAM_RED )
-			{
-				DispatchParticleEffect( "halloween_player_death", pTFVictim->GetAbsOrigin() + Vector( 0, 0, 32 ), vec3_angle );
-			}
+			const char* pszParticle = (pTFVictim->GetTeam()->GetTeamNumber() == TF_TEAM_BLUE) ? 
+				"halloween_player_death_blue" : "halloween_player_death";
+			
+			CPVSFilter filter( pTFVictim->GetAbsOrigin() );
+			TE_TFParticleEffect( filter, 0.0, pszParticle, pTFVictim->GetAbsOrigin() + Vector( 0, 0, 32 ), vec3_angle );
 		}
 	}
 }


### PR DESCRIPTION
Fixes the Exorcism Halloween spell not working properly for Stickybomb launchers and the Ullapool Caber's explosion kills

Fixes:
https://github.com/ValveSoftware/Source-1-Games/issues/7692 
https://github.com/ValveSoftware/source-1-games/issues/7380

Changed the way the Exorcism spell particle is dispatched, the previous DispatchParticleEffect has issues with Exorcism on certain weapons for whatever reason, seems to be some sort of client and server sync issues, I'm not 100% sure, but changing the code to TE_TFParticleEffect seems to fix these issues completely.

For those un-aware, the vanilla game currently, Exorcism is bugged on the stickybomb launcher and will not show the ghosts for the player who achieved the kill, however the ghosts show up for everyone else just fine, if the kill was made by firing a 9th sticky and the 1st stickybomb detonates killing someone, then the ghosts appear for the killer as expected.

As for the Ullapool Caber, it's a somewhat similar scenario, but instead the ghosts don't appear for the killer if the kill in question was done via the caber's explosion even though other players and the victim can see it. `ULLAPOOL_CABER_EXPLOSION` in console to know if the caber's kill was an explosion or not.

As a bonus, this also fixes weapons with taunt kills, so any taunt kills made with a weapon that has Exorcism applied It'll show the ghosts for the taunt kill aswell. This goes for numerous taunt kills, such as Demoman's decapitation taunt with the various swords, or the Engineer's Frontier Justice Guitar smash kill.

Fixed behavior with the stickybomb launcher:


https://github.com/user-attachments/assets/473ba5f4-eb68-43f6-a7d9-3f5bbad6746a

