### PR TITLE
[TF2] Fix Sentry rockets not sending the `object_deflected` game event when deflected

### DIFF
--- a/src/game/server/tf/tf_projectile_rocket.cpp
+++ b/src/game/server/tf/tf_projectile_rocket.cpp
@@ -156,7 +156,7 @@ void CTFProjectile_Rocket::Deflected( CBaseEntity *pDeflectedBy, Vector &vecDir 
 	CTFPlayer *pOldOwner = ToTFPlayer( GetOwnerEntity() );
 	if ( pOldOwner == nullptr )
 	{
-		CBaseObject* pBaseObject = dynamic_cast< CBaseObject* >( GetOwnerEntity() );
+		CBaseObject *pBaseObject = dynamic_cast< CBaseObject* >( GetOwnerEntity() );
 		if ( pBaseObject && pBaseObject->GetOwner() )
 		{
 			pOldOwner = ToTFPlayer( pBaseObject->GetOwner() );


### PR DESCRIPTION
Adds a check to make sure sentry rockets properly send a `object_deflected` game event

