### PR TITLE
Revert 'PDump' specific font definitions

### DIFF
--- a/src/game/client/hud_pdump.h
+++ b/src/game/client/hud_pdump.h
@@ -68,9 +68,9 @@ private:
 
 	EHANDLE			m_hDumpEntity;
 
-	CPanelAnimationVar( vgui::HFont, m_FontSmall, "ItemFont", "PDumpVerySmall" );
-	CPanelAnimationVar( vgui::HFont, m_FontMedium, "LabelFont", "PDumpSmall" );
-	CPanelAnimationVar( vgui::HFont, m_FontBig, "TitleFont", "PDump" );
+	CPanelAnimationVar( vgui::HFont, m_FontSmall, "ItemFont", "DefaultVerySmall" );
+	CPanelAnimationVar( vgui::HFont, m_FontMedium, "LabelFont", "DefaultSmall" );
+	CPanelAnimationVar( vgui::HFont, m_FontBig, "TitleFont", "Trebuchet24" );
 };
 
 CPDumpPanel *GetPDumpPanel();


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
At the launch of the HL2 Anniversary update, the PDump hud got specific definitions, probably due to conflicts with the new GorDIN definitions etc. However for some reason these font definitions have been later reverted for HL2.

These clientscheme font definitions were never added to other Source Engine branches (TF2, CSS etc.) and the SDK 2013 code haven't been updated to reflect the removal of the PDump hud font either.

This revert also fixes https://github.com/ValveSoftware/Source-1-Games/issues/7100 (which also points to the font defs being changed.)