### PR TITLE
all games: Fix a case of dynamic shadows bleeding through thin surfaces

### DIFF
--- a/src/game/client/clientshadowmgr.cpp
+++ b/src/game/client/clientshadowmgr.cpp
@@ -2192,6 +2192,31 @@ void CClientShadowMgr::ComputeExtraClipPlanes( IClientRenderable* pRenderable,
 		}
 	}
 
+	class CTraceFilterShadowReceiversOnly : public CTraceFilter
+	{
+		virtual bool ShouldHitEntity( IHandleEntity *pHandleEntity, int fContentsMask )
+		{
+			if ( !StandardFilterRules( pHandleEntity, fContentsMask ) )
+				return false;
+
+			C_BaseEntity *pEntity = EntityFromEntityHandle( pHandleEntity );
+			if ( pEntity && !pEntity->ShouldReceiveProjectedTextures( SHADOW_FLAGS_PROJECTED_TEXTURE_TYPE_MASK ) )
+				return false;
+
+			return true;
+		}
+	};
+
+	// Do a trace to the bbox corner origin. If it hits a shadow receiving brush
+	// move the corner to be outside it so shadows won't poke-thru thin walls
+	CTraceFilterShadowReceiversOnly traceFilter;
+	trace_t tr;
+	UTIL_TraceLine( pRenderable->GetRenderOrigin(), origin, MASK_SOLID_BRUSHONLY, &traceFilter, &tr );
+	if ( tr.fraction < 1.f )
+	{
+		VectorAdd( tr.endpos, tr.plane.normal, origin );
+	}
+
 	// Now that we have it, create 3 planes...
 	Vector normal;
 	ClearExtraClipPlanes(handle);

--- a/src/game/client/clientshadowmgr.cpp
+++ b/src/game/client/clientshadowmgr.cpp
@@ -2200,7 +2200,7 @@ void CClientShadowMgr::ComputeExtraClipPlanes( IClientRenderable* pRenderable,
 				return false;
 
 			C_BaseEntity *pEntity = EntityFromEntityHandle( pHandleEntity );
-			if ( pEntity && !pEntity->ShouldReceiveProjectedTextures( SHADOW_FLAGS_PROJECTED_TEXTURE_TYPE_MASK ) )
+			if ( pEntity && !pEntity->ShouldReceiveProjectedTextures( SHADOW_FLAGS_SHADOW ) )
 				return false;
 
 			return true;


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
`CClientShadowMgr::ComputeExtraClipPlanes`  builds clip planes from the shadow bounding box corner farthest along the shadow direction to prevent dynamic shadows poking through surfaces.

If that corner goes through a brush it would cause the shadow to render on the other side of the brush's surface. This can happen when a model stands near a thin brush wall.

To fix this, this PR updates the compute routine to do a trace from the caster's render origin to our bounding box corner and push the corner's origin along the surface normal towards the caster as needed so the clip planes won't be positioned through solids.

Note that this doesn't address the lack of dynamic shadow clipping through walls in the shadow direction because of the engine's hard-coded limit of max 4 clip planes per shadow. If the limit were to be incremented by 3 (1 plane for each axis) it would suffice to provide a fix for that.

Comparison screenshots of some problematic spots on Dustbowl:
| Before | After |
| --- | --- |
| <img width="1440" height="1080" alt="rttshadow_clipping_fix_dustbowl1_before" src="https://github.com/user-attachments/assets/229a553f-ce15-44b0-8762-5e05bd1ed5e9" /> | <img width="1440" height="1080" alt="rttshadow_clipping_fix_dustbowl1_after" src="https://github.com/user-attachments/assets/495aea8c-0dbb-4b33-aba6-607aa43fe1a2" /> |
| <img width="1440" height="1080" alt="rttshadow_clipping_fix_dustbowl2_before" src="https://github.com/user-attachments/assets/f7a631b3-0a2f-4360-a333-b7735090a7c1" /> | <img width="1440" height="1080" alt="rttshadow_clipping_fix_dustbowl2_after" src="https://github.com/user-attachments/assets/5623365f-c751-4575-95a8-2143d3fffdaf" /> |
| <img width="1440" height="1080" alt="rttshadow_clipping_fix_dustbowl3_before" src="https://github.com/user-attachments/assets/678ee762-6e81-4bbd-a814-e253fd4c372f" /> | <img width="1440" height="1080" alt="rttshadow_clipping_fix_dustbowl3_after" src="https://github.com/user-attachments/assets/8cb9c5c3-4eee-4ddd-bf44-15e7daaa8ded" /> |
| <img width="1440" height="1080" alt="rttshadow_clipping_fix_dustbowl4_before" src="https://github.com/user-attachments/assets/d78608ad-571c-44f0-81e0-a3347ff18022" />  | <img width="1440" height="1080" alt="rttshadow_clipping_fix_dustbowl4_after" src="https://github.com/user-attachments/assets/c3af3bd2-2ba1-4456-9d83-a48535156dac" /> |

Closes https://github.com/ValveSoftware/Source-1-Games/issues/52