### PR TITLE
[TF2] Added support for Stat Clock to display 'Robots Destroyed' count in MvM (when strange part is applied)

### DIFF
--- a/src/game/client/tf/c_tf_player.cpp
+++ b/src/game/client/tf/c_tf_player.cpp
@@ -3136,7 +3136,7 @@ bool CStatTrakDigitProxy::HelperOnBindGetStatTrakScore( void *pC_BaseEntity, int
 
 					// If we are in MvM mode, overwrite with Robots Destroyed count (if item is tracking this)
 					if (TFGameRules() && TFGameRules()->IsMannVsMachineMode()
-						&& GetKilleaterValueByEvent(pWeap->GetAttributeContainer()->GetItem(), kKillEaterEvent_RobotsDestroyed, &unScore))
+						&& GetKilleaterValueByEvent(pWeap->GetAttributeContainer()->GetItem(), kKillEaterEvent_RobotsDestroyed, unScore))
 					{
 						*piScore = unScore;
 					}

--- a/src/game/shared/tf/tf_weaponbase.cpp
+++ b/src/game/shared/tf/tf_weaponbase.cpp
@@ -6754,7 +6754,7 @@ void CTFWeaponBase::AddStatTrakModel( CEconItemView *pItem, int nStatTrakType, A
 	// Skin
 	int nSkin = pItem->GetTeamNumber() - TF_TEAM_RED;
 	uint32 statVal = 0;
-	if ( TFGameRules() && TFGameRules()->IsMannVsMachineMode() && GetKilleaterValueByEvent(pItem, kKillEaterEvent_RobotsDestroyed, &statVal) ) // If item has Robots Destroyed counter, display robot icon in MvM mode
+	if ( TFGameRules() && TFGameRules()->IsMannVsMachineMode() && GetKilleaterValueByEvent(pItem, kKillEaterEvent_RobotsDestroyed, statVal) ) // If item has Robots Destroyed counter, display robot icon in MvM mode
 	{
 		nSkin += 4;
 	}


### PR DESCRIPTION
Resolves https://github.com/ValveSoftware/Source-1-Games/issues/4044

This PR adds support for Stat Clocks to display a user's "Robots Destroyed" count while in Mann vs. Machine mode:
<img width="1144" height="847" alt="image" src="https://github.com/user-attachments/assets/f9b29515-6c0f-4abf-82ce-417e039c1867" />

New icons have been created for the Stat Clock model to use when this feature has been activated (code points to new skins on existing stat clock model):
<img width="931" height="467" alt="statclock_transparent" src="https://github.com/user-attachments/assets/1c451206-7166-4baa-8c94-34db61f43b00" />

The code has been configured to trigger under the following conditions:
* User must be in Mann vs. Machine mode
* User's weapon must have a Stat Clock attached and "Robots Destroyed" Strange Part applied

Assets featured in this PR (new stat clock icons) have been submitted to Steam Workshop for Valve's consideration/implementation:
https://steamcommunity.com/sharedfiles/filedetails/?id=3643883696
A readme with implementation aid has also been included.