### PR TITLE
[TF2] Fix Stat-Clock model attaching incorrectly on dropped weapons

### DIFF
--- a/src/game/shared/tf/tf_dropped_weapon.cpp
+++ b/src/game/shared/tf/tf_dropped_weapon.cpp
@@ -191,7 +191,7 @@ void CTFDroppedWeapon::OnDataChanged( DataUpdateType_t updateType )
 						pStatTrakEnt->SetModelScale( flScale );
 						pStatTrakEnt->UpdateVisibility();
 
-						pStatTrakEnt->SetBodygroup( 1, 1 );
+						pStatTrakEnt->SetBodygroup( 0, 0 );
 
 						pStatTrakEnt->m_nSkin = m_Item.GetTeamNumber();	// Use the "Sad" skin
 

--- a/src/game/shared/tf/tf_dropped_weapon.cpp
+++ b/src/game/shared/tf/tf_dropped_weapon.cpp
@@ -191,7 +191,7 @@ void CTFDroppedWeapon::OnDataChanged( DataUpdateType_t updateType )
 						pStatTrakEnt->SetModelScale( flScale );
 						pStatTrakEnt->UpdateVisibility();
 
-						pStatTrakEnt->SetBodygroup( 0, 0 );
+						pStatTrakEnt->SetBodygroup( 1, 0 );
 
 						pStatTrakEnt->m_nSkin = m_Item.GetTeamNumber();	// Use the "Sad" skin
 


### PR DESCRIPTION
Fixed Stat Clock model attaching to dropped weapons incorrectly:
<img width="1228" height="597" alt="image" src="https://github.com/user-attachments/assets/4932e6fa-af1d-415c-bbf2-239215924313" />


Live game code currently sets the wrong bodygroup value (reserved for left-handed viewmodels), resulting in it being applied inversely:
<img width="1141" height="622" alt="image" src="https://github.com/user-attachments/assets/968e2104-02ff-4c85-85dc-b9fd1cfb51c1" />
