### PR TITLE
[All Games; ServerBrowser] Use 64bit time_t instead of 32bit unsigned int to store timestamps

### DIFF
--- a/src/common/ServerBrowser/blacklisted_server_manager.cpp
+++ b/src/common/ServerBrowser/blacklisted_server_manager.cpp
@@ -53,7 +53,7 @@ int CBlacklistedServerManager::LoadServersFromFile( const char *pszFilename, boo
 	{
 		const char *pszName = pData->GetString( "name" );
 
-		uint32 ulDate = pData->GetInt( "date" );
+		time_t ulDate = pData->GetUint64( "date" );
 		if ( bResetTimes )
 		{
 			time_t today;
@@ -90,7 +90,7 @@ void CBlacklistedServerManager::SaveToFile( const char *pszFilename )
 	{
 		KeyValues *pSubKey = new KeyValues( "server" );
 		pSubKey->SetString( "name", m_Blacklist[i].m_szServerName );
-		pSubKey->SetInt( "date", m_Blacklist[i].m_ulTimeBlacklistedAt );
+		pSubKey->SetUint64( "date", m_Blacklist[i].m_ulTimeBlacklistedAt );
 		pSubKey->SetString( "addr", m_Blacklist[i].m_NetAdr.ToString() );
 		pKV->AddSubKey( pSubKey );
 	}
@@ -155,7 +155,7 @@ blacklisted_server_t *CBlacklistedServerManager::AddServer( const char *serverNa
 //-----------------------------------------------------------------------------
 // Purpose: Add the given server to the blacklist. Return added server.
 //-----------------------------------------------------------------------------
-blacklisted_server_t *CBlacklistedServerManager::AddServer( const char *serverName, const char *netAddressString, uint32 timestamp )
+blacklisted_server_t *CBlacklistedServerManager::AddServer( const char *serverName, const char *netAddressString, time_t timestamp )
 {
 	netadr_t netAdr( netAddressString );
 

--- a/src/common/ServerBrowser/blacklisted_server_manager.h
+++ b/src/common/ServerBrowser/blacklisted_server_manager.h
@@ -23,7 +23,7 @@ struct blacklisted_server_t
 {
 	int m_nServerID;
 	char m_szServerName[64];
-	uint32 m_ulTimeBlacklistedAt;
+	time_t m_ulTimeBlacklistedAt;
 	netadr_t m_NetAdr;
 };
 
@@ -40,7 +40,7 @@ public:
 
 	blacklisted_server_t *AddServer( gameserveritem_t &server );
 	blacklisted_server_t *AddServer( const char *serverName, uint32 serverIP, int serverPort );
-	blacklisted_server_t *AddServer( const char *serverName, const char *netAddressString, uint32 timestamp );
+	blacklisted_server_t *AddServer( const char *serverName, const char *netAddressString, time_t timestamp );
 
 	void RemoveServer( int iServerID );		// remove server with matching 'server id' from list
 


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
Currently all of Source1 games are using 32bit value to store 64bit timestamps which causes integer overflow and by result displaying a wrong date.
Including these changes will probably require additional code changes in ServerBrowser DLL.

Here's an example of the bug
<img width="181" height="54" alt="image" src="https://github.com/user-attachments/assets/5111d7fe-be7c-4f2c-adc7-b534a440e3ff" />
<img width="118" height="35" alt="image" src="https://github.com/user-attachments/assets/10ed0566-b7d9-44d0-abb5-2e66c3c13f05" />


After the fix
<img width="178" height="56" alt="image" src="https://github.com/user-attachments/assets/34505150-3a89-4488-b66b-9f31fdba888d" />