### PR TITLE
[TF2] Fix fish/arm/slap messages not reflecting feigned deaths

### DIFF
--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -9669,6 +9669,7 @@ int CTFPlayer::OnTakeDamage( const CTakeDamageInfo &inputInfo )
 		}
 	}
 	
+	bool bFeignDeath = false;
 	if ( IsPlayerClass( TF_CLASS_SPY ) && ( inputInfo.GetDamageCustom() != TF_DMG_CUSTOM_TELEFRAG ) && ( inputInfo.GetDamageCustom() != TF_DMG_CUSTOM_CROC ) )
 	{
 		// Trigger feign death if the player has it prepped...
@@ -9677,7 +9678,7 @@ int CTFPlayer::OnTakeDamage( const CTakeDamageInfo &inputInfo )
 			m_Shared.SetFeignDeathReady( false );
 			if ( !m_Shared.InCond( TF_COND_TAUNTING ) )
 			{
-				SpyDeadRingerDeath( info );
+				bFeignDeath = SpyDeadRingerDeath( info );
 
 				if ( pTFAttacker )
 				{
@@ -9739,12 +9740,12 @@ int CTFPlayer::OnTakeDamage( const CTakeDamageInfo &inputInfo )
 		bool bDisguised = m_Shared.InCond( TF_COND_DISGUISED ) && pTFAttacker && ( m_Shared.GetDisguiseTeam() == pTFAttacker->GetTeamNumber() );
 		bool bFish = ( pWeapon->GetWeaponID() == TF_WEAPON_BAT_FISH );
 
-		if ( m_iHealth <= 0 )
+		if ( m_iHealth <= 0 || bFeignDeath )
 		{
 			info.SetDamageCustom( bFish ? TF_DMG_CUSTOM_FISH_KILL : TF_DMG_CUSTOM_SLAP_KILL );
 		}
 
-		if ( m_iHealth <= 0 || !bDisguised )
+		if ( m_iHealth <= 0 || bFeignDeath || !bDisguised )
 		{
 			// Do you ever find yourself typing "fish damage override" into a million-lines-of-code project and
 			// wondering about the world? Because I do.
@@ -9754,7 +9755,15 @@ int CTFPlayer::OnTakeDamage( const CTakeDamageInfo &inputInfo )
 				CALL_ATTRIB_HOOK_INT_ON_OTHER( pWeapon, iFishDamageOverride, fish_damage_override );
 			}
 
+			if ( bFeignDeath )
+			{
+				m_bGoingFeignDeath = true;
+			}
 			TFGameRules()->DeathNotice( this, info, bFish ? ( iFishDamageOverride ? "fish_notice__arm" : "fish_notice" ) : "slap_notice" );
+			if ( bFeignDeath )
+			{
+				m_bGoingFeignDeath = false;
+			}
 		}
 	}
 
@@ -15670,19 +15679,19 @@ void CTFPlayer::DestroyRagdoll( void )
 // Purpose: The player appears to die, creating a corpse and silently stealthing.
 //			Occurs when a player takes damage with the dead ringer active
 //-----------------------------------------------------------------------------
-void CTFPlayer::SpyDeadRingerDeath( const CTakeDamageInfo& info )
+bool CTFPlayer::SpyDeadRingerDeath( const CTakeDamageInfo& info )
 {
 	// Can't feign death if we're actually dead or if we're not a spy.
 	if ( !IsAlive() || !IsPlayerClass( TF_CLASS_SPY ) )
-		return;
+		return false;
 
 	// Can't feign death if we're already stealthed.
 	if ( m_Shared.InCond( TF_COND_STEALTHED ) )
-		return;
+		return false;
 
 	// Can't feign death if we aren't at full cloak energy.
 	if ( !CanGoInvisible( true ) || ( m_Shared.GetSpyCloakMeter() < 100.0f ) )
-		return;
+		return false;
 
 	m_Shared.SetSpyCloakMeter( 50.0f );
 
@@ -15693,6 +15702,7 @@ void CTFPlayer::SpyDeadRingerDeath( const CTakeDamageInfo& info )
 	// Go feign death.
 	m_Shared.AddCond( TF_COND_FEIGN_DEATH, tf_feign_death_duration.GetFloat() );
 	m_bGoingFeignDeath = false;
+	return true;
 }
 
 //-----------------------------------------------------------------------------

--- a/src/game/server/tf/tf_player.h
+++ b/src/game/server/tf/tf_player.h
@@ -442,7 +442,7 @@ public:
 	bool WasGibbedOnLastDeath( void ) { return m_bGibbedOnLastDeath; }
 
 	// Feign Death
-	void SpyDeadRingerDeath( const CTakeDamageInfo& info );
+	bool SpyDeadRingerDeath( const CTakeDamageInfo& info );
 	void FeignDeath( const CTakeDamageInfo& info, bool bDeathnotice );
 	void CreateFeignDeathRagdoll( const CTakeDamageInfo& info, bool bGib, bool bBurning, bool bDisguised );
 


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description

In TF2, if a Spy activates the Dead Ringer and is hit by the Holy Mackerel, Unarmed Combat, or Hot Hand, these weapons' hit counter messages ("x1"/"x2"/etc.) will get added to the killfeed rather than their kill messages ("FISH/ARM/SLAP KILL!"). This is an issue because it can give away to a player when a Spy is feigning their death.

The reason this occurs is because although these weapons' death notices are set to use their kill messages instead of their hit messages for feigned deaths (see [here](https://github.com/ValveSoftware/source-sdk-2013/blob/b2705ba55b3b802b86ef2b2dbf97939c9d4fb685/src/game/client/tf/tf_hud_deathnotice.cpp#L1285)), these death notices only assume they correspond to a feigned death if `CTFPlayer::IsGoingFeignDeath` (i.e. `m_bGoingFeignDeath` in `CTFPlayer`) is true when the notice is run. This PR fixes this by briefly setting `m_bGoingFeignDeath` to true when these death notices are posted for Spies feigning their deaths.

<details>
<summary><b>Screenshots</b></summary>
<p>

Both screenshots are taken after hitting a Spy with their Dead Ringer active with the Holy Mackerel.

Without this PR:

![The Spy's death notice says "x1"](https://github.com/user-attachments/assets/766cad7b-3a96-4d44-92a8-a2e810f862a6)

With this PR:

![The Spy's death notice says "FISH KILL!"](https://github.com/user-attachments/assets/27c48b71-4832-41da-ab19-3ee4e3c6972a)
</p>
</details>

This resolves https://github.com/ValveSoftware/Source-1-Games/issues/7456.
