### PR TITLE
[TF2] Fix a crash with the Reflect power-up vs the Reflect power-up

### DIFF
--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -9243,6 +9243,12 @@ int CTFPlayer::OnTakeDamage( const CTakeDamageInfo &inputInfo )
 	// We do this here, after damage modify rules to ensure distance falloff calculations have already been made before we pass that damage back to the attacker
 	if ( pTFAttacker && m_Shared.GetCarryingRuneType() == RUNE_REFLECT && pTFAttacker != this && !pTFAttacker->m_Shared.IsInvulnerable() && pTFAttacker->IsAlive() )
 	{
+		// Don't receive reflected damage if you are also carrying Reflect (prevents a stack overflow in a game with two Reflect players).
+		if ( info.GetDamageCustom() == TF_DMG_CUSTOM_RUNE_REFLECT )
+		{
+			return 0;
+		}
+
 		CTakeDamageInfo dmg = info;
 		CTFProjectile_SentryRocket *sentryRocket = dynamic_cast<CTFProjectile_SentryRocket *>( info.GetInflictor() );
 
@@ -10664,12 +10670,6 @@ int CTFPlayer::OnTakeDamage_Alive( const CTakeDamageInfo &info )
 	if ( flBleedingTime > 0 && pTFAttacker )
 	{
 		m_Shared.MakeBleed( pTFAttacker, dynamic_cast< CTFWeaponBase * >( info.GetWeapon() ), flBleedingTime );
-	}
-
-	// Don't recieve reflected damage if you are carrying Reflect (prevents a loop in a game with two Reflect players)
-	if ( ( info.GetDamageType() & TF_DMG_CUSTOM_RUNE_REFLECT ) && m_Shared.GetCarryingRuneType() == RUNE_REFLECT )
-	{
-		return 0;
 	}
 
 	CTFWeaponBase *pTFWeapon = dynamic_cast< CTFWeaponBase * >( info.GetWeapon() );


### PR DESCRIPTION
Currently in `CTFPlayer::OnTakeDamage_Alive`, this safeguard exists to prevent a stack overflow whenever a reflected damage instance occurs against a player who themselves is also holding a Reflect power-up.

```cpp
// Don't recieve reflected damage if you are carrying Reflect (prevents a loop in a game with two Reflect players)
if ( ( info.GetDamageType() & TF_DMG_CUSTOM_RUNE_REFLECT ) && m_Shared.GetCarryingRuneType() == RUNE_REFLECT )
{
	return 0;
}
```

The game will still crash when two players with Reflect power-ups attack each other, however, due to two issues:

- `info.GetDamageType()` is checked for `TF_DMG_CUSTOM_RUNE_REFLECT`, when `info.GetDamageCustom()` should be checked instead.
- This test is done in `CTFPlayer::OnTakeDamage_Alive`, but new reflected damage instances are created before that function call is reached in `CTFPlayer::OnTakeDamage`, meaning the stack overflows before this safeguard is ever reached.

This PR addresses both of the above issues by rectifying the conditional and moving the safeguard to a more appropriate location.