### PR TITLE
[TF2] fix explosions being blocked by small protrusions from the ground's geometry (splash bug/stair bug)

### DIFF
--- a/src/game/shared/tf/tf_gamerules.cpp
+++ b/src/game/shared/tf/tf_gamerules.cpp
@@ -5753,6 +5753,7 @@ void CTFRadiusDamageInfo::CalculateFalloff( void )
 // Purpose: Attempt to apply the radius damage to the specified entity
 //-----------------------------------------------------------------------------
 ConVar tf_radiusdamage_los_simple( "tf_radiusdamage_los_simple", "0", FCVAR_NONE, "Use simpler line-of-sight checks for radius damage" );
+ConVar tf_radiusdamage_los_debug( "tf_radiusdamage_los_debug", "0", FCVAR_CHEAT );
 int CTFRadiusDamageInfo::ApplyToEntity( CBaseEntity *pEntity )
 {
 	if ( pEntity == pEntityIgnore || pEntity->m_takedamage == DAMAGE_NO )
@@ -5781,6 +5782,14 @@ int CTFRadiusDamageInfo::ApplyToEntity( CBaseEntity *pEntity )
 		UTIL_TraceLine( vecSrc, vecSpot, MASK_RADIUS_DAMAGE, &filterSelf, &tr );
 	}
 
+	bool bDebugLoS = tf_radiusdamage_los_debug.GetBool() && ( pEntity->IsPlayer() || tf_radiusdamage_los_debug.GetInt() == 2 );
+
+	if ( bDebugLoS )
+	{
+		NDebugOverlay::Line( tr.startpos, tr.endpos, 255, 0, 0, true, 3 );
+		NDebugOverlay::Line( tr.endpos, vecSpot, 96, 0, 0, true, 3 );
+	}
+
 	// If we don't trace the whole way to the target, and we didn't hit the target entity, we're blocked
 	if ( tr.fraction != 1.f && tr.m_pEnt != pEntity )
 	{
@@ -5806,6 +5815,11 @@ int CTFRadiusDamageInfo::ApplyToEntity( CBaseEntity *pEntity )
 		trace_t	trStep;
 		UTIL_TraceLine( vecStartPos, vecTarget, MASK_RADIUS_DAMAGE, &filter, &trStep );
 
+		if ( bDebugLoS )
+		{
+			NDebugOverlay::Line( trStep.startpos, trStep.endpos, 0, 128, 255, true, 3 );
+		}
+
 		if ( trStep.fraction == 1.f || trStep.plane.normal.z < 0.7 )
 			// don't splash if we can't find walkable ground
 			// this stops Soldiers from splashing high-ground targets by shooting at the edge of the ledge from below
@@ -5822,8 +5836,19 @@ int CTFRadiusDamageInfo::ApplyToEntity( CBaseEntity *pEntity )
 		// trace up from the floor to simulate step up
 		UTIL_TraceLine( vecStartPos, vecTarget, MASK_RADIUS_DAMAGE, &filter, &trStep );
 
+		if ( bDebugLoS )
+		{
+			NDebugOverlay::Line( trStep.startpos, trStep.endpos, 0, 255, 255, true, 3 );
+		}
+
 		// check if explosion can see target from this raised position
 		UTIL_TraceLine( trStep.endpos, vecSpot, MASK_RADIUS_DAMAGE, &filter, &trStep );
+
+		if ( bDebugLoS )
+		{
+			NDebugOverlay::Line( trStep.startpos, trStep.endpos, 0, 255, 0, true, 3 );
+			NDebugOverlay::Line( trStep.endpos, vecSpot, 0, 96, 0, true, 3 );
+		}
 
 		if ( trStep.startsolid || trStep.fraction != 1.f && trStep.m_pEnt != pEntity )
 			// target is still blocked


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description

fixes ValveSoftware/Source-1-Games/issues/2486
fixes ValveSoftware/Source-1-Games/issues/4556

what this pr does is it performs a second line-of-sight check from a little bit above where the explosion is
(the offset used is the player stair step height that maps are built for)

<img width="1180" height="490" alt="image" src="https://github.com/user-attachments/assets/7551f1a0-a190-4d70-9bb1-60aa483feacb" />

this only works if the explosion is close to the ground specifically so that this fix won't affect the game's balance,
because otherwise soldiers would be able to deal splash damage against targets on higher ground by simply shooting at the edge of the ledge from below, which would let soldiers be able to deny high ground extremely easily

<img width="330" height="464" alt="image" src="https://github.com/user-attachments/assets/6c22884b-69df-4b66-9865-e34c873b472c" />

note:
another pr exists with an alternative solution: #1273

however, i think its solution (and other similar solutions) would be a pretty significant buff for the soldier and demo's ability to defend chokes such as doorways, which they're already extremely good at

<img height="360" alt="image" src="https://github.com/user-attachments/assets/8aa3c4bb-0adf-45ca-b848-03209025b66d" />

it's really only splashbugs on the ground that players actually complain about, so i don't think it's worth changing splash behaviour around corners horizontally since it would just open a big can of worms

-----

unfixed:

https://github.com/user-attachments/assets/7b208f97-aff3-40f2-b296-f0ca6acb794d

fixed:

https://github.com/user-attachments/assets/1a63cebf-9fdb-4f3d-8681-8d044098e45d
