### PR TITLE
[TF2] Remove the hard-coded F4 ready up bind for mp_tournament matches

### DIFF
--- a/src/game/client/tf/tf_hud_tournament.cpp
+++ b/src/game/client/tf/tf_hud_tournament.cpp
@@ -311,7 +311,7 @@ void CHudTournament::PreparePanel( void )
 					}
 
 					g_pVGuiLocalize->ConvertANSIToUnicode(key, wszKey, sizeof(wszKey));
-					g_pVGuiLocalize->ConstructString_safe(wszLocalized, g_pVGuiLocalize->Find("Tournament_Instructions_Ready"), 1, wszKey);
+					g_pVGuiLocalize->ConstructString_safe(wszLocalized, g_pVGuiLocalize->Find( "Tournament_Instructions_Ready" ), 1, wszKey);
 					SetDialogVariable("readylabel", wszLocalized);
 				}
 				else
@@ -319,7 +319,6 @@ void CHudTournament::PreparePanel( void )
 					SetDialogVariable("readylabel", g_pVGuiLocalize->Find(pszLabelText));
 				}
 
-				// SetDialogVariable( "readylabel", g_pVGuiLocalize->Find( pszLabelText ) );
 				SetDialogVariable( "tournamentstatelabel", g_pVGuiLocalize->Find( "Tournament_WaitingForTeam" ) );
 				SetPlayerPanelsVisible( true );
 				m_pModeImage->SetVisible( m_bCompetitiveMode );
@@ -335,7 +334,6 @@ void CHudTournament::PreparePanel( void )
 					key = "< not bound >";
 				}
 
-				//SetDialogVariable( "readylabel", g_pVGuiLocalize->Find( "Tournament_Instructions" ) ); // old code
 				g_pVGuiLocalize->ConvertANSIToUnicode(key, wszKey, sizeof(wszKey));
 				g_pVGuiLocalize->ConstructString_safe( wszLocalized, g_pVGuiLocalize->Find( "Tournament_Instructions" ), 1, wszKey );
 				SetDialogVariable("readylabel", wszLocalized);
@@ -398,9 +396,8 @@ void CHudTournament::PreparePanel( void )
 							key = "< not bound >";
 						}
 
-						// SetDialogVariable( "readylabel", g_pVGuiLocalize->Find( "Tournament_Instructions_Ready" ) ); old code
 						g_pVGuiLocalize->ConvertANSIToUnicode(key, wszKey, sizeof(wszKey));
-						g_pVGuiLocalize->ConstructString_safe(wszLocalized, g_pVGuiLocalize->Find("Tournament_Instructions_Ready"), 1, wszKey);
+						g_pVGuiLocalize->ConstructString_safe(wszLocalized, g_pVGuiLocalize->Find( "Tournament_Instructions_Ready" ), 1, wszKey);
 						SetDialogVariable("readylabel", wszLocalized);
 					}
 				}
@@ -1136,6 +1133,12 @@ void CHudTournamentSetup::OnCommand( const char *command )
 
 void CHudTournamentSetup::TogglePlayerReadiness()
 {
+	if (!IsVisible())
+		return;
+
+	if (!g_TF_PR)
+		return;
+
 	if (TFGameRules() && TFGameRules()->UsePlayerReadyStatusMode())
 	{
 		int nReady = (TFGameRules()->IsPlayerReady(GetLocalPlayerIndex())) ? 0 : 1;
@@ -1166,30 +1169,6 @@ bool CHudTournamentSetup::ToggleState( ButtonCode_t code )
 
 	if ( !g_TF_PR )
 		return false;
-
-	//if ( code == KEY_F4 || code == STEAMCONTROLLER_F4 ) // stupid hard-coded thing
-	//{
-	//	//if ( TFGameRules() && TFGameRules()->UsePlayerReadyStatusMode() )
-	//	//{
-	//	//	int nReady = ( TFGameRules()->IsPlayerReady( GetLocalPlayerIndex() ) ) ? 0 : 1;
-	//	//	char szCommand[64];
-	//	//	Q_snprintf( szCommand, sizeof( szCommand ), "tournament_player_readystate %d", nReady );
-	//	//	engine->ClientCmd_Unrestricted( szCommand );
-	//	//}
-	//	//else
-	//	//{
-	//	//	if ( IsMouseInputEnabled() )
-	//	//	{
-	//	//		DisableInput();
-	//	//		return true;
-	//	//	}
-	//	//	else
-	//	//	{
-	//	//		EnableInput();
-	//	//		return true;
-	//	//	}
-	//	//}
-	//}
 
 	if ( IsMouseInputEnabled() )
 	{
@@ -1656,7 +1635,6 @@ CON_COMMAND( player_ready_toggle, "Toggle player ready state" )
 		CHudTournamentSetup *pTournamentPanel = dynamic_cast< CHudTournamentSetup* >( GET_HUDELEMENT( CHudTournamentSetup ) );
 		if ( pTournamentPanel )
 		{
-			// pTournamentPanel->ToggleState( KEY_F4 );
 			pTournamentPanel->TogglePlayerReadiness();
 		}
 	}

--- a/src/game/client/tf/tf_hud_tournament.cpp
+++ b/src/game/client/tf/tf_hud_tournament.cpp
@@ -299,14 +299,46 @@ void CHudTournament::PreparePanel( void )
 					pszLabelText = "Tournament_Instructions_Waiting";
 				}
 
-				SetDialogVariable( "readylabel", g_pVGuiLocalize->Find( pszLabelText ) );
+				if ( pszLabelText == "Tournament_Instructions_Ready" )
+				{
+					// Lets get the currently bound ready up button and display it to the user
+					wchar_t wszLocalized[100];
+					wchar_t wszKey[25];
+					const char* key = engine->Key_LookupBinding("player_ready_toggle");
+					if (!key)
+					{
+						key = "< not bound >";
+					}
+
+					g_pVGuiLocalize->ConvertANSIToUnicode(key, wszKey, sizeof(wszKey));
+					g_pVGuiLocalize->ConstructString_safe(wszLocalized, g_pVGuiLocalize->Find("Tournament_Instructions_Ready"), 1, wszKey);
+					SetDialogVariable("readylabel", wszLocalized);
+				}
+				else
+				{
+					SetDialogVariable("readylabel", g_pVGuiLocalize->Find(pszLabelText));
+				}
+
+				// SetDialogVariable( "readylabel", g_pVGuiLocalize->Find( pszLabelText ) );
 				SetDialogVariable( "tournamentstatelabel", g_pVGuiLocalize->Find( "Tournament_WaitingForTeam" ) );
 				SetPlayerPanelsVisible( true );
 				m_pModeImage->SetVisible( m_bCompetitiveMode );
 			}
 			else
 			{
-				SetDialogVariable( "readylabel", g_pVGuiLocalize->Find( "Tournament_Instructions" ) );
+				// Lets get the currently bound ready up button and display it to the user
+				wchar_t wszLocalized[100];
+				wchar_t wszKey[25];
+				const char* key = engine->Key_LookupBinding("player_ready_toggle");
+				if (!key)
+				{
+					key = "< not bound >";
+				}
+
+				//SetDialogVariable( "readylabel", g_pVGuiLocalize->Find( "Tournament_Instructions" ) ); // old code
+				g_pVGuiLocalize->ConvertANSIToUnicode(key, wszKey, sizeof(wszKey));
+				g_pVGuiLocalize->ConstructString_safe( wszLocalized, g_pVGuiLocalize->Find( "Tournament_Instructions" ), 1, wszKey );
+				SetDialogVariable("readylabel", wszLocalized);
 				SetDialogVariable( "tournamentstatelabel", g_pVGuiLocalize->Find( "Tournament_WaitingForTeams" ) );
 				SetPlayerPanelsVisible( false );
 				m_pModeImage->SetVisible( false );
@@ -357,7 +389,19 @@ void CHudTournament::PreparePanel( void )
 					}
 					else
 					{
-						SetDialogVariable( "readylabel", g_pVGuiLocalize->Find( "Tournament_Instructions_Ready" ) );
+						// Lets get the currently bound ready up button and display it to the user
+						wchar_t wszLocalized[100];
+						wchar_t wszKey[25];
+						const char* key = engine->Key_LookupBinding("player_ready_toggle");
+						if (!key)
+						{
+							key = "< not bound >";
+						}
+
+						// SetDialogVariable( "readylabel", g_pVGuiLocalize->Find( "Tournament_Instructions_Ready" ) ); old code
+						g_pVGuiLocalize->ConvertANSIToUnicode(key, wszKey, sizeof(wszKey));
+						g_pVGuiLocalize->ConstructString_safe(wszLocalized, g_pVGuiLocalize->Find("Tournament_Instructions_Ready"), 1, wszKey);
+						SetDialogVariable("readylabel", wszLocalized);
 					}
 				}
 				else
@@ -1090,6 +1134,28 @@ void CHudTournamentSetup::OnCommand( const char *command )
 	}
 }
 
+void CHudTournamentSetup::TogglePlayerReadiness()
+{
+	if (TFGameRules() && TFGameRules()->UsePlayerReadyStatusMode())
+	{
+		int nReady = (TFGameRules()->IsPlayerReady(GetLocalPlayerIndex())) ? 0 : 1;
+		char szCommand[64];
+		Q_snprintf(szCommand, sizeof(szCommand), "tournament_player_readystate %d", nReady);
+		engine->ClientCmd_Unrestricted(szCommand);
+	}
+	else
+	{
+		if (IsMouseInputEnabled())
+		{
+			DisableInput();
+		}
+		else
+		{
+			EnableInput();
+		}
+	}
+}
+
 //-----------------------------------------------------------------------------
 // Purpose: 
 //-----------------------------------------------------------------------------
@@ -1101,29 +1167,29 @@ bool CHudTournamentSetup::ToggleState( ButtonCode_t code )
 	if ( !g_TF_PR )
 		return false;
 
-	if ( code == KEY_F4 || code == STEAMCONTROLLER_F4 )
-	{
-		if ( TFGameRules() && TFGameRules()->UsePlayerReadyStatusMode() )
-		{
-			int nReady = ( TFGameRules()->IsPlayerReady( GetLocalPlayerIndex() ) ) ? 0 : 1;
-			char szCommand[64];
-			Q_snprintf( szCommand, sizeof( szCommand ), "tournament_player_readystate %d", nReady );
-			engine->ClientCmd_Unrestricted( szCommand );
-		}
-		else
-		{
-			if ( IsMouseInputEnabled() )
-			{
-				DisableInput();
-				return true;
-			}
-			else
-			{
-				EnableInput();
-				return true;
-			}
-		}
-	}
+	//if ( code == KEY_F4 || code == STEAMCONTROLLER_F4 ) // stupid hard-coded thing
+	//{
+	//	//if ( TFGameRules() && TFGameRules()->UsePlayerReadyStatusMode() )
+	//	//{
+	//	//	int nReady = ( TFGameRules()->IsPlayerReady( GetLocalPlayerIndex() ) ) ? 0 : 1;
+	//	//	char szCommand[64];
+	//	//	Q_snprintf( szCommand, sizeof( szCommand ), "tournament_player_readystate %d", nReady );
+	//	//	engine->ClientCmd_Unrestricted( szCommand );
+	//	//}
+	//	//else
+	//	//{
+	//	//	if ( IsMouseInputEnabled() )
+	//	//	{
+	//	//		DisableInput();
+	//	//		return true;
+	//	//	}
+	//	//	else
+	//	//	{
+	//	//		EnableInput();
+	//	//		return true;
+	//	//	}
+	//	//}
+	//}
 
 	if ( IsMouseInputEnabled() )
 	{
@@ -1590,7 +1656,8 @@ CON_COMMAND( player_ready_toggle, "Toggle player ready state" )
 		CHudTournamentSetup *pTournamentPanel = dynamic_cast< CHudTournamentSetup* >( GET_HUDELEMENT( CHudTournamentSetup ) );
 		if ( pTournamentPanel )
 		{
-			pTournamentPanel->ToggleState( KEY_F4 );
+			// pTournamentPanel->ToggleState( KEY_F4 );
+			pTournamentPanel->TogglePlayerReadiness();
 		}
 	}
 }

--- a/src/game/client/tf/tf_hud_tournament.h
+++ b/src/game/client/tf/tf_hud_tournament.h
@@ -113,6 +113,7 @@ public:
 	void			DisableInput( void );
 	bool			ToggleState( ButtonCode_t code );
 	virtual void	OnCommand( const char *command );
+	void			TogglePlayerReadiness( void );
 
 	virtual void OnKeyCodeTyped(vgui::KeyCode code)
 	{


### PR DESCRIPTION
### Note: I am not well-versed in the TF2 SDK or C++ in general, I tried my best. If I made any errors please tell me :)

## **The Issue**
An issue with readying up in matches that utilise `mp_tournament 1` (including Mann VS Machine) is that F4 is permanently bound to the `player_ready_toggle` command even if you bind another key to that action or unbind F4 via the console.

Looking at the code shows that `player_ready_toggle` simply simulates an F4 key press and feeds it into the `CHudTournamentSetup::ToggleState` function.


## **The Solution**
Take the code from the `CHudTournamentSetup::ToggleState` function that handles readying up and put it into a new function called `CHudTournamentSetup::TogglePlayerReadiness`. Now update the `player_ready_toggle` command to call `TogglePlayerReadiness`.

This is the first part of the fix done but now we need to handle the text (Which is currently hard-coded to display F4 as the specified key.)

Update the `#Tournament_Instructions` localisation string from `F4 = change team name/status` to `%s1 = change team name/status`, and change `#Tournament_Instructions_Ready` from `F4 = Toggle Ready` to `%s1 = Toggle Ready`.

Now in all applicable places in `tf_hud_tournament.cpp` we look for the key that is bound to `player_ready_toggle` and insert it into the localisation string! This initially caused truncation in the ready up message for Mann VS Machine so I also increased the width of `TournamentInstructionsLabel` and `TournamentInstructionsLabelShadow` from 190 to 300 to ensure enough room, under the `if_mvm` section in `Resource/UI/HudTournament.res`

This also requires the `xpos` of both UI elements to be edited aswell to line up with the new width. `TournamentInstructionsLabel` gets its `xpos` set to c-150 and `TournamentInstructionsLabelShadow` gets its `xpos` set to c-149

# **Video**
https://youtu.be/kE7cYbmGdeM <-- PR in action

## **Possible Issue**
I am unaware if there is a way to dynamically center text based on length, if there is then I either missed it or cant understand it. Because of this the MvM ready up text wont always be centered(?)

## Extra Steps for Valve
All other localisation files will need to be adjusted. `Resource/UI/HudTournament.res` will need to be modified. `config_default.cfg` will need to have `bind "F4" "player_ready_toggle"` added.

## Files
Here are the modified .res and tf_english localisation file :)
[Dynamic Ready Up Extra Files.zip](https://github.com/user-attachments/files/24837584/Dynamic.Ready.Up.Extra.Files.zip) (OLD VERSION)
[Dynamic Ready Up Extra Files 2.zip](https://github.com/user-attachments/files/24846621/Dynamic.Ready.Up.Extra.Files.2.zip) (CURRENT VERSION)


Partially fixes [ValveSoftware/Source-1-Games #7742](https://github.com/ValveSoftware/Source-1-Games/issues/7742)