### PR TITLE
[TF2] Added missing Steam Controller inputs for loadout menus

### DIFF
--- a/src/game/client/econ/base_loadout_panel.cpp
+++ b/src/game/client/econ/base_loadout_panel.cpp
@@ -19,6 +19,7 @@
 #include "vgui_controls/ComboBox.h"
 #include "vgui/IInput.h"
 #include "econ_ui.h"
+#include "c_tf_player.h"
 
 // memdbgon must be the last include file in a .cpp file!!!
 #include <tier0/memdbgon.h>
@@ -265,8 +266,9 @@ void CBaseLoadoutPanel::ShowPanel( int iClass, bool bBackpack, bool bReturningFr
 		UpdateModelPanels();
 
 		// make the first slot be selected so controller input will work
-		static ConVarRef joystick( "joystick" );
-		if( joystick.IsValid() && joystick.GetBool() && m_pItemModelPanels.Count() && m_pItemModelPanels[0] )
+		//static ConVarRef joystick( "joystick" );
+		bool bSteamController = ::input->IsSteamControllerActive();
+		if( bSteamController && m_pItemModelPanels.Count() && m_pItemModelPanels[0] )
 		{
 			m_pItemModelPanels[0]->SetSelected( true );
 			m_pItemModelPanels[0]->RequestFocus();
@@ -678,6 +680,7 @@ bool	CBaseLoadoutPanel::HandleItemSelectionKeyPressed( vgui::KeyCode code )
 	if ( nButtonCode == KEY_XBUTTON_UP || 
 			  nButtonCode == KEY_XSTICK1_UP ||
 			  nButtonCode == KEY_XSTICK2_UP || 
+			  nButtonCode == STEAMCONTROLLER_DPAD_UP ||
 			  nButtonCode == KEY_UP )
 	{
 		SelectAdjacentItem( 0, -1 );
@@ -730,7 +733,7 @@ bool	CBaseLoadoutPanel::HandleItemSelectionKeyPressed( vgui::KeyCode code )
 		}
 		return true;
 	}
-	else if ( nButtonCode == KEY_XBUTTON_Y )
+	else if ( nButtonCode == KEY_XBUTTON_Y || nButtonCode == STEAMCONTROLLER_Y )
 	{
 		m_bTooltipKeyPressed = true;
 		CItemModelPanel *pSelection = GetFirstSelectedItemModelPanel( false );
@@ -754,7 +757,7 @@ bool	CBaseLoadoutPanel::HandleItemSelectionKeyPressed( vgui::KeyCode code )
 bool	CBaseLoadoutPanel::HandleItemSelectionKeyReleased( vgui::KeyCode code ) 
 {
 	ButtonCode_t nButtonCode = GetBaseButtonCode( code );
-	if( nButtonCode == KEY_XBUTTON_Y )
+	if( nButtonCode == KEY_XBUTTON_Y || nButtonCode == STEAMCONTROLLER_Y )
 	{
 		m_bTooltipKeyPressed = false;
 		m_pMouseOverTooltip->HideTooltip();

--- a/src/game/client/econ/econ_controls.cpp
+++ b/src/game/client/econ/econ_controls.cpp
@@ -1910,7 +1910,7 @@ void CExplanationPopup::OnKeyCodePressed( vgui::KeyCode code )
 		ButtonCode_t nButtonCode = GetBaseButtonCode( code );
 
 		// swallow all keys
-		if ( nButtonCode == KEY_XBUTTON_B )
+		if ( nButtonCode == KEY_XBUTTON_B || nButtonCode == STEAMCONTROLLER_B )
 		{
 			OnCommand( "close" );
 			return;
@@ -1918,6 +1918,7 @@ void CExplanationPopup::OnKeyCodePressed( vgui::KeyCode code )
 		else if ( nButtonCode == KEY_XBUTTON_LEFT || 
 				  nButtonCode == KEY_XSTICK1_LEFT ||
 				  nButtonCode == KEY_XSTICK2_LEFT ||
+				  nButtonCode == STEAMCONTROLLER_DPAD_LEFT ||
 				  code == KEY_LEFT )
 		{
 			OnCommand( "prevexplanation" );
@@ -1926,6 +1927,7 @@ void CExplanationPopup::OnKeyCodePressed( vgui::KeyCode code )
 		else if ( nButtonCode == KEY_XBUTTON_RIGHT || 
 				  nButtonCode == KEY_XSTICK1_RIGHT ||
 				  nButtonCode == KEY_XSTICK2_RIGHT ||
+				  nButtonCode == STEAMCONTROLLER_DPAD_RIGHT ||
 				  code == KEY_RIGHT )
 		{
 			OnCommand( "nextexplanation" );

--- a/src/game/client/econ/item_pickup_panel.cpp
+++ b/src/game/client/econ/item_pickup_panel.cpp
@@ -473,6 +473,7 @@ void	CItemPickupPanel::OnKeyCodePressed( vgui::KeyCode code )
 	else if ( nButtonCode == KEY_XBUTTON_RIGHT || 
 			  nButtonCode == KEY_XSTICK1_RIGHT ||
 			  nButtonCode == KEY_XSTICK2_RIGHT || 
+			  nButtonCode == STEAMCONTROLLER_DPAD_RIGHT ||
 			  nButtonCode == KEY_RIGHT )
 	{
 		OnCommand( "nextitem" );
@@ -480,6 +481,7 @@ void	CItemPickupPanel::OnKeyCodePressed( vgui::KeyCode code )
 	else if ( nButtonCode == KEY_XBUTTON_LEFT || 
 			  nButtonCode == KEY_XSTICK1_LEFT ||
 			  nButtonCode == KEY_XSTICK2_LEFT || 
+			  nButtonCode == STEAMCONTROLLER_DPAD_LEFT ||
 			  nButtonCode == KEY_LEFT )
 	{
 		OnCommand( "previtem" );
@@ -848,7 +850,7 @@ void	CItemDiscardPanel::OnKeyCodePressed( vgui::KeyCode code )
 {	
 	ButtonCode_t nButtonCode = GetBaseButtonCode( code );
 
-	if( nButtonCode == KEY_XBUTTON_B )
+	if( nButtonCode == KEY_XBUTTON_B || nButtonCode == STEAMCONTROLLER_B )
 	{
 		OnCommand( "vguicancel" );
 	}

--- a/src/game/client/econ/item_selection_panel.cpp
+++ b/src/game/client/econ/item_selection_panel.cpp
@@ -378,9 +378,10 @@ void CItemSelectionPanel::OnKeyCodePressed( vgui::KeyCode code )
 			NotifySelectionReturned( pItemPanel );
 		}
 	}
-	else if( nButtonCode == KEY_XBUTTON_B )
+	else if( nButtonCode == KEY_XBUTTON_B || nButtonCode == STEAMCONTROLLER_B )
 	{
-		PostMessageSelectionReturned( INVALID_ITEM_ID );
+		//match the same behaviour as pressing ESC
+		PostMessageSelectionReturned( 0 );
 		OnClose();
 	}
 	else
@@ -1085,8 +1086,9 @@ void CEquipSlotItemSelectionPanel::UpdateModelPanelsForSelection( void )
 	int nPageStart = GetCurrentPage() * GetNumSlotsPerPage();
 	nOldSelection += nPageStart;
 
-	static ConVarRef joystick( "joystick" );
-	if ( joystick.IsValid() && joystick.GetBool() )
+	//static ConVarRef joystick( "joystick" );
+	bool bSteamController = ::input->IsSteamControllerActive();
+	if ( bSteamController )
 	{
 		if( nOldSelection == -1 || nOldSelection >= vecDisplayItems.Count() )
 			nOldSelection = nPageStart;
@@ -1102,7 +1104,7 @@ void CEquipSlotItemSelectionPanel::UpdateModelPanelsForSelection( void )
 		m_pItemModelPanels[i]->SetShowGreyedOutTooltip( true );
 		m_pItemModelPanels[i]->SetGreyedOut( NULL );
 		m_pItemModelPanels[i]->SetNoItemText( "#SelectNoItemSlot" );
-		bool bSelected = joystick.IsValid() && joystick.GetBool() && iItemIndex == nOldSelection;
+		bool bSelected = bSteamController && iItemIndex == nOldSelection;
 		m_pItemModelPanels[i]->SetSelected( bSelected );
 		m_pItemModelPanels[i]->SetShowQuantity( true );
 		m_pItemModelPanels[i]->SetForceShowEquipped( false );

--- a/src/game/client/tf/vgui/character_info_panel.cpp
+++ b/src/game/client/tf/vgui/character_info_panel.cpp
@@ -403,7 +403,7 @@ void CCharacterInfoPanel::OnKeyCodePressed(vgui::KeyCode code)
 {
 	ButtonCode_t nButtonCode = GetBaseButtonCode( code );
 
-	if ( nButtonCode == KEY_XBUTTON_B )
+	if ( nButtonCode == KEY_XBUTTON_B || nButtonCode == STEAMCONTROLLER_B )
 	{
 		if ( !m_bPreventClosure )
 		{

--- a/src/game/client/tf/vgui/charinfo_loadout_subpanel.cpp
+++ b/src/game/client/tf/vgui/charinfo_loadout_subpanel.cpp
@@ -1232,7 +1232,7 @@ void CCharInfoLoadoutSubPanel::OnKeyCodePressed(vgui::KeyCode code)
 	{
 		// let escape and B (aka "go back") through so we 
 		// can actually get out of the loadout screen
-		if ( nButtonCode == KEY_XBUTTON_B )
+		if ( nButtonCode == KEY_XBUTTON_B || nButtonCode == STEAMCONTROLLER_B )
 		{
 			BaseClass::OnKeyCodePressed( code );
 		}


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
Title.
- Now it is easy to exit the loadout menu with B.
- Replaced some old joystick checks with IsSteamControllerActive()
- Added missing DPAD UP.

https://github.com/user-attachments/assets/cc538c09-4bed-446f-9e20-6468a18915bc

