### PR TITLE
[TF2] Change overheal to no longer decay while being healed in MvM

### DIFF
--- a/src/game/shared/tf/tf_player_shared.cpp
+++ b/src/game/shared/tf/tf_player_shared.cpp
@@ -2437,8 +2437,10 @@ void CTFPlayerShared::ConditionGameRulesThink( void )
 				if ( pTFHealer )
 				{
 					// Quick fix never lets health decay, even when they're at or above max overheal
+					// In Mann vs. Machine, never decay overheal because Scouts can get >500 overheal
 					CWeaponMedigun *pMedigun = dynamic_cast< CWeaponMedigun* >( pTFHealer->GetActiveTFWeapon() );
-					if ( pMedigun && pMedigun->GetMedigunType() == MEDIGUN_QUICKFIX )
+					if ( pMedigun && ( pMedigun->GetMedigunType() == MEDIGUN_QUICKFIX || 
+						( TFGameRules() && TFGameRules()->IsMannVsMachineMode() ) ) )
 					{
 						bDecayHealth = false;
 						bDecayDisguiseHealth = false;


### PR DESCRIPTION
TL;DR:
This PR prevents overheal from decaying while being healed in Mann vs. Machine by checking if the game mode is Mann vs. Machine (does not work in non-MvM or Freaky Fair-type maps). Scouts with high overheal from credits and high overheal from upgraded Medi Guns should no longer decay from non-Quick-Fix Medi Guns with a lower max overheal.

----

Overheal in Mann vs. Machine can reach higher-than-usual levels, especially for the Scout. In the regular game, the Quick-Fix prevents overheal from decaying if it's higher than the maximum overheal the Quick-Fix allows. In Mann vs. Machine, it also does this but is the only Medi Gun to do so. This creates a problem:

A Scout's overheal from credits gets decayed way faster when being healed. Often, Medics use the Scout's speed to quickly return to the Upgrade Station in-between waves, but this also means their overheal decays much faster. A Medic may also be unaware of this and accidentally deplete a Scout's entire overheal much faster between waves (Scouts playing a damage playstyle often require as much overheal as possible to offset the lack of resistances). The Quick-Fix has neither of these problems, but the Vaccinator and Kritzkrieg are also commonly-used Medi Guns in MvM.

This PR makes it so the overheal does not decay from any Medi Gun in Mann vs. Machine. This change can be useful for Scouts in MvM who can now have a Medic maintain their overheal in-between waves, but this change also allows for some more interesting strategies (such as two Medics, with only one having Overheal Mastery upgraded or a pocket Scout strategy). It also prevents intentional griefing of Medics that deplete their Scout's overheal whenever they can (though this is not a common scenario).

Lastly, this change should really only affect Scouts in 99% of games and is mostly a quality of life change (based on a little over 200 tours of experience).