### PR TITLE
[TF2] Add queue button to contracts

### DIFF
--- a/src/game/client/tf/vgui/tf_quest_map_node_view_panel.cpp
+++ b/src/game/client/tf/vgui/tf_quest_map_node_view_panel.cpp
@@ -176,6 +176,8 @@ CQuestViewSubPanel::CQuestViewSubPanel( Panel* pParent,
 	m_pObjectivePanel = new CQuestObjectivePanel( this, "objectives" );
 	m_pActivateButton = new CExButton( this, "ActivateButton", (const char*)NULL, this, "activate_node" );
 	m_pActivateButton->PassMouseTicksTo( this, true );
+	m_pJoinQueueButton = new CExButton( this, "JoinQueueButton", (const char*)NULL, this, "join_queue" );
+	m_pJoinQueueButton->PassMouseTicksTo( this, true );
 	m_pBGImage = new ImagePanel( this, "BGImage" );
 	m_pAcceptTooltipHack = new EditablePanel( this, "EditableTooltip" );
 	m_pInfo = new ImagePanel( this, "ObjectivesInfoImage" );
@@ -183,6 +185,7 @@ CQuestViewSubPanel::CQuestViewSubPanel( Panel* pParent,
 	m_pTurnInContainer = new EditablePanel( m_pObjectivePanel, "TurnInContainer" );
 
 	ListenForGameEvent( "quest_response" );
+	ListenForGameEvent( "party_updated" );
 }
 
 void CQuestViewSubPanel::ApplySchemeSettings( IScheme *pScheme )
@@ -243,6 +246,20 @@ void CQuestViewSubPanel::PerformLayout()
 	// Make the activate button be very dark and uninviting when not enabled
 	m_pActivateButton->SetDefaultColor( colorTanLight, bCanActivate ? colorActive : colorInactive );
 
+	if ( !bCompleted && bActive )
+	{
+		m_pJoinQueueButton->SetVisible( true );
+		m_pJoinQueueButton->SetEnabled( BIsAllowedToQueue() );
+
+		// Force disable activate button if we are showing the join queue button instead
+		m_pActivateButton->SetVisible( false );
+		m_pActivateButton->SetEnabled( false );
+	}
+	else
+	{
+		m_pJoinQueueButton->SetVisible( false );
+		m_pJoinQueueButton->SetEnabled( false );
+	}
 
 	if ( !bCanActivate && !bCanChoose && !bActive )
 	{
@@ -323,6 +340,32 @@ void CQuestViewSubPanel::OnCommand( const char *command )
 
 		InvalidateLayout();
 	}
+	else if ( FStrEq( "join_queue", command ) )
+	{
+		if ( !BIsAllowedToQueue() )
+			return;
+
+		CTFGroupMatchCriteria& criteria = GTFPartyClient()->MutLocalGroupCriteria();
+
+		// Select the quest specific maps if there are any
+		CUtlVector< int > vecValidMaps;
+		if ( BFillValidMaps( vecValidMaps ) )
+		{
+			criteria.ClearCasualCriteria();
+
+			FOR_EACH_VEC( vecValidMaps, i )
+			{
+				criteria.SetCasualMapSelected( vecValidMaps[ i ], true );
+			}
+		}
+		// Otherwise fallback to the users favourites, which simply loads the Core category if there are no favourites
+		if ( !criteria.GetCasualCriteriaHelper().AnySelected() )
+			GTFPartyClient()->LoadSavedCasualCriteria();
+
+		// Sanity check
+		if ( criteria.GetCasualCriteriaHelper().AnySelected() )
+			GTFPartyClient()->RequestQueueForMatch( k_eTFMatchGroup_Casual_12v12 );
+	}
 	else if ( FStrEq( "turn_in", command ) ) 
 	{
 		if ( !GetQuestMapHelper().BCanNodeBeTurnedIn( m_msgNodeData.defindex() ) )
@@ -339,6 +382,77 @@ void CQuestViewSubPanel::OnCommand( const char *command )
 			PlaySoundEntry( strCommandArgs[ 1 ] );
 		}
 	}
+}
+
+bool CQuestViewSubPanel::BFillValidMaps( CUtlVector< int >& vecValidMaps ) const
+{
+	const CQuestDefinition* pQuestDef = m_pQuest->GetDefinition();
+	if ( !pQuestDef )
+		return false;
+
+	const QuestObjectiveDefVec_t& vecQuestObjectives = pQuestDef->GetObjectives();
+	FOR_EACH_VEC( vecQuestObjectives, i )
+	{
+		if ( m_pQuest->BEarnedAllPointsForCategory( vecQuestObjectives[ i ].GetPointsType() ) )
+			continue; // This objective is complete, don't queue it
+
+		const CQuestObjectiveDefinition* pQuestObjDef = vecQuestObjectives[ i ].GetObjectiveDef();
+		if ( !pQuestObjDef )
+			continue;
+		const CMsgQuestObjectiveDef& msgQuestObjDef = pQuestObjDef->GetTypedMsg();
+
+		int nMapsSize = msgQuestObjDef.map_size();
+		for ( int j = 0; j < nMapsSize; j++ )
+		{
+			const char *pszMapName = msgQuestObjDef.map( j ).c_str();
+			const MapDef_t* pMapDef = GetItemSchema()->GetMasterMapDefByName( pszMapName );
+			assert( pMapDef );
+			if ( !pMapDef )
+				return false; // A map is defined but we can't find it, something is very wrong
+
+			vecValidMaps.AddToTail( pMapDef->m_nDefIndex );
+		}
+
+		int nGameModesSize = msgQuestObjDef.game_mode_size();
+		for ( int j = 0; j < nGameModesSize; j++ )
+		{
+			EGameCategory eGameMode = (EGameCategory)msgQuestObjDef.game_mode( j );
+			const SchemaGameCategory_t* pGameCategory = GetItemSchema()->GetGameCategory( eGameMode );
+			assert( pGameCategory );
+			if ( !pGameCategory )
+				return false; // A gamemode is defined but we can't find it, something is very wrong
+
+			FOR_EACH_VEC( pGameCategory->m_vecEnabledMaps, k )
+			{
+				vecValidMaps.AddToTail( pGameCategory->m_vecEnabledMaps[ k ]->m_nDefIndex );
+			}
+		}
+	}
+	return vecValidMaps.Count() > 0;
+}
+
+bool CQuestViewSubPanel::BIsAllowedToQueue()
+{
+	CUtlVector< CTFPartyClient::QueueEligibilityData_t > vecReasons;
+	if ( !GTFPartyClient()->BCanQueueForMatch( k_eTFMatchGroup_Casual_12v12, vecReasons ) )
+	{
+		FOR_EACH_VEC( vecReasons, i )
+		{
+			// Ugly hack to check if this is casual criteria, we override the selected maps anyways so we ignore this one
+			const wchar_t* pszNoCasualCriteriaString = g_pVGuiLocalize->Find( "#TF_Matchmaking_CantQueue_NoCasualCriteria" );
+			if ( Q_wcscmp( pszNoCasualCriteriaString, vecReasons[ i ].wszCantReason ) == 0 )
+				continue;
+
+			m_pAcceptTooltipHack->SetVisible( true );
+			m_pAcceptTooltipHack->SetTooltip( m_pToolTip, NULL );
+			m_pAcceptTooltipHack->SetDialogVariable( "tiptext", vecReasons[i].wszCantReason );
+			return false;
+		}
+	}
+
+	m_pJoinQueueButton->SetTooltip( NULL, NULL );
+	m_pAcceptTooltipHack->SetVisible( false );
+	return true;
 }
 
 void CQuestViewSubPanel::BeginTurnInAnimation()
@@ -416,6 +530,10 @@ void CQuestViewSubPanel::FireGameEvent( IGameEvent *event )
 				return;
 			}
 		}
+	}
+	else if ( FStrEq( "party_updated", event->GetName() ) )
+	{
+		InvalidateLayout();
 	}
 }
 

--- a/src/game/client/tf/vgui/tf_quest_map_node_view_panel.h
+++ b/src/game/client/tf/vgui/tf_quest_map_node_view_panel.h
@@ -96,9 +96,14 @@ public:
 private:
 	void HideSelectQuestInfo();
 	void BeginTurnInAnimation();
+	// Will return false if the quest is not map restricted
+	bool BFillValidMaps( CUtlVector<int>& vecValidMaps ) const;
+	// Also sets up the tooltip for m_pJoinQueueButton
+	bool BIsAllowedToQueue();
 
 	EditablePanel* m_pAcceptTooltipHack;
 	CExButton* m_pActivateButton;
+	CExButton* m_pJoinQueueButton;
 	CTFTextToolTip* m_pToolTip;
 	ImagePanel* m_pBGImage;
 	ImagePanel* m_pInfo;


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->
This PR makes the flow of activating contracts and queuing for a match a little nicer. Players no longer have to activate a contract, deselect all maps, search for that one specific map they need, and then finally queue. Instead there is a "Start Search" button in place of the "Activate" button.


<img width="695" height="531" alt="image" src="https://github.com/user-attachments/assets/17d1fb76-48a5-4a1e-bee6-e0331f97c96e" />

The button only shows if the contract is not fully finished and if the contract is active. If required it will automatically select the required maps/modes and then start the casual queue, otherwise it will simply start the queue with the current settings without modifying them. If no maps are selected at all a fallback will load the players saved maps which internally falls back to the entire core category if there are no saved maps.

I also added handling for the usual queue restrictions such as bans, not being party leader, etc. However this includes an ugly hack because `CTFPartyClient::BCanQueueForMatch` also returns an error if there are no maps selected, which for us isn't an issue since we will automatically select at least one map anyways. The only way to check for this case is to manually compare the translation strings, which works fine but isn't nice.

The following button would have to be added into `resource/ui/econ/questviewsubpanel.res`

```
"JoinQueueButton"
{
	"ControlName"	"CExButton"
	"fieldName"		"JoinQueueButton"
	"xpos"			"3"
	"ypos"			"26"
	"zpos"			"10"
	"wide"			"80"
	"tall"			"16"
	"autoResize"	"0"
	"pinCorner"		"0"
	"visible"		"1"
	"enabled"		"1"
	"tabPosition"	"0"
	"labeltext"		"#TF_Matchmaking_StartSearch"
	"textAlignment"	"center"
	"dulltext"		"0"
	"brighttext"	"0"
	"default"		"0"
	"sound_depressed"	"UI/buttonclick.wav"
	"sound_released"	"UI/buttonclickrelease.wav"
	"Command"		"join_queue"
	"proportionaltoparent" "1"
	"actionsignallevel"	"2"
	"textinsety"	"0"
	"eatmouseinput"	"0"	
	"font"			"QuestMap_Large"
	"roundedcorners"	"0"

	"paintbackground"	"1"

	"defaultBgColor_override"	"StoreGreen"
	"armedBgColor_override"		"CreditsGreen"
	"depressedBgColor_override" "CreditsGreen"

	"defaultFgColor_override"	"TanLight"
	"armedFgColor_override"		"TanLight"
	"depressedFgColor_override" "TanLight"
} // JoinQueueButton
```

The entire modified file is also attached to this PR:
[questviewsubpanel.res.txt](https://github.com/user-attachments/files/24983773/questviewsubpanel.res.txt) (had to upload as .txt because github sucks)

Also fixes https://github.com/ValveSoftware/Source-1-Games/issues/4406
