### PR TITLE
VRAD - don't generate per-vertex fallbacks for lightmaped props by default

### DIFF
--- a/src/utils/vrad/vrad.cpp
+++ b/src/utils/vrad/vrad.cpp
@@ -61,6 +61,7 @@ bool		bRed2Black = true;
 bool		g_bFastAmbient = false;
 bool        g_bNoSkyRecurse = false;
 bool		g_bDumpPropLightmaps = false;
+bool		g_bPropLightmapFallbacks = false;
 
 
 int			junk;
@@ -2698,6 +2699,10 @@ int ParseCommandLine( int argc, char **argv, bool *onlydetail )
 				return -1;
 			}
 		}
+		else if (!Q_stricmp(argv[i],"-propmapvertexfallbacks"))
+		{
+			g_bPropLightmapFallbacks = true;
+		}
 
 #if ALLOWDEBUGOPTIONS
 		else if (!Q_stricmp(argv[i],"-scale"))
@@ -2876,6 +2881,7 @@ void PrintUsage( int argc, char **argv )
 		"  -textureshadows : Allows texture alpha channels to block light - rays intersecting alpha surfaces will sample the texture\n"
 		"  -noskyboxrecurse : Turn off recursion into 3d skybox (skybox shadows on world)\n"
 		"  -nossprops      : Globally disable self-shadowing on static props\n"
+		"  -propmapvertexfallbacks : Generate fallback per-vertex lighting for lightmapped static props"
 		"\n"
 #if 1 // Disabled for the initial SDK release with VMPI so we can get feedback from selected users.
 		);

--- a/src/utils/vrad/vradstaticprops.cpp
+++ b/src/utils/vrad/vradstaticprops.cpp
@@ -1377,57 +1377,60 @@ void CVradStaticPropMgr::ComputeLighting( CStaticProp &prop, int iThread, int pr
 					GenerateLightmapSamplesForMesh( matPos, matNormal, iThread, skip_prop, nFlags, prop.m_LightmapImageWidth, prop.m_LightmapImageHeight, pStudioHdr, pStudioModel, pVtxModel, meshID, pResults );
 				}
 
-				// If we do lightmapping, we also do vertex lighting as a potential fallback. This may change.
-				for ( int vertexID = 0; vertexID < pStudioMesh->numvertices; ++vertexID )
+				// If we do lightmapping, only do vertex lighting as a potential fallback if user requests.
+				if (!withTexelLighting || g_bPropLightmapFallbacks)
 				{
-					Vector sampleNormal;
-					Vector samplePosition;
-					// transform position and normal into world coordinate system
-					VectorTransform(*vertData->Position(vertexID), matPos, samplePosition);
-					VectorTransform(*vertData->Normal(vertexID), matNormal, sampleNormal);
-
-					if ( PositionInSolid( samplePosition ) )
+					for ( int vertexID = 0; vertexID < pStudioMesh->numvertices; ++vertexID )
 					{
-						// vertex is in solid, add to the bad list, and recover later
-						badVertex_t badVertex;
-						badVertex.m_ColorVertex = numVertexes;
-						badVertex.m_Position = samplePosition;
-						badVertex.m_Normal = sampleNormal;
-						badVerts.AddToTail( badVertex );			
-					}
-					else
-					{
-						Vector direct_pos=samplePosition;
-							
-						
+						Vector sampleNormal;
+						Vector samplePosition;
+						// transform position and normal into world coordinate system
+						VectorTransform(*vertData->Position(vertexID), matPos, samplePosition);
+						VectorTransform(*vertData->Normal(vertexID), matNormal, sampleNormal);
 
-						Vector directColor(0,0,0);
-						ComputeDirectLightingAtPoint( direct_pos,
-														sampleNormal, directColor, iThread,
-														skip_prop, nFlags );
-						Vector indirectColor(0,0,0);
-
-						if (g_bShowStaticPropNormals)
+						if ( PositionInSolid( samplePosition ) )
 						{
-							directColor= sampleNormal;
-							directColor += Vector(1.0,1.0,1.0);
-							directColor *= 50.0;
+							// vertex is in solid, add to the bad list, and recover later
+							badVertex_t badVertex;
+							badVertex.m_ColorVertex = numVertexes;
+							badVertex.m_Position = samplePosition;
+							badVertex.m_Normal = sampleNormal;
+							badVerts.AddToTail( badVertex );			
 						}
 						else
 						{
-							if (numbounce >= 1)
-								ComputeIndirectLightingAtPoint( 
-									samplePosition, sampleNormal, 
-									indirectColor, iThread, true,
-									( prop.m_Flags & STATIC_PROP_IGNORE_NORMALS) != 0 );
+							Vector direct_pos=samplePosition;
+								
+							
+
+							Vector directColor(0,0,0);
+							ComputeDirectLightingAtPoint( direct_pos,
+															sampleNormal, directColor, iThread,
+															skip_prop, nFlags );
+							Vector indirectColor(0,0,0);
+
+							if (g_bShowStaticPropNormals)
+							{
+								directColor= sampleNormal;
+								directColor += Vector(1.0,1.0,1.0);
+								directColor *= 50.0;
+							}
+							else
+							{
+								if (numbounce >= 1)
+									ComputeIndirectLightingAtPoint( 
+										samplePosition, sampleNormal, 
+										indirectColor, iThread, true,
+										( prop.m_Flags & STATIC_PROP_IGNORE_NORMALS) != 0 );
+							}
+							
+							colorVerts[numVertexes].m_bValid = true;
+							colorVerts[numVertexes].m_Position = samplePosition;
+							VectorAdd( directColor, indirectColor, colorVerts[numVertexes].m_Color );
 						}
 						
-						colorVerts[numVertexes].m_bValid = true;
-						colorVerts[numVertexes].m_Position = samplePosition;
-						VectorAdd( directColor, indirectColor, colorVerts[numVertexes].m_Color );
+						numVertexes++;
 					}
-					
-					numVertexes++;
 				}
 			}
 			


### PR DESCRIPTION
Speeds up compile times, by not compiling lighting for lightmapped props twice (or thrice, if compiling `-both`). Can re-enable old behavior with `-propmapvertexfallbacks`, if needed (generally shouldn't need to, but leaving the option out there. Might be necessary for dx8?).

<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 

I agree. All code modifications were done by myself without any code from elsewhere.
-->
