### PR TITLE
[TF2] Fixed Stat Clock values always displaying '0' on world models

### DIFF
--- a/src/game/client/tf/c_tf_player.cpp
+++ b/src/game/client/tf/c_tf_player.cpp
@@ -3137,6 +3137,31 @@ bool CStatTrakDigitProxy::HelperOnBindGetStatTrakScore( void *pC_BaseEntity, int
 				}
 			}
 		}
+		else
+		{
+			CTFWeaponBase* pWeap = NULL;
+
+			// Check if it's an attachment model (world model)
+			C_TFWeaponAttachmentModel* pAttachment = dynamic_cast<C_TFWeaponAttachmentModel*>(pEntity);
+			if (pAttachment)
+			{
+				// StatTrak will be child of world model it is attached to
+				C_BaseEntity* pParent = pAttachment->GetMoveParent();
+				if (pParent)
+				{
+					pWeap = dynamic_cast<CTFWeaponBase*>(pParent);
+				}
+			}
+			if (pWeap)
+			{
+				CEconItemView* pItem = pWeap->GetAttributeContainer()->GetItem();
+				if (pItem && pItem->FindAttribute(GetKillEaterAttr_Score(0), &unScore))
+				{
+					*piScore = unScore;
+					bReturnValue = true;
+				}
+			}
+		}
 	}
 	else
 	{

--- a/src/game/client/tf/c_tf_player.cpp
+++ b/src/game/client/tf/c_tf_player.cpp
@@ -3141,17 +3141,18 @@ bool CStatTrakDigitProxy::HelperOnBindGetStatTrakScore( void *pC_BaseEntity, int
 		{
 			CTFWeaponBase* pWeap = NULL;
 
-			// Check if it's an attachment model (world model)
+			// Check if it's an attachment for world model
 			C_TFWeaponAttachmentModel* pAttachment = dynamic_cast<C_TFWeaponAttachmentModel*>(pEntity);
 			if (pAttachment)
 			{
-				// StatTrak will be child of world model it is attached to
+				// If we're dealing with a world model, Stat Clock will be it's child attachment
 				C_BaseEntity* pParent = pAttachment->GetMoveParent();
 				if (pParent)
 				{
 					pWeap = dynamic_cast<CTFWeaponBase*>(pParent);
 				}
 			}
+
 			if (pWeap)
 			{
 				CEconItemView* pItem = pWeap->GetAttributeContainer()->GetItem();
@@ -3159,6 +3160,23 @@ bool CStatTrakDigitProxy::HelperOnBindGetStatTrakScore( void *pC_BaseEntity, int
 				{
 					*piScore = unScore;
 					bReturnValue = true;
+				}
+			}
+			else
+			{
+				// Are we dealing with a dropped weapon?
+				C_BaseEntity* pParent = pEntity->GetMoveParent();
+				CTFDroppedWeapon* pDroppedWeapon = dynamic_cast<CTFDroppedWeapon*>(pParent);
+
+				if (pDroppedWeapon)
+				{
+					// We're able to extract item attributes from dropped weapons, including strange count
+					CEconItemView* pItem = pDroppedWeapon->GetItem();
+					if (pItem && pItem->FindAttribute(GetKillEaterAttr_Score(0), &unScore))
+					{
+						*piScore = unScore;
+						bReturnValue = true;
+					}
 				}
 			}
 		}

--- a/src/game/client/tf/c_tf_player.cpp
+++ b/src/game/client/tf/c_tf_player.cpp
@@ -3142,21 +3142,21 @@ bool CStatTrakDigitProxy::HelperOnBindGetStatTrakScore( void *pC_BaseEntity, int
 			CTFWeaponBase* pWeap = NULL;
 
 			// Check if it's an attachment for world model
-			C_TFWeaponAttachmentModel* pAttachment = dynamic_cast<C_TFWeaponAttachmentModel*>(pEntity);
-			if (pAttachment)
+			C_TFWeaponAttachmentModel* pAttachment = dynamic_cast<C_TFWeaponAttachmentModel*>( pEntity );
+			if ( pAttachment )
 			{
 				// If we're dealing with a world model, Stat Clock will be it's child attachment
 				C_BaseEntity* pParent = pAttachment->GetMoveParent();
-				if (pParent)
+				if ( pParent )
 				{
-					pWeap = dynamic_cast<CTFWeaponBase*>(pParent);
+					pWeap = dynamic_cast<CTFWeaponBase*>( pParent );
 				}
 			}
 
-			if (pWeap)
+			if ( pWeap )
 			{
 				CEconItemView* pItem = pWeap->GetAttributeContainer()->GetItem();
-				if (pItem && pItem->FindAttribute(GetKillEaterAttr_Score(0), &unScore))
+				if ( pItem && pItem->FindAttribute( GetKillEaterAttr_Score( 0 ), &unScore ) )
 				{
 					*piScore = unScore;
 					bReturnValue = true;
@@ -3166,13 +3166,13 @@ bool CStatTrakDigitProxy::HelperOnBindGetStatTrakScore( void *pC_BaseEntity, int
 			{
 				// Are we dealing with a dropped weapon?
 				C_BaseEntity* pParent = pEntity->GetMoveParent();
-				CTFDroppedWeapon* pDroppedWeapon = dynamic_cast<CTFDroppedWeapon*>(pParent);
+				CTFDroppedWeapon* pDroppedWeapon = dynamic_cast<CTFDroppedWeapon*>( pParent );
 
-				if (pDroppedWeapon)
+				if ( pDroppedWeapon )
 				{
 					// We're able to extract item attributes from dropped weapons, including strange count
 					CEconItemView* pItem = pDroppedWeapon->GetItem();
-					if (pItem && pItem->FindAttribute(GetKillEaterAttr_Score(0), &unScore))
+					if ( pItem && pItem->FindAttribute( GetKillEaterAttr_Score( 0 ), &unScore ) )
 					{
 						*piScore = unScore;
 						bReturnValue = true;


### PR DESCRIPTION
This PR allows Stat Clocks to display an accurate strange count when drawn on world models:
<img width="1233" height="722" alt="image" src="https://github.com/user-attachments/assets/e3bf97ee-1066-4873-810d-b3fa5e007a70" />

Stat Clocks on dropped weapons will now also display strange count:
<img width="1034" height="654" alt="image" src="https://github.com/user-attachments/assets/f67865f3-12fc-4d67-996a-8c3fdfe462fd" />
NOTE: You will need to merge #1754 to properly view the Stat Clock model on dropped weapons, as live code currently sets incorrect bodygroup values that invert its placement.