### PR TITLE
[TF2] Fixed duplicate itemtype line appearing in collection cosmetic descriptions

### DIFF
--- a/src/game/shared/econ/econ_item_description.cpp
+++ b/src/game/shared/econ/econ_item_description.cpp
@@ -1263,9 +1263,15 @@ void CEconItemDescription::Generate_ItemLevelDesc_Default( const CLocalizationPr
 	const bool bIsStoreItem = IsStorePreviewItem( pEconItem );
 	const bool bIsPreviewItem = pEconItem->GetFlags() & kEconItemFlagClient_Preview;
 
+	// For collection cosmetics, we already display itemtype with item grade (ie. "Mercenary Grade Hat")
+	if (pEconItem->GetItemDefinition()->GetRarity() != k_unItemRarity_Any)
+	{
+		return;
+	}
+		
 	// If the item doesn't have a valid itemID, we'll just use the locTypename for the item level description. 
 	// We don't want to display "Level 0 Hat" in places like the Mann Co. Store and Armory. We'll just display "Hat".
-	if ( bIsStoreItem || bIsPreviewItem || pEconItem->GetItemDefinition()->GetRarity() != k_unItemRarity_Any )
+	if ( bIsStoreItem || bIsPreviewItem )
 	{
 		if ( locTypename && *locTypename )
 		{


### PR DESCRIPTION
Resolves https://github.com/ValveSoftware/Source-1-Games/issues/4163

Fixed duplicate/redundant itemtype line appearing in descriptions for graded cosmetics:
<img width="1284" height="684" alt="image" src="https://github.com/user-attachments/assets/5262cd41-6d33-4246-84b1-5144c97050fc" />


Live client currently displays the extra line even when the cosmetic is not strange-quality:
<img width="1201" height="663" alt="image" src="https://github.com/user-attachments/assets/ec414e4d-b5c6-4072-82c2-487ad0a8857c" />

Strange-quality items remain unaffected by change and behave as intended:
<img width="408" height="403" alt="image" src="https://github.com/user-attachments/assets/d75c0b10-7c95-4c58-ba97-09d388c05238" />


