### PR TITLE
Fix multiplication in memoverride calloc macro

### DIFF
--- a/src/public/tier0/memdbgon.h
+++ b/src/public/tier0/memdbgon.h
@@ -88,7 +88,7 @@ inline void *MemAlloc_InlineCallocMemset( void *pMem, size_t nCount, size_t nEle
 }
 #endif
 
-#define calloc(c, s)		MemAlloc_InlineCallocMemset(malloc(c*s), c, s)
+#define calloc(c, s)		MemAlloc_InlineCallocMemset( malloc( (c) * (s) ), c, s )
 #define free(p)				g_pMemAlloc->Free( p )
 #define _msize(p)			g_pMemAlloc->GetSize( p )
 #define _expand(p, s)		_expand_NoLongerSupported(p, s)


### PR DESCRIPTION
Without this change, a seemingly-innocent call such as `calloc( 1 + 1, 2 )` will allocate 3 bytes ( `1 + 1 * 2`) and then memset 4 bytes ( `(1 + 1) * 2` ), overflowing the buffer & corrupting the heap.

I don't believe any code in this repo is currently doing math in the calloc callsite like this.