### PR TITLE
[TF2] Added convar to display high-res backpack icons in econ UI + item importer futureproofing

### DIFF
--- a/src/game/client/econ/item_model_panel.cpp
+++ b/src/game/client/econ/item_model_panel.cpp
@@ -582,6 +582,8 @@ bool CEmbeddedItemModelPanel::IsImageNotLoaded( void ) const
 }
 
 
+ConVar  tf_use_large_backpack_icons("tf_use_large_backpack_icons", "0", FCVAR_NONE, "Display full resolution backpack icons in econ ui.");
+
 IMaterial* GetMaterialForImage( CEmbeddedItemModelPanel::InventoryImageType_t eImageType, const char* pszBaseName )
 {
 	IMaterial *pMaterial = NULL;
@@ -594,7 +596,15 @@ IMaterial* GetMaterialForImage( CEmbeddedItemModelPanel::InventoryImageType_t eI
 	switch ( eImageType )
 	{
 	case CEmbeddedItemModelPanel::IMAGETYPE_SMALL:
-		pMaterial = g_pMaterialSystem->FindMaterial( pszBaseName, TEXTURE_GROUP_VGUI );
+		if ( !tf_use_large_backpack_icons.GetBool() )
+		{
+			pMaterial = g_pMaterialSystem->FindMaterial(pszBaseName, TEXTURE_GROUP_VGUI);
+		}
+		else
+		{
+			pMaterial = g_pMaterialSystem->FindMaterial(CFmtStr("%s_large", pszBaseName).Access(), TEXTURE_GROUP_VGUI);
+		}
+
 		break;
 	case CEmbeddedItemModelPanel::IMAGETYPE_DETAILED:
 		pMaterial = g_pMaterialSystem->FindMaterial( CFmtStr("%s_detail",pszBaseName).Access(), TEXTURE_GROUP_VGUI, false );
@@ -770,7 +780,7 @@ void CEmbeddedItemModelPanel::Paint( void )
 			}
 			else
 			{
-				bool bForceHighRes = false;
+				bool bForceHighRes = tf_use_large_backpack_icons.GetBool();
 				if ( m_iInventoryImageType != IMAGETYPE_SMALL || bForceHighRes )
 				{
 					// Normal is 128*128, large is 512x512

--- a/src/vgui2/matsys_controls/mdlpicker.cpp
+++ b/src/vgui2/matsys_controls/mdlpicker.cpp
@@ -764,6 +764,7 @@ void CMDLPicker::WriteBackbackVMTFiles( const char *pAssetName )
 			g_pFullFileSystem->FPrintf( fileHandle, "{\n" );
 			g_pFullFileSystem->FPrintf( fileHandle, "	\"$baseTexture\" \"%s\"\n", pBaseTextureName );
 			g_pFullFileSystem->FPrintf( fileHandle, "	$translucent 1\n" );
+			g_pFullFileSystem->FPrintf(fileHandle, "	$vertexcolor 1\n");
 			g_pFullFileSystem->FPrintf( fileHandle, "}\n" );
 
 			g_pFullFileSystem->Close( fileHandle );

--- a/src/vgui2/matsys_controls/mdlpicker.cpp
+++ b/src/vgui2/matsys_controls/mdlpicker.cpp
@@ -764,7 +764,7 @@ void CMDLPicker::WriteBackbackVMTFiles( const char *pAssetName )
 			g_pFullFileSystem->FPrintf( fileHandle, "{\n" );
 			g_pFullFileSystem->FPrintf( fileHandle, "	\"$baseTexture\" \"%s\"\n", pBaseTextureName );
 			g_pFullFileSystem->FPrintf( fileHandle, "	$translucent 1\n" );
-			g_pFullFileSystem->FPrintf(fileHandle, "	$vertexcolor 1\n");
+			g_pFullFileSystem->FPrintf( fileHandle, "	$vertexcolor 1\n" );
 			g_pFullFileSystem->FPrintf( fileHandle, "}\n" );
 
 			g_pFullFileSystem->Close( fileHandle );


### PR DESCRIPTION
This PR adds a new convar (tf_use_large_backpack_icons) to display high-resolution backpack icons across all econ-related UI (backpack, loadout slots, inspect panel).

To properly support this feature, game code has also been updated to futureproof large backpack icon VMTs generated through the item importer so that they can be properly grayed out when unselectable.

<img width="1373" height="405" alt="image" src="https://github.com/user-attachments/assets/1a75f366-fc81-4b46-ad55-3806908cdf9a" />

<img width="1637" height="855" alt="image" src="https://github.com/user-attachments/assets/0102d73d-936d-484d-a11d-2f620e16f62e" />

<img width="1483" height="596" alt="image" src="https://github.com/user-attachments/assets/f5627912-8ee4-43d7-bf62-2d84f7c70a05" />

**FOR VALVE**
=================================================================
A known issue is that many items (mainly workshop items submitted through importer) currently do not have their large icon VMTs set up to support this:
<img width="249" height="173" alt="Discord_2hcr05wEpR" src="https://github.com/user-attachments/assets/0ed7a4cb-30a3-4b46-8134-16b7ddbb418b" />


Affected VMTs will need to be updated with the following text:

"UnlitGeneric"
{
"$baseTexture" "path to the backpack icon here"
$translucent 1
$vertexcolor 1 // this line is missing for "_large" backpack icons
}

**Game code has been updated in this PR to auto-generate large backpack icon VMTs with all necessary parameters when generated from the item importer. This should prevent the issue from happening with future cosmetic icons.**

The updated VMT files, as well as the script used to generate these, can also be found here: [updated_vmts_for_hires_icons.zip](https://github.com/user-attachments/files/24724785/updated_vmts_for_hires_icons.zip)

Steam Workshop copy: https://steamcommunity.com/sharedfiles/filedetails/?id=3649586055

An included script can be used to locally generate updated VMTs for ALL backpack icons that require it (2776 total). Generated files will automatically be stored in their respective folders.
[backpack_vmt_patcher.py](https://github.com/user-attachments/files/24720013/backpack_vmt_patcher.py)

You will need to execute it from "/tf" folder, script will hook onto "materials" folder and generate updated copies of all "_large" icon files in backpack folder that require the vmt changes.

It should fix some large icons not graying out in ui when needed:
<img width="462" height="333" alt="image" src="https://github.com/user-attachments/assets/ef90283e-7d66-4a0e-bb08-c1d84b239d49" />



