### PR TITLE
[TF2] fix miniguns having inconsistent spin-down time based on which mouse button is released

### DIFF
--- a/src/game/shared/tf/tf_weapon_minigun.cpp
+++ b/src/game/shared/tf/tf_weapon_minigun.cpp
@@ -435,6 +435,12 @@ void CTFMinigun::SharedAttack()
 		}
 	}
 
+	if ( m_iWeaponState == AC_STATE_FIRING || m_iWeaponState == AC_STATE_SPINNING )
+	{
+		// make sure both primary and secondary fire will spin down at identical times
+		SetWeaponIdleTime( gpGlobals->curtime + 0.01 );
+	}
+
 	if ( pPlayer->GetAmmoCount( m_iPrimaryAmmoType ) > 0 )
 	{
 		if ( m_iWeaponState > AC_STATE_STARTFIRING )


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description

when you unrev the minigun by releasing your left mouse button, it takes ~1.15 secs to fully spin down

when you unrev the minigun by releasing your right mouse button, it takes ~1.44 secs to fully spin down

this is because when `SendWeaponAnim( ACT_VM_SECONDARYATTACK )` is used to set the weapon's idle rev animation, it also inadvertently changes the weapon's "idle time" as a side effect which adds a delay:

https://github.com/ValveSoftware/source-sdk-2013/blob/7191ecc418e28974de8be3a863eebb16b974a7ef/src/game/shared/basecombatweapon_shared.cpp#L2425

unfixed:

https://github.com/user-attachments/assets/d57b4547-8c95-421f-9f47-645748293b95

fixed:

https://github.com/user-attachments/assets/8e001858-b9aa-451f-b917-4df95b7c5938

note: green crosshair = no mouse buttons pressed