### PR TITLE
Fix logic_branch OnRemove doesnt call I/O's

### DIFF
--- a/src/game/server/logicentities.cpp
+++ b/src/game/server/logicentities.cpp
@@ -2244,7 +2244,7 @@ void CLogicBranch::UpdateOnRemove()
 		CBaseEntity *pEntity = m_Listeners.Element( i ).Get();
 		if ( pEntity )
 		{
-			g_EventQueue.AddEvent( this, "_OnLogicBranchRemoved", 0, this, this );
+			g_EventQueue.AddEvent( pEntity, "_OnLogicBranchRemoved", 0, this, this );
 		}
 	}
 	


### PR DESCRIPTION
``CLogicBranch::UpdateOnRemove`` supposed to call _OnLogicBranchRemoved on listeners, but `AddEvent` was called with `AddEvent( this, ...` instead of the `AddEvent( pEntity, ...` where `pEntity` is one of the listeners. Because of that `UpdateOnRemove` wasnt doing anything. 

This wont break anything because this thing was broken in the first place, and didnt work at all. No one used it. 