### PR TITLE
[All] Increase aspect ratio clamp from 1.85:1 to 2.40:1 when `sv_restrict_aspect_ratio_fov` is enabled

### DIFF
--- a/src/game/client/view.cpp
+++ b/src/game/client/view.cpp
@@ -1077,7 +1077,8 @@ void CViewRender::Render( vrect_t *rect )
 	    if ( ( sv_restrict_aspect_ratio_fov.GetInt() > 0 && engine->IsWindowedMode() && gpGlobals->maxClients > 1 ) ||
 		    sv_restrict_aspect_ratio_fov.GetInt() == 2 )
 	    {
-		    limitedAspectRatio = MIN( aspectRatio, 1.85f * 0.75f ); // cap out the FOV advantage at a 1.85:1 ratio (about the widest any legit user should be)
+		    // cap out the FOV advantage at a 2.40:1 ratio (slightly wider than most "21:9" monitors)
+			limitedAspectRatio = MIN( aspectRatio, 2.4f * 0.75f ); 
 	    }
 
 		viewEye.fov = ScaleFOVByWidthRatio( viewEye.fov, limitedAspectRatio );


### PR DESCRIPTION
This cvar is designed to prevent "wallhacks" caused by high FOVs on multi-monitor setups, but it also negatively impacts users with "21:9" ultrawide setups, which aren't wide enough for the wide FOV to clip into walls.

Note that the cvar description will need to be updated in the engine. The actual clamping is completely done in the game DLL, afaict.

Valve TF2 servers have the cvar set to the default of 1, which means it only affects windowed mode.

The specific value of 2.40:1 was chosen because it is wider than "21:9" monitors (2560x1080 is 2.37:1; 3440x1440 is 2.38:1), and is the widest that ultrawide movies generally are (1920x800, which is also a common custom resolution for ultrawide gaming on a 16:9 monitor), but is not wide enough for the "wallhack" bugs pop up that this cvar was designed to mitigate.

<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 

I agree; all changes are my own.
-->
