### PR TITLE
Reduce seam in water refraction

### DIFF
--- a/src/game/client/viewrender.cpp
+++ b/src/game/client/viewrender.cpp
@@ -6051,6 +6051,9 @@ void CAboveWaterView::CRefractionView::Draw()
 	g_pPortalRender->WaterRenderingHandler_PreRefraction();
 #endif
 
+	// Move camera 4u down to remove visible refraction gap
+	origin.z -= 4.f;
+
 	// Store off view origin and angles and set the new view
 	int nSaveViewID = CurrentViewID();
 	SetupCurrentView( origin, angles, VIEW_REFRACTION );


### PR DESCRIPTION
This PR adjusts water clipping plane by 4 units up, enough to fix visible seam
**Note:** it leads to x2 performance usage as it renders view above but clips it early

Before:
<img width="791" height="266" alt="image" src="https://github.com/user-attachments/assets/4ebd5711-a35d-4028-b720-27e1604223f5" />

After:
<img width="869" height="371" alt="image" src="https://github.com/user-attachments/assets/adb06b95-c4a5-4925-a09d-6a877eb0585b" />

