### PR TITLE
Allow all games to use detail prop shapes & update detail prop cvar defaults

### DIFF
--- a/src/game/client/detailobjectsystem.cpp
+++ b/src/game/client/detailobjectsystem.cpp
@@ -27,9 +27,7 @@
 #include <algorithm>
 #include "tier0/valve_minmax_on.h"
 
-#if defined(DOD_DLL) || defined(CSTRIKE_DLL) || defined(TF_CLIENT_DLL)
 #define USE_DETAIL_SHAPES
-#endif
 
 #ifdef USE_DETAIL_SHAPES
 #include "engine/ivdebugoverlay.h"


### PR DESCRIPTION
# Description
This PR simply enables detail shapes for all games, which also includes detail prop swaying and avoidance.
I'm unsure why this was never enabled for all games, nothing seems to be noticeably incorrect or bad after some basic testing in TF2.

I also updated the defaults for the CVars added to match the ones found in Day of Defeat: Source so that the new features can take effect.