### PR TITLE
[TF2] fix fire rate being slower than intended for some weapons

### DIFF
--- a/src/game/shared/tf/tf_weaponbase_gun.cpp
+++ b/src/game/shared/tf/tf_weaponbase_gun.cpp
@@ -125,7 +125,7 @@ void CTFWeaponBaseGun::PrimaryAttack( void )
 		if ( GetOwner() && GetAmmoPerShot() > GetOwner()->GetAmmoCount( m_iPrimaryAmmoType ) )
 		{
 			WeaponSound( EMPTY );
-			m_flNextPrimaryAttack = GetCorrectedNextAttackTime( flFireDelay );
+			m_flNextPrimaryAttack = GetCorrectedNextAttackTime( m_flNextPrimaryAttack, flFireDelay );
 			return;
 		}
 	}
@@ -181,7 +181,7 @@ void CTFWeaponBaseGun::PrimaryAttack( void )
 	}
 
 	// Set next attack times.
-	m_flNextPrimaryAttack = GetCorrectedNextAttackTime( flFireDelay );
+	m_flNextPrimaryAttack = GetCorrectedNextAttackTime( m_flNextPrimaryAttack, flFireDelay );
 
 	// Don't push out secondary attack, because our secondary fire
 	// systems are all separate from primary fire (sniper zooming, demoman pipebomb detonating, etc)
@@ -218,7 +218,7 @@ void CTFWeaponBaseGun::PrimaryAttack( void )
 //-----------------------------------------------------------------------------
 // Purpose: Calculates the next attack time that averages the attack interval correctly for continuous fire
 //-----------------------------------------------------------------------------
-float CTFWeaponBaseGun::GetCorrectedNextAttackTime( float flFireDelay, float flAttackTime ) const
+float CTFWeaponBaseGun::GetCorrectedNextAttackTime( float flAttackTime, float flFireDelay ) const
 {
 	float flDiff = gpGlobals->curtime - flAttackTime;
 	

--- a/src/game/shared/tf/tf_weaponbase_gun.h
+++ b/src/game/shared/tf/tf_weaponbase_gun.h
@@ -54,8 +54,7 @@ public:
 	virtual void SecondaryAttack( void );
 	virtual bool Holster( CBaseCombatWeapon *pSwitchingTo );
 
-	virtual float GetCorrectedNextAttackTime( float flFireDelay, float flAttackTime ) const;
-	virtual float GetCorrectedNextAttackTime( float flFireDelay ) const { return GetCorrectedNextAttackTime( flFireDelay, m_flNextPrimaryAttack ); }
+	float GetCorrectedNextAttackTime( float flAttackTime, float flFireDelay ) const;
 
 	// Derived classes call this to fire a bullet.
 	//bool TFBaseGunFire( void );


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description

explained here: https://www.youtube.com/watch?v=7puuYqq_rgw

fixes ValveSoftware/Source-1-Games/issues/5982

this is most likely gonna be contentious since it buffs some weapons as a result, but i wanted to see what ppl think about this anyway

for example:

- buffs MvM firing speed upgrades if they're misaligned with the server's tick interval (default: 0.015 seconds)

- minigun, syringe gun, and smg average attack interval will be 0.1 seconds instead of 0.105 seconds, which slightly buffs their fire rate from 571 RPM to 600 PM

- currently, the pretty boy's pocket pistol has a "+15% faster firing speed" attribute which actually is functionally only +10% rather than +15%, since it fires every 0.135 seconds (444 RPM) instead of the intended 0.1275 seconds (470 RPM) while the stock pistol's attack interval is 0.15 seconds (400 RPM), this pr will fix this

- currently, the cleaner's carbine has a "25% slower firing speed" attribute which is functionally 35%, since it fires every 0.135 seconds (444 RPM) instead of the intended 0.125 seconds (480 RPM), this pr will fix this

- this does not affect flamethrowers and sentryguns