### PR TITLE
[TF2] Fixed teleporter recharge bar not working when teleporting from exit

### DIFF
--- a/src/game/client/tf/tf_hud_building_status.cpp
+++ b/src/game/client/tf/tf_hud_building_status.cpp
@@ -1004,6 +1004,25 @@ void CBuildingStatusItem_TeleporterEntrance::OnTick( void )
 			float flChargeTime = pTeleporter->GetChargeTime();
 			m_pRechargeTimer->SetProgress( 1.0 - ( flChargeTime / flMaxRecharge ) );
 		}
+		else
+		{
+			// Check if teleporter exit is recharging (two-way teleporters)
+			C_TFPlayer* pLocalPlayer = C_TFPlayer::GetLocalTFPlayer();
+			if (pLocalPlayer)
+			{
+				C_ObjectTeleporter* pExitTeleporter = static_cast<C_ObjectTeleporter*>(
+					pLocalPlayer->GetObjectOfType( OBJ_TELEPORTER, MODE_TELEPORTER_EXIT )
+					);
+
+				if ( pExitTeleporter && pExitTeleporter->GetState() == TELEPORTER_STATE_RECHARGING )
+				{
+					// Update the recharge using the exit's data
+					float flMaxRecharge = pExitTeleporter->GetCurrentRechargeDuration();
+					float flChargeTime = pExitTeleporter->GetChargeTime();
+					m_pRechargeTimer->SetProgress( 1.0 - ( flChargeTime / flMaxRecharge ) );
+				}
+			}
+		}
 	}
 
 	BaseClass::OnTick();
@@ -1025,6 +1044,23 @@ void CBuildingStatusItem_TeleporterEntrance::PerformLayout( void )
 	}
 
 	bool bRecharging = ( pTeleporter->GetState() == TELEPORTER_STATE_RECHARGING );
+
+	// If entrance isn't recharging, check if exit is recharging
+	if ( !bRecharging )
+	{
+		C_TFPlayer* pLocalPlayer = C_TFPlayer::GetLocalTFPlayer();
+		if ( pLocalPlayer )
+		{
+			C_ObjectTeleporter* pExitTeleporter = static_cast<C_ObjectTeleporter*>(
+				pLocalPlayer->GetObjectOfType( OBJ_TELEPORTER, MODE_TELEPORTER_EXIT )
+				);
+
+			if ( pExitTeleporter )
+			{
+				bRecharging = ( pExitTeleporter->GetState() == TELEPORTER_STATE_RECHARGING );
+			}
+		}
+	}
 
 	m_pChargingPanel->SetVisible( bRecharging );
 	m_pFullyChargedPanel->SetVisible( !bRecharging );

--- a/src/game/client/tf/tf_hud_building_status.h
+++ b/src/game/client/tf/tf_hud_building_status.h
@@ -96,6 +96,7 @@ public:
 	virtual void Paint( void );
 	virtual void PaintBackground( void );
 	virtual void OnTick( void );
+	virtual void GetRechargingTeleporter( void );
 
 	virtual void PerformLayout( void );
 


### PR DESCRIPTION
This PR fixes the teleporter recharge bar not properly displaying incorrect progress when teleporting from exit (2 way teleporter)

https://github.com/user-attachments/assets/dffe7674-dad7-4fe3-b235-2f9323408d3f

