### PR TITLE
Fix race condition in CUtlSymbolTableMT lookup

### DIFF
--- a/src/public/tier1/utlsymbol.h
+++ b/src/public/tier1/utlsymbol.h
@@ -139,6 +139,17 @@ protected:
 		unsigned short m_iOffset;	// Index into the string pool.
 	};
 
+	// Helper to store search string on the stack for safe thread access
+	class CStringPoolIndexSearch : public CStringPoolIndex
+	{
+	public:
+		CStringPoolIndexSearch( const char* pString ) : CStringPoolIndex( 0xFFFF, 0xFFFF )
+		{
+			m_pUserSearchString = pString;
+		}
+		const char* m_pUserSearchString;
+	};
+
 	class CLess
 	{
 	public:

--- a/src/tier1/utlsymbol.cpp
+++ b/src/tier1/utlsymbol.cpp
@@ -142,9 +142,9 @@ bool CUtlSymbolTable::CLess::operator()( const CStringPoolIndex &i1, const CStri
 	// right now at least, because m_LessFunc is the first member of CUtlRBTree, and m_Lookup
 	// is the first member of CUtlSymbolTabke, this == pTable
 	CUtlSymbolTable *pTable = (CUtlSymbolTable *)( (byte *)this - offsetof(CUtlSymbolTable::CTree, m_LessFunc) ) - offsetof(CUtlSymbolTable, m_Lookup );
-	const char* str1 = (i1 == INVALID_STRING_INDEX) ? pTable->m_pUserSearchString :
+	const char* str1 = (i1 == INVALID_STRING_INDEX) ? static_cast< const CUtlSymbolTable::CStringPoolIndexSearch& >( i1 ).m_pUserSearchString :
 													  pTable->StringFromIndex( i1 );
-	const char* str2 = (i2 == INVALID_STRING_INDEX) ? pTable->m_pUserSearchString :
+	const char* str2 = (i2 == INVALID_STRING_INDEX) ? static_cast< const CUtlSymbolTable::CStringPoolIndexSearch& >( i2 ).m_pUserSearchString :
 													  pTable->StringFromIndex( i2 );
 
 	if ( !str1 && str2 )
@@ -181,11 +181,11 @@ CUtlSymbol CUtlSymbolTable::Find( const char* pString ) const
 		return CUtlSymbol();
 	
 	// Store a special context used to help with insertion
-	m_pUserSearchString = pString;
+	CStringPoolIndexSearch search( pString );
 	
 	// Passing this special invalid symbol makes the comparison function
 	// use the string passed in the context
-	UtlSymId_t idx = m_Lookup.Find( INVALID_STRING_INDEX );
+	UtlSymId_t idx = m_Lookup.Find( search );
 
 #ifdef _DEBUG
 	m_pUserSearchString = NULL;


### PR DESCRIPTION
See https://github.com/ValveSoftware/source-sdk-2013/issues/612 for an explanation of how the race condition arises

This PR puts the search string on the stack, which prevents threads from reading a stale pointer that got switched out between execution

This mainly fixes flickering water materials. Materialsystem uses a CUtlSymbolTableMT lookup for material vars internally, and therefore it will occasionally read a stale state for fog parameters. It also fixes various other random bugs such as eyes becoming missing textures