### PR TITLE
[HLDMS] HL1Port - fix (un)locked sounds for old doors

### DIFF
--- a/src/game/server/doors.cpp
+++ b/src/game/server/doors.cpp
@@ -558,16 +558,16 @@ void CBaseDoor::Precache( void )
 		// Too short to be ANYTHING ".wav", so it must be an old button index.
 		// Call appropriate button soundscript to respect the designer's original 
 		// selection, so we don't get unresponsive doors.
-		m_ls.sLockedSound = MakeButtonSound( (int)m_ls.sLockedSound );
-		PrecacheScriptSound(m_ls.sLockedSound.ToCStr());
+		m_ls.sLockedSound = MakeButtonSound( atoi(STRING(m_ls.sLockedSound)) );
+		PrecacheScriptSound(STRING(m_ls.sLockedSound));
 	}
 	if( m_ls.sUnlockedSound != NULL_STRING && strlen((char*)STRING(m_ls.sUnlockedSound)) < 4 )
 	{
 		// Too short to be ANYTHING ".wav", so it must be an old button index.
 		// Call appropriate button soundscript to respect the designer's original 
 		// selection, so we don't get unresponsive doors.
-		m_ls.sUnlockedSound = MakeButtonSound( (int)m_ls.sUnlockedSound );
-		PrecacheScriptSound(m_ls.sUnlockedSound.ToCStr());
+		m_ls.sUnlockedSound = MakeButtonSound( atoi(STRING(m_ls.sUnlockedSound)) );
+		PrecacheScriptSound(STRING(m_ls.sUnlockedSound));
 	}
 #endif//HL1_DLL
 


### PR DESCRIPTION
A few doors weren't changed to use an explicitly defined WAV or soundscript instead of a button index for the locked/unlocked sounds. The existing fallback behavior hardcoded such doors to use "buttons/button2.wav", instead of the proper button soundscript that matches the array that GoldSrc used; this edit uses the code from buttons.cpp to properly chose the correct soundscript to restore the "designer's original selection".

Rather than porting HLSDK code (which is technically against the license for both SDKs, for some reason), this PR duplicates a function from buttons.cpp. While I probably could've #included buttons.cpp, I don't trust that that wouldn't have broken things. HLSDK made the function accessible from anything that #includes cbase.h, which seems overkill.

This same fix can be applied to HLS, but that is a separate Git branch now, so it can't be applied in the same PR. In the unlikely event that this PR gets pulled upstream, make sure the cherry-pick it for the singleplayer branch as well.

<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 

This PR only uses existing Source SDK code.
-->
