### PR TITLE
[TF2] Fixed Stat Clocks not drawing correctly in UI using playermodelpanel (3D playermodels)

### DIFF
--- a/src/game/client/tf/vgui/tf_playermodelpanel.cpp
+++ b/src/game/client/tf/vgui/tf_playermodelpanel.cpp
@@ -1268,6 +1268,14 @@ void CTFPlayerModelPanel::UpdatePreviewVisuals()
 		SetMDLSkinForTeam( GetMergeMDL( m_MergeMDL ), GetPreviewItem( m_pHeldItem ), m_iTeam );
 	}
 
+	// Set the StatTrack model skin
+	if ( !m_StatTrackModel.m_bDisabled )
+	{
+		int iSkin = 0;
+		iSkin = m_iTeam == TF_TEAM_RED ? 0 : 1;
+		m_StatTrackModel.m_MDL.m_nSkin = iSkin;
+	}
+
 	// Set the skin for all other equipped items (wearables, etc).
 	for ( int i=0; i<m_vecDynamicAssetsLoaded.Count(); i++ )
 	{


### PR DESCRIPTION
This PR intends to fix Stat Clocks not attaching/updating properly to UI elements utilizing playermodelpanel. This fixes Stat Clocks not drawing properly in the following UI elements:

Loadout UI
<img width="938" height="786" alt="image" src="https://github.com/user-attachments/assets/585eacfe-1862-4c86-9415-4b1dbcc15430" />

Scoreboard:
<img width="600" height="467" alt="image" src="https://github.com/user-attachments/assets/5c576b1b-a328-42fd-9e58-7469db4afda0" />

Player Status HUD:
<img width="536" height="444" alt="image" src="https://github.com/user-attachments/assets/ca644b34-9bb7-41e8-b82c-461daa3e5fe4" />

Class Select:
<img width="715" height="522" alt="image" src="https://github.com/user-attachments/assets/c99ab8de-a356-4c60-b618-ea9577076a99" />