### PR TITLE
Fix sentrygun tracers not alternating position between shots

### DIFF
--- a/src/game/server/tf/tf_obj_sentrygun.cpp
+++ b/src/game/server/tf/tf_obj_sentrygun.cpp
@@ -1403,7 +1403,6 @@ int CObjectSentrygun::GetFireAttachment()
 	{
 		iAttachment = m_iAttachments[SENTRYGUN_ATTACHMENT_MUZZLE];
 	}
-	m_iLastMuzzleAttachmentFired = iAttachment;
 
 	return iAttachment;
 }
@@ -1553,6 +1552,9 @@ bool CObjectSentrygun::Fire()
 
 		FireBullets( info );
 
+		// this will alternate the attachment next time
+		m_iLastMuzzleAttachmentFired = iAttachment;
+
 		// sentry gun fire 'heats up' the nav mesh around it
 		UpdateNavMeshCombatStatus();
 
@@ -1685,7 +1687,7 @@ void CObjectSentrygun::MakeTracer( const Vector &vecTracerSrc, const trace_t &tr
 //-----------------------------------------------------------------------------
 int	CObjectSentrygun::GetTracerAttachment( void )
 {
-	return m_iAttachments[SENTRYGUN_ATTACHMENT_MUZZLE];
+	return GetFireAttachment();
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
On level 2 and 3 sentries, the muzzleflash particle alternates the barrel position between each shot, but tracers are always stuck to the left side. This PR fixes that.

Before:

https://github.com/user-attachments/assets/fae8f1f6-8a6c-43f0-9763-b61371116160


After

https://github.com/user-attachments/assets/2453a9be-2099-4020-b378-7515b26a876f

