### PR TITLE
all games: Use cl_interp_npcs for non-player NextBot interpolation

### DIFF
--- a/src/game/client/c_baseentity.cpp
+++ b/src/game/client/c_baseentity.cpp
@@ -78,7 +78,7 @@ void cc_cl_interp_all_changed( IConVar *pConVar, const char *pOldString, float f
 
 
 static ConVar  cl_extrapolate( "cl_extrapolate", "1", FCVAR_CHEAT, "Enable/disable extrapolation if interpolation history runs out." );
-static ConVar  cl_interp_npcs( "cl_interp_npcs", "0.0", FCVAR_USERINFO, "Interpolate NPC positions starting this many seconds in past (or cl_interp, if greater)" );  
+static ConVar  cl_interp_npcs( "cl_interp_npcs", "0.1", FCVAR_USERINFO | FCVAR_NOT_CONNECTED | FCVAR_ARCHIVE, "Interpolate NPC positions starting this many seconds in past (or cl_interp, if greater)", true, 0.0f, true, 0.5f );
 static ConVar  cl_interp_all( "cl_interp_all", "0", 0, "Disable interpolation list optimizations.", 0, 0, 0, 0, cc_cl_interp_all_changed );
 ConVar  r_drawmodeldecals( "r_drawmodeldecals", "1", FCVAR_ALLOWED_IN_COMPETITIVE );
 extern ConVar	cl_showerror;
@@ -5901,7 +5901,7 @@ static float AdjustInterpolationAmount( C_BaseEntity *pEntity, float baseInterpo
 		{
 			while ( pEntity )
 			{
-				if ( pEntity->IsNPC() )
+				if ( pEntity->IsNPC() || ( !pEntity->IsPlayer() && pEntity->IsNextBot() ) )
 					return minNPCInterpolation;
 
 				pEntity = pEntity->GetMoveParent();


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
This PR makes NPC NextBots such as tf_zombie and MvM/Halloween bosses respect `cl_interp_npcs` value for interpolation rather than using base `cl_interp`. Previously this ConVar would've only affected HL1, HL2 and ASW NPCs.

The upside to this change is that it lets you keep lower interp for players while being able to give NPCs a higher value so their animations won't be laggy. Old behavior can be restored by setting `cl_interp_npcs` lower than `cl_interp` which will make it use the base value again.

`cl_interp_npcs` ConVar definition has been also updated to be more inline with `cl_interp`.

Both of the comparison videos below were recorded with `cl_interp_ratio 2;cl_interp 0.03;cl_interp_npcs 0.1`.

Before:

[cl_interp_nb_before.webm](https://github.com/user-attachments/assets/599bd867-6cb6-4d55-9515-083f8c444e45)

After:

[cl_interp_nb_after.webm](https://github.com/user-attachments/assets/a921c039-a9be-46a9-8d51-f454f429df6b)
