### PR TITLE
Fix TF Bots firing at enemy players while a truce is active

### DIFF
--- a/src/game/server/tf/bot/tf_bot.cpp
+++ b/src/game/server/tf/bot/tf_bot.cpp
@@ -4989,3 +4989,22 @@ float CTFBot::GetUberDeployDelayDuration()
 	
 	return -1.f;
 }
+
+bool CTFBot::IsEnemy( const CBaseEntity *them ) const
+{
+	if ( them == NULL )
+		return false;
+		
+	int theirTeamNum = them->GetTeamNumber();
+	
+	// Check if a truce is active, as this will make enemy players no longer an "enemy" as they cannot be damaged during this state.
+	if ( TFGameRules() && TFGameRules()->IsTruceActive() )
+	{
+		return theirTeamNum != TF_TEAM_BLUE && theirTeamNum != TF_TEAM_RED;
+	}
+	else
+	{
+		// this is not strictly correct, as spectators are not enemies
+		return ( ( INextBot * ) this )->GetEntity()->GetTeamNumber() != theirTeamNum;
+	}
+}

--- a/src/game/server/tf/bot/tf_bot.h
+++ b/src/game/server/tf/bot/tf_bot.h
@@ -491,6 +491,7 @@ public:
 
 	bool ShouldReEvaluateCurrentClass( void ) const;
 	void ReEvaluateCurrentClass( void );
+	bool IsEnemy( const CBaseEntity* ) const;
 
 private:
 	CTFBotLocomotion	*m_locomotor;


### PR DESCRIPTION
Currently, TF Bots will continue firing at enemy players during a truce, resulting in uselessly firing at the enemy as they cannot be damaged. This adds an override to INextBot's IsEnemy to now check if a truce is active, and if so, ignore players that are on both Blue and Red team as bosses should be on a separate team.