### PR TITLE
[TF2] Fixed war paint items not displaying rarity color in various UI

### DIFF
--- a/src/game/client/econ/base_loadout_panel.cpp
+++ b/src/game/client/econ/base_loadout_panel.cpp
@@ -137,7 +137,7 @@ void CBaseLoadoutPanel::SetBorderForItem( CItemModelPanel *pItemPanel, bool bMou
 		{
 			iRarity = pItemPanel->GetItem()->GetItemQuality() ;
 
-			uint8 nRarity = pItemPanel->GetItem()->GetItemDefinition()->GetRarity();
+			uint8 nRarity = pItemPanel->GetItem()->GetRarity();
 			if ( ( nRarity != k_unItemRarity_Any ) && ( iRarity != AE_SELFMADE ) && ( iRarity != AE_UNUSUAL ) )
 			{
 				// translate this quality to rarity

--- a/src/game/client/tf/tf_hud_playerstatus.cpp
+++ b/src/game/client/tf/tf_hud_playerstatus.cpp
@@ -324,7 +324,11 @@ void CTFHudPlayerClass::OnThink()
 					m_pCarryingWeaponPanel->SetDialogVariable( "carrying", wszLocString );
 
 					// Get and set the rarity color of the weapon
-					const char* pszColorName = GetItemSchema()->GetRarityColor( pItem->GetItemDefinition()->GetRarity() );
+					const char* pszColorName = GetItemSchema()->GetRarityColor( pItem->GetRarity() );
+					if (pItem->GetItemQuality() == AE_SELFMADE)
+					{
+						pszColorName = EconQuality_GetColorString( AE_SELFMADE );
+					}
 					pszColorName = pszColorName ? pszColorName : "TanLight";
 					if ( pszColorName )
 					{

--- a/src/game/client/tf/tf_hud_target_id.cpp
+++ b/src/game/client/tf/tf_hud_target_id.cpp
@@ -969,7 +969,12 @@ void CTargetID::UpdateID( void )
 							vgui::IScheme *pScheme = vgui::scheme()->GetIScheme( GetScheme() );
 							if ( pScheme )
 							{
-								const char* pszColorName = GetItemSchema()->GetRarityColor( pDroppedEconItem->GetItemDefinition()->GetRarity() );
+								const char* pszColorName = GetItemSchema()->GetRarityColor(pDroppedEconItem->GetRarity());
+								// Addition for consistency with other economy UI
+								if (pDroppedEconItem->GetItemQuality() == AE_SELFMADE)
+								{
+									pszColorName = EconQuality_GetColorString(AE_SELFMADE);
+								}
 								pszColorName = pszColorName ? pszColorName : "TanLight";
 								colorName = pScheme->GetColor( pszColorName, Color( 255, 255, 255, 255 ) );
 							}


### PR DESCRIPTION
Partial fix for https://github.com/ValveSoftware/Source-1-Games/issues/3520

This PR fixes rarities not applying properly in various UI when handling war-painted items.

When dealing with dropped weapons, the live TF client currently typically points to static data in the item schema for weapon details, including item rarities. However, War Paint items bypass requiring their own respective schema entries by having attributes applied to individual instances of base paintkit items. This change meant that while the same attributes are present on war paint items, certain game code was not updated to support this:
<img width="1197" height="509" alt="image" src="https://github.com/user-attachments/assets/773d52f1-feb1-4b06-bc98-dc912e090506" />

Game code has been updated to extract details from dropped weapons rather than static schema entry to display rarity for War Paints in the following UI:
**Weapon Pickup (Target HUD)**
<img width="816" height="429" alt="image" src="https://github.com/user-attachments/assets/9ee8a527-b96b-4799-bec6-2838b825def9" />
**Loadout - Item Selection Screen**
<img width="701" height="325" alt="image" src="https://github.com/user-attachments/assets/8bbed65e-3319-4aba-b025-bb8af1bf72bc" />
**Player Status HUD (when using dropped weapon)**
<img width="456" height="381" alt="image" src="https://github.com/user-attachments/assets/f7c09dfb-71c0-495e-9a61-658ce0adf648" />
