### PR TITLE
Fix scaled physics prop save/restore

### DIFF
--- a/src/game/server/props.cpp
+++ b/src/game/server/props.cpp
@@ -41,6 +41,7 @@
 #include "physics_collisionevent.h"
 #include "gamestats.h"
 #include "vehicle_base.h"
+#include "physics_saverestore.h"
 
 #ifdef TF_DLL
 #include "nav_mesh/tf_nav_mesh.h"
@@ -6098,6 +6099,7 @@ bool UTIL_CreateScaledPhysObject( CBaseAnimating *pInstance, float flScale )
 
 	pInstance->VPhysicsDestroyObject();
 	pInstance->VPhysicsSetObject( pNewObject );
+	g_pPhysSaveRestoreManager->AssociateModel( pNewObject, pInstance->GetModelIndex() );
 
 	// Increase our model bounds
 	const model_t *pModel = modelinfo->GetModel( pInstance->GetModelIndex() );


### PR DESCRIPTION
Creating a scaled physics object involves deleting the unscaled object and creating a new one. However the new physics object was not registered in the physics saverestore handler.

Test by creating scaled prop_physics entities, save, restore, observe broken physics or game crash.