### PR TITLE
[TF2] Fix pyrovision effect for mods on TF2.

### DIFF
--- a/game/mod_tf/cfg/mtp.cfg
+++ b/game/mod_tf/cfg/mtp.cfg
@@ -1,0 +1,14 @@
+"VisionFilterShadersMapWhitelist"
+{
+	"arena_badlands.bsp"	"1"
+	"ctf_2fort.bsp"		"1"
+	"cp_badlands.bsp"	"1"
+	"cp_dustbowl.bsp"	"1"
+	"cp_gravelpit.bsp"	"1"
+	"koth_badlands.bsp"	"1"
+	"koth_viaduct.bsp"	"1"
+	"plr_hightower.bsp"	"1"
+	"pl_badwater.bsp"	"1"
+	"pl_goldrush.bsp"	"1"
+	"sd_doomsday.bsp"	"1"
+}

--- a/src/game/client/cdll_client_int.cpp
+++ b/src/game/client/cdll_client_int.cpp
@@ -1045,6 +1045,20 @@ int CHLClient::Init( CreateInterfaceFn appSystemFactory, CreateInterfaceFn physi
 	IGameSystem::Add( GetPredictionCopyTester() );
 #endif
 
+#ifndef DEDICATED
+
+	//usually thats in materialsystem but sdk dont have that
+	//overlays freaks out when flashlight support is on while having pyrovision
+	//this check is only for tf mods, because pyrovision is only tf thing
+#if defined( TF_CLIENT_DLL )
+	{
+		ConVarRef( "mat_supportflashlight" ).SetValue( false );
+	}
+#endif
+
+
+#endif
+
 	modemanager->Init( );
 
 	g_pClientMode->InitViewport();


### PR DESCRIPTION
While pyrovision is on, overlays freaks out. This happens only in mods, and not in default tf. 

https://github.com/user-attachments/assets/608cb60d-c45c-4d5a-a9ce-fc4b54bcb0b7

After this commit.

https://github.com/user-attachments/assets/5c4cde5d-d7fd-494f-9c8c-f8b92c01a36a

Hardcoded check for gameinfo folder that prevented this was in materialsystem, but mods cant modify this, so check falsely sets mat_supportflashlight as true. Setting mat_supportflashlight in CHLClient::Init for TF fixes this issue for mods. 