### PR TITLE
Fix prediction error when crouch jumping

### DIFF
--- a/src/game/shared/gamemovement.cpp
+++ b/src/game/shared/gamemovement.cpp
@@ -4012,6 +4012,18 @@ void CGameMovement::PlayerRoughLandingEffects( float fvol )
 }
 
 //-----------------------------------------------------------------------------
+// Purpose: Reset interpolation when player duck state changes
+// Input  : direction - 
+//-----------------------------------------------------------------------------
+void CGameMovement::ResetDuckLatched()
+{
+#ifdef CLIENT_DLL
+	if ( !player->InFirstPersonView() )
+		player->ResetLatched();
+#endif
+}
+
+//-----------------------------------------------------------------------------
 // Purpose: Use for ease-in, ease-out style interpolation (accel/decel)  Used by ducking code.
 // Input  : value - 
 //			scale - 
@@ -4133,9 +4145,7 @@ void CGameMovement::FinishUnDuck( void )
 
 	mv->SetAbsOrigin( newOrigin );
 
-#ifdef CLIENT_DLL
-	player->ResetLatched();
-#endif // CLIENT_DLL
+	ResetDuckLatched();
 
 	// Recategorize position since ducking can change origin
 	CategorizePosition();
@@ -4232,9 +4242,7 @@ void CGameMovement::FinishDuck( void )
    		VectorAdd( mv->GetAbsOrigin(), viewDelta, out );
 		mv->SetAbsOrigin( out );
 
-#ifdef CLIENT_DLL
-		player->ResetLatched();
-#endif // CLIENT_DLL
+		ResetDuckLatched();
 	}
 
 	// See if we are stuck?

--- a/src/game/shared/gamemovement.h
+++ b/src/game/shared/gamemovement.h
@@ -227,6 +227,7 @@ protected:
 	void			FinishUnDuckJump( trace_t &trace );
 	void			SetDuckedEyeOffset( float duckFraction );
 	void			FixPlayerCrouchStuck( bool moveup );
+	void			ResetDuckLatched();
 
 	float			SplineFraction( float value, float scale );
 


### PR DESCRIPTION
In multiplayer, crouch jumping will always cause a prediction error. This has been a bug since 2007, and it causes a very minor view hitch (more noticeable with higher ping). This error is caused by crouch jumps resetting interpolation state, to prevent the playermodel position from stuttering due to change of origin.

However, after the [change to interpolate viewpunch](https://github.com/ValveSoftware/source-sdk-2013/pull/1392) was merged, this caused the bug to manifest itself more clearly. When firing a weapon with viewpunch such as Scattergun/Shotgun, the viewpunch will get reset after crouch jumping due to the prediction error, which causes a very noticeable/disorienting snap in the aim.

This PR fixes this by not resetting player interpolation in firstperson. Since the client alway predicts the view change, and the playermodel isn't visible, there is no need to reset interpolation. However, an interpolation reset is still needed for playermodels to prevent the position from stuttering heavily. 

Due to complicated interactions with interpolation and prediction, fixing this properly would be involved and likely lead to regressions, so I opted for the simpler solution. While crouchjumping will still creates prediction errors in thirdperson, thirdperson already has several other prediction errors (due to the weapon model changing), and thirdperson never applies viewpunch, so the snapping issue does not manifest there.

Tested with `net_fakelag 50`, `cl_showerror 2` (the prediction error does not appear with no latency).

Before:

https://github.com/user-attachments/assets/c3fc84d5-5e48-4c99-91f1-af8f6ee38b94

After:

https://github.com/user-attachments/assets/f2e37368-fce8-41fd-b112-c0affc546cdf


Video that more clearly shows the issue: https://youtu.be/883f9DY-H-Y
