### PR TITLE
Add cvar to automatically mute low-tour players in MvM

### DIFF
--- a/src/game/client/c_baseplayer.h
+++ b/src/game/client/c_baseplayer.h
@@ -359,6 +359,8 @@ public:
 	// Called by the renderer to apply the prediction error smoothing.
 	void GetPredictionErrorSmoothingVector( Vector &vOffset ); 
 
+	virtual bool CanHearAndReadChatFrom( C_BasePlayer *pPlayer ) { return true; }
+
 	virtual void ExitLadder() {}
 	surfacedata_t *GetLadderSurface( const Vector &origin );
 

--- a/src/game/client/cdll_client_int.cpp
+++ b/src/game/client/cdll_client_int.cpp
@@ -357,6 +357,11 @@ public:
 	// ingame voice manipulation
 	bool IsPlayerGameVoiceMuted(int playerIndex)
 	{
+		C_BasePlayer *pSelf = C_BasePlayer::GetLocalPlayer();
+		C_BasePlayer *pOther = UTIL_PlayerByIndex( playerIndex );
+		if ( pSelf && pOther && !pSelf->CanHearAndReadChatFrom( pOther ) )
+			return true;
+
 		return GetClientVoiceMgr()->IsPlayerBlocked(playerIndex);
 	}
 

--- a/src/game/client/hud_basechat.cpp
+++ b/src/game/client/hud_basechat.cpp
@@ -1790,6 +1790,11 @@ void CBaseHudChat::ChatPrintf( int iPlayerIndex, int iFilter, const char *fmt, .
 	if ( !cl_enable_text_chat.GetBool() && ( iPlayerIndex != 0 ) )
 		return;
 
+	C_BasePlayer *pSelf = C_BasePlayer::GetLocalPlayer();
+	C_BasePlayer *pOther = UTIL_PlayerByIndex( iPlayerIndex );
+	if ( pSelf && pOther && !pSelf->CanHearAndReadChatFrom( pOther ) )
+		return;
+
 	if ( *pmsg < 32 )
 	{
 		hudlcd->AddChatLine( pmsg + 1 );

--- a/src/game/client/tf/c_tf_player.cpp
+++ b/src/game/client/tf/c_tf_player.cpp
@@ -114,6 +114,8 @@
 #include "econ_paintkit.h"
 #include "soundstartparams.h"
 #include "SoundEmitterSystem/isoundemittersystembase.h"
+#include "tf_gc_client.h"
+#include "tf_lobby_server.h"
 
 
 #if defined( REPLAY_ENABLED )
@@ -220,6 +222,7 @@ ConVar tf_taunt_first_person( "tf_taunt_first_person", "0", FCVAR_NONE, "1 = tau
 ConVar tf_romevision_opt_in( "tf_romevision_opt_in", "0", FCVAR_ARCHIVE, "Enable Romevision in Mann vs. Machine mode when available." );
 ConVar tf_romevision_skip_prompt( "tf_romevision_skip_prompt", "0", FCVAR_ARCHIVE, "If nonzero, skip the prompt about sharing Romevision." );
 
+ConVar tf_mvm_tour_mute_threshold( "tf_mvm_tour_mute_threshold", "0", FCVAR_ARCHIVE, "Mute players below a certain tour count in Mann vs. Machine mode." );
 
 #define BDAY_HAT_MODEL		"models/effects/bday_hat.mdl"
 #define BOMB_HAT_MODEL		"models/props_lakeside_event/bomb_temp_hat.mdl"
@@ -9873,6 +9876,31 @@ void C_TFPlayer::UpdateWearables()
 	{
 		pWeapon->UpdateVisibility();
 	}
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: Game-specific chat filtering
+//-----------------------------------------------------------------------------
+bool C_TFPlayer::CanHearAndReadChatFrom( C_BasePlayer *pPlayer )
+{
+	if ( TFGameRules() && TFGameRules()->IsMannVsMachineMode() )
+	{
+		// Mute players below a certain tour count in Mann Up
+		if ( tf_mvm_tour_mute_threshold.GetInt() > 0 )
+		{
+			CTFGSLobby *pLobby = GTFGCClientSystem()->GetLobby();
+			if ( pLobby && IsMannUpGroup( pLobby->GetMatchGroup() ) )
+			{
+				int idx = pLobby->GetMemberIndexBySteamID( GetSteamIDForPlayerIndex( pPlayer->entindex() ) );
+				if ( idx >= 0 )
+				{
+					if ( pLobby->GetMemberDetails( idx ).GetBadgeLevel() < ( uint32_t )tf_mvm_tour_mute_threshold.GetInt() )
+						return false;
+				}
+			}
+		}
+	}
+	return BaseClass::CanHearAndReadChatFrom( pPlayer );
 }
 
 //-----------------------------------------------------------------------------

--- a/src/game/client/tf/c_tf_player.h
+++ b/src/game/client/tf/c_tf_player.h
@@ -301,6 +301,8 @@ public:
 	bool			CanDisguise( void );
 	bool			CanDisguise_OnKill( void );
 
+	virtual bool CanHearAndReadChatFrom( C_BasePlayer *pPlayer );
+
 	virtual void OnAchievementAchieved( int iAchievement );
 
 	virtual void OverrideView( CViewSetup *pSetup );


### PR DESCRIPTION
This adds a new cvar `tf_mvm_tour_mute_threshold` to automatically mute players below a certain tour count in Mann Up mode.