### PR TITLE
Fix annoying Eureka Effect + 2-way teleporter interaction

### DIFF
--- a/src/game/server/tf/tf_obj_teleporter.cpp
+++ b/src/game/server/tf/tf_obj_teleporter.cpp
@@ -226,6 +226,8 @@ CObjectTeleporter::CObjectTeleporter()
 	m_flCurrentRechargeDuration = 0.0f;
 	m_flRechargeTime = 0.0f;
 
+	m_flEurekaEffectCooldown = 0.0f;
+
 	ListenForGameEvent( "player_spawn" );
 	ListenForGameEvent( "player_team" );
 }
@@ -535,6 +537,10 @@ bool CObjectTeleporter::PlayerCanBeTeleported( CTFPlayer *pPlayer )
 		return false;
 
 	if ( TFGameRules() && TFGameRules()->IsPasstimeMode() && pPlayer->m_Shared.HasPasstimeBall() )
+		return false;
+
+	// If the player just used the Eureka Effect, give them time to step off the teleporter
+	if ( pBuilder && pBuilder->entindex() == pPlayer->entindex() && m_flEurekaEffectCooldown >= gpGlobals->curtime )
 		return false;
 
 	return true;
@@ -1537,4 +1543,9 @@ void CObjectTeleporter::FireGameEvent( IGameEvent *event )
 			SetTeleportingPlayer( NULL );
 		}
 	}
+}
+
+void CObjectTeleporter::AddEurekaEffectCooldown()
+{
+	m_flEurekaEffectCooldown = gpGlobals->curtime + g_iTeleporterRechargeTimes[3];
 }

--- a/src/game/server/tf/tf_obj_teleporter.h
+++ b/src/game/server/tf/tf_obj_teleporter.h
@@ -129,6 +129,7 @@ public:
 
 	virtual void FireGameEvent( IGameEvent *event ) OVERRIDE;
 
+	void AddEurekaEffectCooldown();
 protected:
 	CNetworkVar( int, m_iState );
 	CNetworkVar( float, m_flRechargeTime );
@@ -167,6 +168,8 @@ private:
 	void SpawnBread( const CTFPlayer* pTeleportingPlayer );
 
 	CUtlStringList m_teleportWhereName;
+
+	float m_flEurekaEffectCooldown;
 };
 
 #endif // TF_OBJ_TELEPORTER_H

--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -1610,6 +1610,7 @@ void CTFPlayer::TFPlayerThink()
 			if ( m_eEurekaTeleportTarget == EUREKA_TELEPORT_TELEPORTER_EXIT && pTeleExit && ( pTeleExit->GetState() != TELEPORTER_STATE_BUILDING ) )
 			{
 				pTeleExit->RecieveTeleportingPlayer( this );
+				pTeleExit->AddEurekaEffectCooldown();
 			}
 			else
 			{


### PR DESCRIPTION
Hi. This PR adds a short cooldown that blocks the player from taking their own teleporter after warping to an exit. Previously, teleporting to an exit with the "2-Way Teleporters" upgrade would immediately teleport you back to the entrance.

The cooldown is 3 seconds, matching the recharge time of a level 3 teleporter.

I tested to ensure this does not break demos recorded on the master branch.

Fixes: https://github.com/ValveSoftware/Source-1-Games/issues/7217

https://github.com/user-attachments/assets/157db9e0-1a4b-4593-85ac-1bc03f13376d