### PR TITLE
Adjust glow_overlay ray trace position calculation

### DIFF
--- a/src/game/client/glow_overlay.cpp
+++ b/src/game/client/glow_overlay.cpp
@@ -159,7 +159,7 @@ void CGlowOverlay::UpdateSkyGlowObstruction( float zFar, bool bCacheFullSceneSta
 	if ( PixelVisibility_IsAvailable() )
 	{
 		// Trace a ray at the object. 
-		Vector pos = CurrentViewOrigin() + m_vDirection * zFar * 0.999f;
+		Vector pos = CurrentViewOrigin() + m_vDirection * zFar * 0.99f;
 
 		// UNDONE: Can probably do only the pixelvis query in this case if you can figure out where
 		// to put it - or save the position of this trace


### PR DESCRIPTION
# Description:

Change the pos value of glow_overlay.cpp from `Vector pos = CurrentViewOrigin() + m_vDirection * zFar * 0.999f;` to `Vector pos = CurrentViewOrigin() + m_vDirection * zFar * 0.99f;`.

This fixes the issue of env_sun disappearing when directly under the crosshair, even when the crosshair sprite is not active.