### PR TITLE
[TF2] Fix Killstreak meter overlapping with Spy Disguise info in Player Status HUD

### DIFF
--- a/src/game/client/tf/tf_hud_itemeffectmeter.cpp
+++ b/src/game/client/tf/tf_hud_itemeffectmeter.cpp
@@ -729,7 +729,7 @@ bool CHudItemEffectMeter_Weapon<CTFWeaponBase>::IsEnabled( void )
 {
 	C_TFPlayer *pTFPlayer = C_TFPlayer::GetLocalTFPlayer();
 
-	if ( pTFPlayer )
+	if ( pTFPlayer && ( !pTFPlayer->m_Shared.InCond( TF_COND_DISGUISED ) ) )
 	{
 		int iKillStreak = 0;
 		CALL_ATTRIB_HOOK_INT_ON_OTHER( pTFPlayer, iKillStreak, killstreak_tier );


### PR DESCRIPTION
This PR updates the Killstreak meter to hide itself when a player is disguised:

https://github.com/user-attachments/assets/af0c2932-fe3b-42ee-bbbe-6cf3601c18a3

This fixes an issue with the Player Status HUD in live TF2 where it currently conflicts with the Spy Disguise info:
<img width="394" height="152" alt="image" src="https://github.com/user-attachments/assets/c2e82bef-a829-4ea9-a13d-c88703e72a5c" />

https://github.com/user-attachments/assets/ca09122e-b35a-4512-a041-f8e77d2b3e86

