### PR TITLE
[TF2] fix dragon's fury fireballs having incorrect projectile path

### DIFF
--- a/src/game/shared/tf/tf_weapon_dragons_fury.cpp
+++ b/src/game/shared/tf/tf_weapon_dragons_fury.cpp
@@ -21,7 +21,7 @@
 #endif
 
 extern ConVar tf_flamethrower_burstammo;
-
+extern ConVar tf_fireball_distance;
 
 //=============================================================================
 //
@@ -144,24 +144,19 @@ CBaseEntity* CTFWeaponFlameBall::FireProjectile( CTFPlayer *pPlayer )
 	RemoveProjectileAmmo( pPlayer );
 
 #ifdef GAME_DLL
-	Vector vecForward, vecRight, vecUp;
-	AngleVectors( pPlayer->EyeAngles(), &vecForward, &vecRight, &vecUp );
+	QAngle angForward = pPlayer->EyeAngles();
 
-	float fRight = 8.f;
+	Vector vecForward, vecRight, vecUp;
+	AngleVectors( angForward, &vecForward, &vecRight, &vecUp );
+
+	float fRight = 7.0f;
 	if ( IsViewModelFlipped() )
 	{
 		fRight *= -1;
 	}
-	Vector vecSrc = pPlayer->Weapon_ShootPosition();
+	Vector vecShootPos = pPlayer->Weapon_ShootPosition();
 	// Shoot from the right location
-	vecSrc = vecSrc + (vecUp * -9.0f) + (vecRight * 7.0f) + (vecForward * 3.0f);
-
-	QAngle angForward = pPlayer->EyeAngles();
-
-	trace_t trace;	
-	Vector vecEye = pPlayer->EyePosition();
-	CTraceFilterSimple traceFilter( this, COLLISION_GROUP_NONE );
-	UTIL_TraceHull( vecEye, vecSrc, -Vector(8,8,8), Vector(8,8,8), MASK_SOLID_BRUSHONLY, &traceFilter, &trace );
+	Vector vecSrc = vecShootPos + ( vecUp * -9.0f ) + ( vecRight * fRight ) + ( vecForward * 3.0f );
 
 	CTFProjectile_Rocket *pRocket = static_cast<CTFProjectile_Rocket*>( CBaseEntity::CreateNoSpawn( "tf_projectile_balloffire", vecSrc, angForward, pPlayer ) );
 	if ( pRocket )
@@ -171,12 +166,14 @@ CBaseEntity* CTFWeaponFlameBall::FireProjectile( CTFPlayer *pPlayer )
 		DoFireEffects();
 
 		pRocket->SetOwnerEntity( pPlayer );
-		pRocket->SetLauncher( this ); 
+		pRocket->SetLauncher( this );
 
-		Vector vForward;
-		AngleVectors( angForward, &vForward, NULL, NULL );
+		float flEndDist = tf_fireball_distance.GetFloat();
 
-		pRocket->SetAbsVelocity( vForward * 600 );
+		Vector vecProjForward = ( vecShootPos + vecForward * flEndDist ) - vecSrc;
+		VectorNormalize( vecProjForward );
+
+		pRocket->SetAbsVelocity( vecProjForward * 600 );
 
 		pRocket->SetDamage( 20 );
 		pRocket->ChangeTeam( pPlayer->GetTeamNumber() );


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description

the Dragon's Fury's fireballs seem to be the only projectiles with a spawn offset that don't get their path corrected to be pointed at the player's crosshair

this is because the df never uses the GetProjectileFireSetup method which handles projectile path correction:
https://github.com/ValveSoftware/source-sdk-2013/blob/7191ecc418e28974de8be3a863eebb16b974a7ef/src/game/shared/tf/tf_weaponbase.cpp#L5645

this results in the fireballs being visibly offset to the bottom right of the player's crosshair

for this fix, i don't use the GetProjectileFireSetup method because it wouldnt be ideal for the df's projectiles which have 2 unique properties compared to other projectiles:
- it automatically deletes itself after traveling 500 units
- it's supposed to penetrate and deal damage to multiple players

<img width="810" height="720" alt="image" src="https://github.com/user-attachments/assets/3dbbf56a-4bd6-44c0-8b41-e1f1c95a149d" />

video:

https://github.com/user-attachments/assets/6f25ff97-47d3-43dc-870f-34615c0888ad

note: in this video, im using a keybind to toggle the fix on and off
also here's what the debug shapes mean:
\- red = crosshair path starting from eyepos, up to 500 units
\- green = correct expected projectile path starting from the projectile spawn offset, green box at 500 units is where the projectile should despawn
\- blue = actual projectile path, blue box is the projectile's current position, blue line is the path it has traveled