### PR TITLE
Don't increment revive counter between waves

### DIFF
--- a/src/game/server/tf/tf_gamestats.cpp
+++ b/src/game/server/tf/tf_gamestats.cpp
@@ -2897,6 +2897,10 @@ void CTFGameStats::Event_PlayerLoadoutChanged( CTFPlayer *pPlayer, bool bForceRe
 //-----------------------------------------------------------------------------
 void CTFGameStats::Event_PlayerRevived( CTFPlayer *pPlayer )
 {
+	// Don't count revives between MvM waves
+	if ( TFGameRules() && TFGameRules()->IsMannVsMachineMode() && TFGameRules()->State_Get() != GR_STATE_RND_RUNNING )
+		return;
+
 	IncrementStat( pPlayer, TFSTAT_REVIVED, 1 );
 }
 


### PR DESCRIPTION
Hi. This fixes an oversight where reviving a player during setup in MvM would increase the revive penalty. The linked issue includes a detailed explanation of why deaths during setup shouldn't count negatively against players.

Fixes: https://github.com/ValveSoftware/Source-1-Games/issues/4782