### PR TITLE
Fix flipped initial pitch/yaw on thirdperson switch

### DIFF
--- a/src/game/client/in_camera.cpp
+++ b/src/game/client/in_camera.cpp
@@ -683,7 +683,7 @@ void CInput::CAM_ToThirdPerson(void)
 	{
 		m_fCameraInThirdPerson = true; 
 	
-		g_ThirdPersonManager.SetCameraOffsetAngles( Vector( viewangles[ YAW ], viewangles[ PITCH ], CAM_MIN_DIST ) );
+		g_ThirdPersonManager.SetCameraOffsetAngles( Vector( viewangles[ PITCH ], viewangles[ YAW ], CAM_MIN_DIST ) );
 	}
 
 	cam_command.SetValue( 0 );


### PR DESCRIPTION
When switching to thirdperson (such as via `thirdperson` command or by taunting in TF2), the camera experiences a snap at the beginning. This is due to an oversight where the initial camera pitch and yaw are flipped. This PR simply flips them to the correct ordering

Before:

https://github.com/user-attachments/assets/1654aa40-45e0-478b-8858-30b5bfabfbb1

After:

https://github.com/user-attachments/assets/ea7bd552-61ec-4ad7-93ba-55bef58f3aa2

