### PR TITLE
[TF2] fix shortstop shove being prevented by reloading

### DIFF
--- a/src/game/shared/tf/tf_weapon_pistol.cpp
+++ b/src/game/shared/tf/tf_weapon_pistol.cpp
@@ -12,6 +12,7 @@
 #ifdef CLIENT_DLL
 #include "c_tf_player.h"
 #include "c_tf_gamestats.h"
+#include "prediction.h"
 // Server specific.
 #else
 #include "tf_player.h"
@@ -110,7 +111,44 @@ void CTFPistol_ScoutPrimary::SecondaryAttack( void )
 	m_flNextSecondaryAttack = gpGlobals->curtime + 1.5f;
 	m_flPushTime = gpGlobals->curtime + 0.2f;	// Anim delay
 
-	EmitSound( "Weapon_Hands.Push" );
+#ifdef CLIENT_DLL
+	if ( !prediction->InPrediction() || prediction->IsFirstTimePredicted() )
+#endif
+	{
+		EmitSound( "Weapon_Hands.Push" );
+	}
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
+bool CTFPistol_ScoutPrimary::Reload( void )
+{
+	// allow reloading 0.5 secs early, since the full 1.5-sec delay looks awkward
+	if ( ( m_flNextSecondaryAttack - 0.5f ) > gpGlobals->curtime )
+		return false;
+
+	return BaseClass::Reload();
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
+bool CTFPistol_ScoutPrimary::ShouldAbortReload()
+{
+	if ( BaseClass::ShouldAbortReload() )
+		return true;
+
+	// allow aborting reloads with alt-fire
+
+	if ( m_flNextSecondaryAttack > gpGlobals->curtime )
+		return false;
+
+	CBasePlayer *pOwner = GetPlayerOwner();
+	if ( !pOwner )
+		return false;
+
+	return pOwner->m_nButtons & IN_ATTACK2;
 }
 
 //-----------------------------------------------------------------------------

--- a/src/game/shared/tf/tf_weapon_pistol.h
+++ b/src/game/shared/tf/tf_weapon_pistol.h
@@ -78,6 +78,8 @@ public:
 	virtual int		GetWeaponID( void ) const	{ return TF_WEAPON_HANDGUN_SCOUT_PRIMARY; }
 	virtual void	PlayWeaponShootSound( void );
 	virtual void	SecondaryAttack( void );
+	virtual bool	Reload( void );
+	virtual bool	ShouldAbortReload();
 	virtual void	ItemPostFrame();
 	virtual bool	Holster( CBaseCombatWeapon *pSwitchingTo );
 	virtual void	Precache( void );

--- a/src/game/shared/tf/tf_weaponbase.cpp
+++ b/src/game/shared/tf/tf_weaponbase.cpp
@@ -1841,6 +1841,15 @@ bool CTFWeaponBase::IsReloading() const
 	return m_iReloadMode != TF_RELOAD_START;
 }
 
+bool CTFWeaponBase::ShouldAbortReload() //const
+{
+	CBasePlayer *pOwner = GetPlayerOwner();
+	if ( !pOwner )
+		return false;
+
+	return ( pOwner->m_nButtons & IN_ATTACK ) && Clip1() > 0;
+}
+
 bool CTFWeaponBase::UsesCenterFireProjectile( void ) const
 {
 	int nCenterFireProjectile = 0;
@@ -2377,7 +2386,7 @@ void CTFWeaponBase::ItemBusyFrame( void )
 	}
 
 	// Interrupt a reload on reload singly weapons.
-	if ( ( pOwner->m_nButtons & IN_ATTACK ) && Clip1() > 0 )
+	if ( ShouldAbortReload() )
 	{
 		bool bAbortReload = false;
 		if ( m_bReloadsSingly )

--- a/src/game/shared/tf/tf_weaponbase.h
+++ b/src/game/shared/tf/tf_weaponbase.h
@@ -379,6 +379,7 @@ class CTFWeaponBase : public CBaseCombatWeapon, public IHasOwner, public IHasGen
 	void SendReloadEvents();
 	virtual bool IsReloading() const;			// is the weapon reloading right now?
 	virtual float GetReloadSpeedScale() const { return 1.f; }
+	virtual bool ShouldAbortReload();// const;
 
 	virtual bool AutoFiresFullClip( void ) const OVERRIDE;
 	bool AutoFiresFullClipAllAtOnce( void ) const;


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description

fixes ValveSoftware/Source-1-Games/issues/5326

i think that this can reasonably be considered a bug because the shortstop's alt-fire is the only action in the game that can't interrupt a reload, so i highly doubt that this was intentional at all especially since autoreload is enabled by default

this change allows the secondary fire to cancel a reload in the exact same way the primary fire cancels a reload

(i have also tested this change under high latency conditions)