### PR TITLE
[TF2] Fixed restoring drained health removing overheal while not actively being healed

### DIFF
--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -1117,6 +1117,7 @@ CTFPlayer::CTFPlayer()
 
 	m_bViewingCYOAPDA = false;
 
+	m_flLastOverhealMultiplier = 1.f;
 	ResetMaxHealthDrain();
 
 	m_bRegenerating = false;
@@ -14267,6 +14268,11 @@ int CTFPlayer::GetMaxHealthForBuffing()
 	int iMax = m_PlayerClass.GetMaxHealth();
 	CALL_ATTRIB_HOOK_INT( iMax, add_maxhealth );
 
+	if (m_Shared.GetNumHealers() > 0)
+	{
+		m_flLastOverhealMultiplier = m_Shared.GetMaxOverhealMultiplier();
+	}
+	
 	CTFWeaponBase *pWeapon = GetActiveTFWeapon();
 	if ( pWeapon )
 	{
@@ -14402,7 +14408,7 @@ int CTFPlayer::GetMaxHealthForBuffing()
 				if ( nHealthRestore > 0 )
 				{
 					m_dMaxHealthDrainHealthAccumulator -= nHealthRestore;
-					int nHealthMaxOverheal = nOriginalMaxHealth * m_Shared.GetMaxOverhealMultiplier();
+					int nHealthMaxOverheal = nOriginalMaxHealth * m_flLastOverhealMultiplier;
 					int nHealthMaxAttribute = nOriginalMaxHealth;
 					CALL_ATTRIB_HOOK_INT( nHealthMaxAttribute, add_maxhealth_nonbuffed );
 					int nHealthMax = Max( nHealthMaxOverheal, nHealthMaxAttribute );

--- a/src/game/server/tf/tf_player.h
+++ b/src/game/server/tf/tf_player.h
@@ -1557,6 +1557,8 @@ private:
 	float m_flLastAutobalanceTime;
 
 	void ResetMaxHealthDrain( void );
+	
+	float m_flLastOverhealMultiplier;
 	int m_nMaxHealthDrainBucket;
 	double m_dMaxHealthDrainLastUpdate;
 	bool m_bMaxHealthRefilling;


### PR DESCRIPTION
While using health draining items such as the Eviction Notice or the Gloves of Running Urgently, TF2 completely removes your overheal while restoring max health. Since overheal is so important as heavy, this is a significant gameplay issue when trying to use these weapons.

This behavior is caused by the function trying to cap how much health can be restored to `Max( nHealthMaxOverheal, nHealthMaxAttribute )`. `nHealthMaxOverheal` is `nOriginalMaxHealth * m_Shared.GetMaxOverhealMultiplier()` where the multiplier is `1` when not actively being healed. So the player's health is just capped to their max health.

My solution is to just remember the last `m_Shared.GetMaxOverhealMultiplier()` while the player is actively being healed and to use that as the multiplier instead.

___

Before:

https://github.com/user-attachments/assets/5107514a-ccab-403d-be2e-42bce8747dff


Fixed:

https://github.com/user-attachments/assets/08e3e53d-8aa1-4972-a62e-8f52f1fdf877