### PR TITLE
[All] Fix func_wall `Use` input

### DIFF
--- a/src/game/server/bmodels.cpp
+++ b/src/game/server/bmodels.cpp
@@ -36,6 +36,7 @@ public:
 	bool	CreateVPhysics( void );
 	void	Use( CBaseEntity *pActivator, CBaseEntity *pCaller, USE_TYPE useType, float value );
 
+	// formerly pev->frame
 	int		m_nState;
 };
 
@@ -58,6 +59,16 @@ void CFuncWall::Spawn( void )
 	
 	// If it can't move/go away, it's really part of the world
 	AddFlag( FL_WORLDBRUSH );
+
+	// attempt to detect VMT-set texframeindex, without overriding it
+	if (GetTextureFrameIndex() != 0)
+	{
+		m_nState = 1;
+	}
+	else
+	{
+		m_nState = 0;
+	}
 
 	// set manual mode
 	CreateVPhysics();
@@ -88,6 +99,34 @@ void CFuncWall::Use( CBaseEntity *pActivator, CBaseEntity *pCaller, USE_TYPE use
 	if ( ShouldToggle( useType, m_nState ) )
 	{
 		m_nState = 1 - m_nState;
+		SetTextureFrameIndex(m_nState);
+	}
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: Modified Use input that properly sets USE_TYPE instead of using
+//			a bogus value based upon output ID.
+//-----------------------------------------------------------------------------
+void CBaseEntity::InputUse( inputdata_t &inputdata )
+{
+	if ( (inputdata.value.String()) == "")
+	{
+		// if empty, assume USE_TOGGLE
+		Use( inputdata.pActivator, inputdata.pCaller, USE_TOGGLE, 0 );
+	}
+	else
+	{
+		int iData = inputdata.value.Int();
+		if ( (iData >= 0) && (iData <= 3) )
+		{
+			// Valid USE_TYPE; pass to Use funcion as-is
+			Use( inputdata.pActivator, inputdata.pCaller, iData, 0 );
+		}
+		else
+		{
+			// Invalid USE_TYPE; fall back to USE_TOGGLE
+			Use( inputdata.pActivator, inputdata.pCaller, USE_TOGGLE, 0 );
+		}
 	}
 }
 


### PR DESCRIPTION
This PR fixes the `Use` input and function for func_wall to toggle between frames 0 and 1, as it did in GoldSrc.

When porting this entity, `pev->frame` was changed to a `m_nState`. Unlike GoldSrc's pev->frame, m_nState doesn't do anything on its own. This PR uses it as it seems to have been intended: to store the on/off state of the entity so that `SetTextureFrameIndex()` can be called accordingly. The Use input has also been updated to properly handle USE_TYPE.

Yes, I am aware that this can be achieved with env_texturetoggle, and that func_wall is deprecated by func_brush. This was an exercise and demonstration in how the underutilized [SetTextureFrameIndex()](https://developer.valvesoftware.com/wiki/SetTextureFrameIndex()) can be used to toggle textures via code.

While this replicates GoldSrc behavior, no HLSDK code was used (as it would not have worked).