### PR TITLE
game_controls: Fix model panels erroneously setting mouse cursor position after camera manipulation

### DIFF
--- a/src/game/client/game_controls/basemodel_panel.cpp
+++ b/src/game/client/game_controls/basemodel_panel.cpp
@@ -516,6 +516,10 @@ void CBaseModelPanel::OnMouseReleased( vgui::MouseCode code )
 	if ( !m_bAllowRotation && !m_bAllowPitch )
 		return;
 
+	// Only accept manipulation if we were capturing the mouse
+	if ( input()->GetMouseCapture() != GetVPanel() )
+		return;
+
 	EnableMouseCapture( false );
 	m_bMousePressed = false;
 


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
This PR adds a check to `CBaseModelPanel::OnMouseReleased` to only restore cursor position when the panel is capturing the mouse.

This caused an issue where if the mouse was released when the press wasn't started on the model panel it caused the mouse cursor to warp to a wrong position, that either being:
&nbsp;&nbsp;&nbsp;&nbsp;a) garbage memory caused by m_nClickStartX and m_nClickStartY not being initialized
&nbsp;&nbsp;&nbsp;&nbsp;b) the position of where the panel was clicked on the last time

Demonstration video of the issue (had to make the cursor very large because otherwise Shadowplay wouldn't render it into the video (?)):

[pottery_wheel_cursor_wrong_warp_before.webm](https://github.com/user-attachments/assets/f150aeb1-b828-4ae7-9153-cbd029b0a11c)
