### PR TITLE
[TF2] Added convar to force high resolution paintkit textures

### DIFF
--- a/src/game/client/tf/c_tf_player.cpp
+++ b/src/game/client/tf/c_tf_player.cpp
@@ -3314,7 +3314,7 @@ struct TextureVarSetter
 	ITexture* m_pTexture;
 };
 
-// Convar to force full resolution paintkit textures in situations they normally wouldn't (world model, other player's skins)
+// Convar to force full resolution paintkit textures in situations they normally wouldn't (world model, other players' skins)
 ConVar  tf_paintkit_force_fullres("tf_paintkit_force_fullres", "0", FCVAR_NONE, "Display full resolution paintkit textures on weapons.");
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Resolves https://github.com/ValveSoftware/Source-1-Games/issues/3930

This PR adds a new convar (tf_paintkit_force_fullres 0/1) to allow players to display full resolution paintkit textures on world models + other players (when permittable by user's texture settings).

Convar is turned off by default.

In-Game (world view)
<img width="1775" height="964" alt="image" src="https://github.com/user-attachments/assets/9f0e38af-cd5d-4024-aa9d-c1f490464a46" />

Loadout UI
<img width="1857" height="954" alt="image" src="https://github.com/user-attachments/assets/5eddadd9-acee-408e-b0a6-3365a84163a3" />

Spectate (firstperson)
<img width="2171" height="718" alt="image" src="https://github.com/user-attachments/assets/4862b8a0-42ba-4409-ac56-8fd50c86726c" />



