### PR TITLE
[TF2] Allow TF_COND_INVULNERABLE_HIDE_UNLESS_DAMAGED to function outside MvM

### DIFF
--- a/src/game/client/tf/c_tf_player.cpp
+++ b/src/game/client/tf/c_tf_player.cpp
@@ -8334,7 +8334,9 @@ bool C_TFPlayer::IsOverridingViewmodel( void )
 		pPlayer = assert_cast<C_TFPlayer*>(pLocalPlayer->GetObserverTarget());
 	}
 
-	if ( pPlayer->m_Shared.IsInvulnerable() )
+	bool bUseInvulnMaterial = ( pPlayer->m_Shared.IsInvulnerable() && 
+								( !pPlayer->m_Shared.InCond( TF_COND_INVULNERABLE_HIDE_UNLESS_DAMAGED ) || gpGlobals->curtime < pPlayer->GetLastDamageTimeMvMOnly() + 2.0f ) );
+	if ( bUseInvulnMaterial )
 		return true;
 
 	return BaseClass::IsOverridingViewmodel();
@@ -8369,7 +8371,9 @@ int	C_TFPlayer::DrawOverriddenViewmodel( C_BaseViewModel *pViewmodel, int flags 
 		pPlayer = assert_cast<C_TFPlayer*>(pLocalPlayer->GetObserverTarget());
 	}
 
-	if ( pPlayer->m_Shared.IsInvulnerable() )
+	bool bUseInvulnMaterial = ( pPlayer->m_Shared.IsInvulnerable() && 
+								( !pPlayer->m_Shared.InCond( TF_COND_INVULNERABLE_HIDE_UNLESS_DAMAGED ) || gpGlobals->curtime < pPlayer->GetLastDamageTimeMvMOnly() + 2.0f ) );
+	if ( bUseInvulnMaterial )
 	{
 		if ( flags & STUDIO_RENDER )
 		{

--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -10632,9 +10632,10 @@ int CTFPlayer::OnTakeDamage_Alive( const CTakeDamageInfo &info )
 	}
 
 	m_flLastDamageTime = gpGlobals->curtime; // not networked
-	if ( TFGameRules()->IsMannVsMachineMode() )
+	if ( TFGameRules()->IsMannVsMachineMode() || m_Shared.InCond( TF_COND_INVULNERABLE_HIDE_UNLESS_DAMAGED ) )
 	{
 		// We only need damage time networked while in MvM
+		// also set it if victim has INVULNERABLE_HIDE_UNLESS_DAMAGED
 		m_flMvMLastDamageTime = gpGlobals->curtime;
 	}
 

--- a/src/game/shared/tf/tf_item_wearable.cpp
+++ b/src/game/shared/tf/tf_item_wearable.cpp
@@ -295,7 +295,7 @@ int	CTFWearable::InternalDrawModel( int flags )
 	}
 
 	bool bUseInvulnMaterial = ( pOwner && pOwner->m_Shared.IsInvulnerable() && 
-							    ( !pOwner->m_Shared.InCond( TF_COND_INVULNERABLE_HIDE_UNLESS_DAMAGED ) || gpGlobals->curtime < pOwner->GetLastDamageTimeMvMOnly() + 2.0f ) );
+								( !pOwner->m_Shared.InCond( TF_COND_INVULNERABLE_HIDE_UNLESS_DAMAGED ) || gpGlobals->curtime < pOwner->GetLastDamageTimeMvMOnly() + 2.0f ) );
 
 	if ( bUseInvulnMaterial && (flags & STUDIO_RENDER) )
 	{


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
This allows `TF_COND_INVULNERABLE_HIDE_UNLESS_DAMAGED` to display its effects properly outside MvM (shows Ubercharge skin when damaged). In order to prevent networking data when not necessary, it only sets `m_flMvMLastDamageTime` for players that have the condition (this netprop is not used for any other feature in the game).
In addition, it also adds the relevant logic to `C_TFPlayer::IsOverridingViewmodel` and `C_TFPlayer::DrawOverriddenViewmodel` so that a player's viewmodels gain the same effect (only showing the Uber skin when taking damage, instead of live behavior of showing it at all times).

Demonstration: https://youtu.be/ospEI-UsMTY
