### PR TITLE
[TF2] disable "spawn wallhacks" for disguised enemy spies and visible teammates

### DIFF
--- a/src/game/client/tf/tf_hud_spectator_extras.cpp
+++ b/src/game/client/tf/tf_hud_spectator_extras.cpp
@@ -119,9 +119,12 @@ void CTFHudSpectatorExtras::OnTick()
 		return;
 	}
 
+	bool bLocalPlayerIsAlive = pLocalPlayer->IsAlive();
+	bool bLocalPlayerTeamGlows = bLocalPlayerIsAlive && pLocalPlayer->m_Shared.InCond( TF_COND_TEAM_GLOWS );
+
 	if ( nLocalPlayerTeam >= FIRST_GAME_TEAM )
 	{
-		if ( pLocalPlayer->IsAlive() && !pLocalPlayer->m_Shared.InCond( TF_COND_TEAM_GLOWS ) )
+		if ( bLocalPlayerIsAlive && !bLocalPlayerTeamGlows )
 		{
 			if ( m_vecEntitiesToDraw.Count() > 0 )
 			{
@@ -132,7 +135,7 @@ void CTFHudSpectatorExtras::OnTick()
 	}
 
 	if ( bIsHLTV || 
-		( tf_spec_xray.GetBool() && ( ( nLocalPlayerTeam == TEAM_SPECTATOR ) || ( pLocalPlayer->GetObserverMode() > OBS_MODE_FREEZECAM ) || ( pLocalPlayer->m_Shared.InCond( TF_COND_TEAM_GLOWS ) && tf_enable_glows_after_respawn.GetBool() ) ) ) )
+		( tf_spec_xray.GetBool() && ( ( nLocalPlayerTeam == TEAM_SPECTATOR ) || ( pLocalPlayer->GetObserverMode() > OBS_MODE_FREEZECAM ) || ( bLocalPlayerTeamGlows && tf_enable_glows_after_respawn.GetBool() ) ) ) )
 	{
 		bool bShowEveryone = ( bIsHLTV || 
 							   ( ( nLocalPlayerTeam == TEAM_SPECTATOR ) && tf_spec_xray.GetBool() ) ||
@@ -163,7 +166,8 @@ void CTFHudSpectatorExtras::OnTick()
 				( pPlayer->m_Shared.IsStealthed() && ( nLocalPlayerTeam >= FIRST_GAME_TEAM ) && ( nPlayerTeamNumber != nLocalPlayerTeam ) ) ||
 				( !bShowEveryone && !pPlayer->IsPlayerClass( TF_CLASS_SPY ) && ( nPlayerTeamNumber != nLocalPlayerTeam ) ) ||
 				( !bShowEveryone && pPlayer->IsPlayerClass( TF_CLASS_SPY ) && !pPlayer->m_Shared.InCond( TF_COND_DISGUISED ) && ( nPlayerTeamNumber != nLocalPlayerTeam ) ) ||
-				( !bShowEveryone && pPlayer->IsPlayerClass( TF_CLASS_SPY ) && pPlayer->m_Shared.InCond( TF_COND_DISGUISED ) && ( nPlayerTeamNumber != nLocalPlayerTeam ) && ( pPlayer->m_Shared.GetDisguiseTeam() != nLocalPlayerTeam ) ) )
+				( !bShowEveryone && pPlayer->IsPlayerClass( TF_CLASS_SPY ) && pPlayer->m_Shared.InCond( TF_COND_DISGUISED ) && ( nPlayerTeamNumber != nLocalPlayerTeam ) && ( pPlayer->m_Shared.GetDisguiseTeam() != nLocalPlayerTeam ) ) ||
+				( !bShowEveryone && bLocalPlayerTeamGlows && ( ( nPlayerTeamNumber != nLocalPlayerTeam ) || pLocalPlayer->IsLineOfSightClear( pPlayer, CBaseCombatCharacter::IGNORE_ACTORS ) ) ) )
 			{
 				if ( pPlayer->IsClientSideGlowEnabled() )
 				{
@@ -193,7 +197,7 @@ void CTFHudSpectatorExtras::OnTick()
 
 			// don't draw their name if we're currently spectating them, but we still want them to glow
 			m_vecEntitiesToDraw[nVecIndex].m_bDrawName = true;
-			if ( !pLocalPlayer->IsAlive() )
+			if ( !bLocalPlayerIsAlive )
 			{
 				CSpectatorTargetID *pSpecTargetID = (CSpectatorTargetID *)GET_HUDELEMENT( CSpectatorTargetID );
 				if ( ( pLocalPlayer->GetObserverTarget() == pPlayer ) || ( pSpecTargetID && pSpecTargetID->GetTargetIndex() == i ) )


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description

the `tf_enable_glows_after_respawn` feature is intended to guide players towards their teammates, which helps keep the game more focused since it subtly encourages everyone to play closer together and prevents people from getting lost in an unfamiliar map

however, the way this interacts with spy is extremely controversial, which is why the community has dubbed it as "spawn wallhacks"

when you respawn you get 10 seconds where you're just able to see any disguised spies through walls at any distance, and they instantly give themselves away by cloaking, decloaking, undisguising, changing disguise, or even just by looking suspicious or out of position which is really unfair especially when they can't see you through walls like you can

a common suggestion is to just disable the outlines for enemy spies, however this is usually countered with the fact that it would make disguised enemy spies immediately obvious because you'll see their lack of outline

my solution to that is to simply not draw outlines for all teammates that are already visible, which also has the added benefit that it saves performance and limits visual clutter since it's kinda pointless to highlight unoccluded teammates anyway

this won't completely eliminate the ability to catch spies using the respawn glow effect, but i think this is the best compromise available

demonstration:

https://github.com/user-attachments/assets/4c73acbc-9253-4cee-b7ef-caa676f8fad6

closes ValveSoftware/Source-1-Games/issues/4361