### PR TITLE
[TF2] Fix oversight preventing see_enemy_health attribute from functioning properly on classes other than Medic and Heavy

### DIFF
--- a/src/game/client/tf/tf_hud_target_id.cpp
+++ b/src/game/client/tf/tf_hud_target_id.cpp
@@ -799,11 +799,14 @@ void CTargetID::UpdateID( void )
 			bool bMedic = pLocalTFPlayer->IsPlayerClass( TF_CLASS_MEDIC );
 			bool bHeavy = pLocalTFPlayer->IsPlayerClass( TF_CLASS_HEAVYWEAPONS );
 
+			int iSeeEnemyHealth = 0;
+			CALL_ATTRIB_HOOK_FLOAT_ON_OTHER( pLocalTFPlayer, iSeeEnemyHealth, see_enemy_health )
+
 			// See if the player wants to fill in the data string
 			bool bIsAmmoData = false;
 			bool bIsKillStreakData = false;
 			pPlayer->GetTargetIDDataString( bDisguisedTarget, sDataString, sizeof(sDataString), bIsAmmoData, bIsKillStreakData );
-			if ( pLocalTFPlayer->GetTeamNumber() == TEAM_SPECTATOR || bInSameTeam || bSpy || bDisguisedEnemy || bMedic || bHeavy )
+			if ( pLocalTFPlayer->GetTeamNumber() == TEAM_SPECTATOR || bInSameTeam || bSpy || bDisguisedEnemy || bMedic || bHeavy || iSeeEnemyHealth )
 			{
 				printFormatString = "#TF_playerid_sameteam";
 				bShowHealth = true;


### PR DESCRIPTION
# Description
This PR fixes an oversight that prevents the `see_enemy_health`/`mod see enemy health` attribute from functioning when applied to any class other than Heavy or Medic.

Currently, the `CTargetID::UpdateID` function manually checks if the player is either a Heavy or Medic to determine whether to update target ID data or not.

This results in the enemy target IDs having no text when the attribute is applied to classes other than Heavy or Medic.

This PR fixes this issue by also checking `pLocalTFPlayer` for the `see_enemy_health` attribute.

The original manual checks for Heavy or Medic are left in place in case they are necessary for any obscure edge cases I'm not aware of.

Before             |  After
:-------------------------:|:-------------------------:
![](https://github.com/user-attachments/assets/618ede07-ccbf-4aa0-93a9-f4375f3b29f1)  | ![](https://github.com/user-attachments/assets/73b35165-1a11-4979-a56a-39ca81f82431)