### PR TITLE
[All] Fold `env_texturetoggle` inputs into `CBaseEntity`

### DIFF
--- a/src/game/server/baseentity.cpp
+++ b/src/game/server/baseentity.cpp
@@ -2199,6 +2199,9 @@ BEGIN_DATADESC_NO_BASE( CBaseEntity )
 	DEFINE_INPUTFUNC( FIELD_STRING, "CallScriptFunction", InputCallScriptFunction ),
 	DEFINE_INPUTFUNC( FIELD_VOID, "TerminateScriptScope", InputTerminateScriptScope ),
 
+	DEFINE_INPUTFUNC( FIELD_VOID, "IncrementTextureFrameIndex", InputIncrementBrushTexIndex ),
+	DEFINE_INPUTFUNC( FIELD_INTEGER, "SetTextureFrameIndex", InputSetBrushTexIndex ),
+
 	DEFINE_OUTPUT( m_OnUser1, "OnUser1" ),
 	DEFINE_OUTPUT( m_OnUser2, "OnUser2" ),
 	DEFINE_OUTPUT( m_OnUser3, "OnUser3" ),
@@ -7318,6 +7321,28 @@ float g_debugCounter = 0;
 #define UPDATE_VMPROFILE
 
 #endif // VMPROFILE
+
+//-----------------------------------------------------------------------------
+// Purpose: Increment toggleTextureVar of materials on the entity with 
+// 			ToggleTexture material proxy.
+// Input  : &inputdata - 
+//-----------------------------------------------------------------------------
+void CTextureToggle::InputIncrementBrushTexIndex( inputdata_t& inputdata )
+{
+	int iCurrentIndex = GetTextureFrameIndex() + 1;
+	SetTextureFrameIndex( iCurrentIndex );
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: Explicitly set toggleTextureVar of materials on the entity with 
+// 			ToggleTexture material proxy.
+// Input  : &inputdata - 
+//-----------------------------------------------------------------------------
+void CTextureToggle::InputSetBrushTexIndex( inputdata_t& inputdata )
+{
+	int iData = inputdata.value.Int();
+	SetTextureFrameIndex( iData );
+}
 
 //-----------------------------------------------------------------------------
 // Returns true if the function was located and called. false otherwise.

--- a/src/game/server/baseentity.h
+++ b/src/game/server/baseentity.h
@@ -705,6 +705,8 @@ public:
 	void InputCallScriptFunction( inputdata_t &inputdata );
 	void TerminateScriptScope();
 	void InputTerminateScriptScope( inputdata_t &inputdata );
+	void InputIncrementBrushTexIndex( inputdata_t &inputdata );
+	void InputSetBrushTexIndex( inputdata_t &inputdata );
 
 	inline void ScriptDisableDraw()
 	{


### PR DESCRIPTION
This deprecates `env_texturetoggle`, reducing entity spaghetti. Inputs have been renamed to avoid conflicts in existing maps, in case a entity has the same name as a env_texturetoggle.

FGD entries are as such, and can be added to the `Targetname` BaseClass:
```d
	input	IncrementTextureFrameIndex(void) : "Increments entity's current texture frame by one."
	input	SetTextureFrameIndex(integer) : "Sets entity's texture frame to the specified index."
```

I doubt this works on sprite models and studio models, but there is no collective C++ class that all brush entities and info_overlay_accessor inherit that sprite and studio entities do not.