### PR TITLE
[TF2] fix being unable to detonate stickybombs while switching weapons or attacking with melee

### DIFF
--- a/src/game/shared/tf/tf_weaponbase.cpp
+++ b/src/game/shared/tf/tf_weaponbase.cpp
@@ -2366,14 +2366,27 @@ void CTFWeaponBase::ItemBusyFrame( void )
 		return;
 	}
 
+	bool bDoSpecialSkill = false;
+
 	if ( ( pOwner->m_nButtons & IN_ATTACK2 ) && /*m_bInReload == false &&*/ m_bInAttack2 == false )
 	{
-		pOwner->DoClassSpecialSkill();
+		bDoSpecialSkill = true;
 		m_bInAttack2 = true;
 	}
 	else if ( !(pOwner->m_nButtons & IN_ATTACK2) && m_bInAttack2 )
 	{
 		m_bInAttack2 = false;
+	}
+
+	// always let demoman detonate their stickybombs
+	if ( ( pOwner->m_nButtons & IN_ATTACK2 ) && pOwner->GetNumActivePipebombs() != 0 )
+	{
+		bDoSpecialSkill = true;
+	}
+
+	if ( bDoSpecialSkill )
+	{
+		pOwner->DoClassSpecialSkill();
 	}
 
 	// Interrupt a reload on reload singly weapons.
@@ -5752,9 +5765,15 @@ bool CTFWeaponBase::CanPerformSecondaryAttack() const
 {
 	CTFPlayer *pOwner = ToTFPlayer( GetOwner() );
 
-	// Demo shields are allowed to charge whenever
-	if ( pOwner->m_Shared.HasDemoShieldEquipped() )
-		return true;
+	if ( pOwner )
+	{
+		if ( pOwner->GetNumActivePipebombs() != 0 )
+			return true;
+
+		// Demo shields are allowed to charge whenever
+		if ( pOwner->m_Shared.HasDemoShieldEquipped() )
+			return true;
+	}
 
 	return BaseClass::CanPerformSecondaryAttack();
 }


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description

fixes ValveSoftware/Source-1-Games/issues/2185

this fixes two sticky det delay bugs:

1\) not being able to detonate stickies while swinging your melee

2\) if you switch weapons (to either primary or melee) while holding down right-click, your stickies will not detonate until your primary/melee is fully deployed

the 2nd bug was supposed to have been patched by the [December 13, 2017 Patch](https://wiki.teamfortress.com/wiki/December_13,_2017_Patch), however the patch doesn't actually work as you can see in the video below
> Fixed not being able to detonate stickybombs when switching to melee with secondary attack held down

unfixed:

https://github.com/user-attachments/assets/f6a5881f-3dea-4e26-8a91-d02b69dd4f54

fixed:

https://github.com/user-attachments/assets/3f3b160d-611b-45b1-8da4-4fb9e2bd98d9

crosshair colour note for these videos:
green = no buttons held
red = only left-click held
cyan = only right-click held
magenta = both buttons held