### PR TITLE
Don't enable glow outlines on carried buildings

### DIFF
--- a/src/game/client/tf/tf_hud_spectator_extras.cpp
+++ b/src/game/client/tf/tf_hud_spectator_extras.cpp
@@ -264,7 +264,7 @@ void CTFHudSpectatorExtras::OnTick()
 		{
 			bool bDraw = false;
 			C_BaseObject *pObject = static_cast<C_BaseObject*>( IBaseObjectAutoList::AutoList()[nCount] );
-			if ( !pObject->IsDormant() && !pObject->IsMapPlaced() && !pObject->IsEffectActive( EF_NODRAW ) )
+			if ( !pObject->IsDormant() && !pObject->IsMapPlaced() && !pObject->IsEffectActive( EF_NODRAW ) && !pObject->IsPlacing() )
 			{
 				if ( bShowEveryone || ( ( nLocalPlayerTeam >= FIRST_GAME_TEAM ) && ( nLocalPlayerTeam == pObject->GetTeamNumber() ) ) )
 				{


### PR DESCRIPTION
This makes engineer blueprints and sapper outlines exempt from spectator/respawn glow.

Before:
<img width="712" height="559" alt="image" src="https://github.com/user-attachments/assets/145e85b9-beb9-415b-b12c-2712d0a753d6" />


After:
<img width="746" height="558" alt="image" src="https://github.com/user-attachments/assets/a93dfaea-71bf-4c88-a9d2-bf04d8e74434" />
