### PR TITLE
Address hitching with GenerateRandomItem

### DIFF
--- a/src/game/server/tf/bot/tf_bot.cpp
+++ b/src/game/server/tf/bot/tf_bot.cpp
@@ -4898,9 +4898,8 @@ void CTFBot::AddItem( const char* pszItemName )
 {
 	CItemSelectionCriteria criteria;
 	criteria.SetQuality( AE_USE_SCRIPT_VALUE );
-	criteria.BAddCondition( "name", k_EOperator_String_EQ, pszItemName, true );
 
-	CBaseEntity *pItem = ItemGeneration()->GenerateRandomItem( &criteria, WorldSpaceCenter(), vec3_angle );
+	CBaseEntity *pItem = ItemGeneration()->GenerateItem( &criteria, pszItemName, WorldSpaceCenter(), vec3_angle );
 	if ( pItem )
 	{
 		CEconItemView *pScriptItem = static_cast< CBaseCombatWeapon * >( pItem )->GetAttributeContainer()->GetItem();

--- a/src/game/server/tf/tf_bot_temp.cpp
+++ b/src/game/server/tf/tf_bot_temp.cpp
@@ -1391,9 +1391,8 @@ void BotGenerateAndWearItem( CTFPlayer *pBot, const char *itemName )
 	CItemSelectionCriteria criteria;
 	criteria.SetItemLevel( AE_USE_SCRIPT_VALUE );
 	criteria.SetQuality( AE_USE_SCRIPT_VALUE );
-	criteria.BAddCondition( "name", k_EOperator_String_EQ, itemName, true );
 
-	CBaseEntity *pItem = ItemGeneration()->GenerateRandomItem( &criteria, pBot->GetAbsOrigin(), vec3_angle );
+	CBaseEntity *pItem = ItemGeneration()->GenerateItem( &criteria, itemName, pBot->GetAbsOrigin(), vec3_angle );
 	if ( pItem )
 	{
 		// If it's a weapon, remove the current one, and give us this one.

--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -5565,8 +5565,7 @@ CBaseEntity	*CTFPlayer::GiveNamedItem( const char *pszName, int iSubType, const 
 		// Generate a base item of the specified type
 		CItemSelectionCriteria criteria;
 		criteria.SetQuality( AE_NORMAL );
-		criteria.BAddCondition( "name", k_EOperator_String_EQ, pszName, true );
-		pItem = ItemGeneration()->GenerateRandomItem( &criteria, GetAbsOrigin(), vec3_angle, pszName );
+		pItem = ItemGeneration()->GenerateItem( &criteria, pszName, GetAbsOrigin(), vec3_angle, pszName );
 	}
 
 	if ( pItem == NULL )

--- a/src/game/shared/econ/econ_entity_creation.cpp
+++ b/src/game/shared/econ/econ_entity_creation.cpp
@@ -57,6 +57,19 @@ CBaseEntity *CItemGeneration::GenerateItemFromDefIndex( int iDefIndex, const Vec
 }
 
 //-----------------------------------------------------------------------------
+// Purpose: Generate a item matching the specified definition index
+//-----------------------------------------------------------------------------
+CBaseEntity *CItemGeneration::GenerateItem( CItemSelectionCriteria *pCriteria, const char *pszItemName, const Vector &vecOrigin, const QAngle &vecAngles, const char* pszOverrideClassName )
+{
+	entityquality_t iQuality;
+	int iChosenItem = ItemSystem()->GenerateItem( pCriteria, pszItemName, &iQuality );
+	if ( iChosenItem == INVALID_ITEM_DEF_INDEX )
+		return NULL;
+
+	return SpawnItem( iChosenItem, vecOrigin, vecAngles, pCriteria->GetItemLevel(), iQuality, pszOverrideClassName );
+}
+
+//-----------------------------------------------------------------------------
 // Purpose: Generate an item from the specified item data
 //-----------------------------------------------------------------------------
 CBaseEntity *CItemGeneration::GenerateItemFromScriptData( const CEconItemView *pData, const Vector &vecOrigin, const QAngle &vecAngles, const char *pszOverrideClassName )

--- a/src/game/shared/econ/econ_entity_creation.h
+++ b/src/game/shared/econ/econ_entity_creation.h
@@ -32,6 +32,9 @@ public:
 	// Generate a random item matching the specified definition index
 	CBaseEntity *GenerateItemFromDefIndex( int iDefIndex, const Vector &vecOrigin, const QAngle &vecAngles );
 
+	// Generate a item matching the specified definition index
+	CBaseEntity* GenerateItem( CItemSelectionCriteria* pCriteria, const char *pszItemName, const Vector& vecOrigin, const QAngle& vecAngles, const char* pszOverrideClassName = NULL );
+
 	// Generate an item from the specified item data
 	CBaseEntity *GenerateItemFromScriptData( const CEconItemView *pData, const Vector &vecOrigin, const QAngle &vecAngles, const char *pszOverrideClassName );
 

--- a/src/game/shared/econ/econ_item_system.h
+++ b/src/game/shared/econ/econ_item_system.h
@@ -54,6 +54,9 @@ public:
 	// Select and return a random item's definition index matching the specified criteria
 	item_definition_index_t	GenerateRandomItem( CItemSelectionCriteria *pCriteria, entityquality_t *outEntityQuality );
 
+	// Select and return a item's definition index matching the specified criteria
+	item_definition_index_t	GenerateItem( CItemSelectionCriteria *pCriteria, const char *pszItemName, entityquality_t *outEntityQuality );
+
 	// Select and return the base item definition index for a class's load-out slot 
 	// Note: baseitemcriteria_t is game-specific and/or may not exist!
 	virtual item_definition_index_t GenerateBaseItem( struct baseitemcriteria_t *pCriteria ) { return INVALID_ITEM_DEF_INDEX; }


### PR DESCRIPTION
Within gamemodes such as Mann vs. Machine, on a listen server, notable hitching occurs when bots spawn in this is due to GenerateRandomItem which does a big lookup to find the item it wants to spawn. This pull request implements GenerateItem which follows the same rules but avoids the lookup by specifying the name directly which avoids that hitching.