### PR TITLE
[All] env_projectedtexture - Fix `texturename` KV

### DIFF
--- a/src/game/server/env_projectedtexture.cpp
+++ b/src/game/server/env_projectedtexture.cpp
@@ -73,7 +73,7 @@ BEGIN_DATADESC( CEnvProjectedTexture )
 	DEFINE_KEYFIELD( m_bLightWorld, FIELD_BOOLEAN, "lightworld" ),
 	DEFINE_KEYFIELD( m_bCameraSpace, FIELD_BOOLEAN, "cameraspace" ),
 	DEFINE_KEYFIELD( m_flAmbient, FIELD_FLOAT, "ambient" ),
-	DEFINE_AUTO_ARRAY_KEYFIELD( m_SpotlightTextureName, FIELD_CHARACTER, "texturename" ),
+	DEFINE_AUTO_ARRAY( m_SpotlightTextureName, FIELD_CHARACTER),
 	DEFINE_KEYFIELD( m_nSpotlightTextureFrame, FIELD_INTEGER, "textureframe" ),
 	DEFINE_KEYFIELD( m_flNearZ, FIELD_FLOAT, "nearz" ),
 	DEFINE_KEYFIELD( m_flFarZ, FIELD_FLOAT, "farz" ),
@@ -160,6 +160,10 @@ bool CEnvProjectedTexture::KeyValue( const char *szKeyName, const char *szValue 
 		Vector tmp;
 		UTIL_ColorStringToLinearFloatColor( tmp, szValue );
 		m_LinearFloatLightColor = tmp;
+	}
+	else if ( FStrEq( szKeyName, "texturename" ) )
+	{
+		Q_strncpy( m_SpotlightTextureName.GetForModify(), szValue, MAX_PATH );
 	}
 	else
 	{


### PR DESCRIPTION
The `texturename` KV doesn't work due to relying upon DEFINE_AUTO_ARRAY_KEYFIELD(), which doesn't handle keyvalue parsing correctly. While the macro could be fixed, it's hardly ever used (it's for C strings, whereas most KVs use string_t), and it's easier to just to manually handle parsing the KV in the KeyValues function, using DEFINE_AUTO_ARRAY() instead.

This PR is similar to the fix that Portal 2 did, but was developed independently, referencing only SDK code.