### PR TITLE
[TF2] Fix heal target marker disappearing while using Ubercharge

### DIFF
--- a/src/game/shared/tf/tf_weapon_medigun.cpp
+++ b/src/game/shared/tf/tf_weapon_medigun.cpp
@@ -349,9 +349,11 @@ void CWeaponMedigun::Precache()
 	PrecacheParticleSystem( "medicgun_invulnstatus_fullcharge_blue" );
 	PrecacheParticleSystem( "medicgun_invulnstatus_fullcharge_red" );
 	PrecacheParticleSystem( "medicgun_beam_red_invun" );
+	PrecacheParticleSystem( "medicgun_beam_red_invun_targeted" );
 	PrecacheParticleSystem( "medicgun_beam_red" );
 	PrecacheParticleSystem( "medicgun_beam_red_targeted" );
 	PrecacheParticleSystem( "medicgun_beam_blue_invun" );
+	PrecacheParticleSystem( "medicgun_beam_blue_invun_targeted" );
 	PrecacheParticleSystem( "medicgun_beam_blue" );
 	PrecacheParticleSystem( "medicgun_beam_blue_targeted" );
 	PrecacheParticleSystem( "vaccinator_red_buff1" );
@@ -2405,7 +2407,14 @@ void CWeaponMedigun::UpdateEffects( void )
 		{
 			if ( m_bChargeRelease )
 			{
-				pszEffectName = "medicgun_beam_red_invun";
+				if ( bHealTargetMarker && pFiringPlayer == pLocalPlayer )
+				{
+					pszEffectName = "medicgun_beam_red_invun_targeted";
+				}
+				else
+				{
+					pszEffectName = "medicgun_beam_red_invun";
+				}
 			}
 			else
 			{
@@ -2423,7 +2432,14 @@ void CWeaponMedigun::UpdateEffects( void )
 		{
 			if ( m_bChargeRelease )
 			{
-				pszEffectName = "medicgun_beam_blue_invun";
+				if ( bHealTargetMarker && pFiringPlayer == pLocalPlayer )
+				{
+					pszEffectName = "medicgun_beam_blue_invun_targeted";
+				}
+				else
+				{
+					pszEffectName = "medicgun_beam_blue_invun";
+				}
 			}
 			else
 			{


### PR DESCRIPTION
Adds extra checks to `tf_weapon_medigun.cpp` so the weapon checks if the local player has the heal target marker setting (`hud_medichealtargetmarker`) enabled while using an Ubercharge and if so, use a separate particle system. This fixes [this issue](https://github.com/ValveSoftware/Source-1-Games/issues/7747) where the target marker disappears when deploying an Ubercharge.
The relevant particle files with the new particle systems can be downloaded [here](https://github.com/user-attachments/files/24223753/medicgun_beam.zip). I have also taken the opportunity to add the missing `trail_stage3` particles to the DirectX 8.0 version of the invun beams, fixing [this issue](https://github.com/ValveSoftware/Source-1-Games/issues/4895).