### PR TITLE
Fix Wrap Assassin's bauble bouncing off from brush entities

### DIFF
--- a/src/game/shared/tf/tf_weapon_bat.cpp
+++ b/src/game/shared/tf/tf_weapon_bat.cpp
@@ -1256,8 +1256,8 @@ void CTFBall_Ornament::VPhysicsCollision( int index, gamevcollisionevent_t *pEve
 	if ( !pHitEntity )
 		return;
 
-	// Break if we hit the world.
-	if ( pHitEntity->IsWorld() )
+	// Break if we hit anything that isn't a player (the world, doors, etc)
+	if ( !pHitEntity->IsPlayer() )
 	{
 		// Explode immediately next frame. (Can't explode in the collision callback.)
 		m_vCollisionVelocity = pEvent->preVelocity[index];


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
Fixes https://github.com/ValveSoftware/Source-1-Games/issues/4826. Instead of just breaking the bauble when hitting the world, it now breaks if it hits anything that isn't a player.

Tested with doors, players, payload, everything seems to work fine.

https://github.com/user-attachments/assets/f62c81f7-43f6-41d8-a3e8-ccc1b409723a


