### PR TITLE
[TF2] check for collision before breaking penetrating huntsman arrows

### DIFF
--- a/src/game/server/tf/tf_projectile_arrow.cpp
+++ b/src/game/server/tf/tf_projectile_arrow.cpp
@@ -744,9 +744,6 @@ void CTFProjectile_Arrow::ArrowTouch( CBaseEntity *pOther )
 	bool bShield = pOther->IsCombatItem() && !InSameTeam( pOther );
 	CTFPumpkinBomb *pPumpkinBomb = dynamic_cast< CTFPumpkinBomb * >( pOther );
 
-	if ( pOther->IsSolidFlagSet( FSOLID_TRIGGER | FSOLID_VOLUME_CONTENTS ) && !pPumpkinBomb && !bShield )
-		return;
-
 	// test against combat characters, which include players, engineer buildings, and NPCs
 	CBaseCombatCharacter *pOtherCombatCharacter = dynamic_cast< CBaseCombatCharacter * >( pOther );
 
@@ -758,6 +755,19 @@ void CTFProjectile_Arrow::ArrowTouch( CBaseEntity *pOther )
 		{
 			pOther = pOtherCombatCharacter;
 		}
+	}
+
+	// Verify a correct "other."
+	const trace_t *pTrace = &CBaseEntity::GetTouchTrace();
+	if ( ( !pOther->IsSolid() ||
+		   ( pOther->GetCollisionGroup() == TFCOLLISION_GROUP_RESPAWNROOMS ) ||
+		   pOther->IsFuncLOD() ||
+		   pOther->IsBaseProjectile() ||
+		   !ShouldTouchNonWorldSolid( pOther, pTrace ) ||
+		   pOther->IsSolidFlagSet( FSOLID_TRIGGER | FSOLID_VOLUME_CONTENTS ) )
+		 && !pPumpkinBomb && !bShield )
+	{
+		return;
 	}
 
 	CTFMerasmusTrickOrTreatProp *pMerasmusProp = dynamic_cast< CTFMerasmusTrickOrTreatProp* >( pOther );


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
This fixes https://github.com/ValveSoftware/Source-1-Games/issues/7745.
Adds some checks from other trigger based projectiles to `CTFProjectile_Arrow::ArrowTouch` to prevent processing of bounding box collisions if the arrow did not actually touch the model.