### PR TITLE
[TF2] Fixed Beach Ball going Invisible when shot at

### DIFF
--- a/src/public/jigglebones.cpp
+++ b/src/public/jigglebones.cpp
@@ -588,14 +588,15 @@ void CJiggleBones::BuildJiggleTransformations( int boneIndex, float currenttime,
 
 		data->lastBoingPos = goalBasePosition;
 
-		float speed = vel.NormalizeInPlace();
-		if ( speed < 0.00001f )
+				float speed;
+		if ( vel.IsZero() )
 		{
 			vel = Vector( 0, 0, 1.0f );
 			speed = 0.0f;
 		}
 		else
 		{
+			speed = vel.NormalizeInPlace();
 			speed /= deltaT;
 		}
 
@@ -674,9 +675,6 @@ void CJiggleBones::BuildJiggleTransformations( int boneIndex, float currenttime,
 				boingSide = CrossProduct( data->boingDir, Vector( 0, 0, 1.0f ) );
 			}
 			boingSide.NormalizeInPlace();
-			
-				if (data->boingDir.IsZero()) data->boingDir = Vector(0, 0, 1);
-			if (boingSide.IsZero()) boingSide = Vector(1, 0, 0);
 			
 			Vector boingOtherSide = CrossProduct( data->boingDir, boingSide );
 

--- a/src/public/jigglebones.cpp
+++ b/src/public/jigglebones.cpp
@@ -674,7 +674,10 @@ void CJiggleBones::BuildJiggleTransformations( int boneIndex, float currenttime,
 				boingSide = CrossProduct( data->boingDir, Vector( 0, 0, 1.0f ) );
 			}
 			boingSide.NormalizeInPlace();
-
+			
+				if (data->boingDir.IsZero()) data->boingDir = Vector(0, 0, 1);
+			if (boingSide.IsZero()) boingSide = Vector(1, 0, 0);
+			
 			Vector boingOtherSide = CrossProduct( data->boingDir, boingSide );
 
 			matrix3x4_t xfrmToBoingCoordsMX;


### PR DESCRIPTION
This patch fixes the beach ball/Smissmas ornament ball from going invisible by preventing invalid numbers from being used in the math. If invalid numbers are used (for example 0) it catches it and changes it to 1

To note: While this issue could technically be fixed by preventing the Ball from using the is_boing property, it would also remove the jiggle effect when interacting with the world. My fix preserves both the visibility of the ball when shot as well as the jiggle effect included in the model's QC

Before

https://github.com/user-attachments/assets/be2bab2e-08d8-4fd4-b098-0984210db175

After

https://github.com/user-attachments/assets/8f49eb09-0faa-49d8-8efb-c611aca497cd

