### PR TITLE
[TF2] Stop teleporter spin sound when carried

### DIFF
--- a/src/game/client/tf/c_obj_teleporter.cpp
+++ b/src/game/client/tf/c_obj_teleporter.cpp
@@ -186,6 +186,13 @@ void C_ObjectTeleporter::StopActiveEffects()
 		ParticleProp()->StopEmission( m_hChargedRightArmEffect );
 		m_hChargedRightArmEffect = NULL;
 	}
+
+	if ( m_pSpinSound && IsCarried() )
+	{
+		CSoundEnvelopeController& controller = CSoundEnvelopeController::GetController();
+		controller.SoundDestroy( m_pSpinSound );
+		m_pSpinSound = NULL;
+	}
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This addresses an issue where a teleporter will continue playing its spin sound after being picked up by an engineer, which only stops when the teleporter is no longer being carried (e.g. placed down again, engineer dies / disconnects from the game while carrying etc.)

This also prevents another related issue in MvM where a teleporter will start playing its spin sound after being picked up even when its matching teleporter isn't online.

Before:

[before.webm](https://github.com/user-attachments/assets/5095dae9-76b7-4208-8a23-6bf617438163)

[before-mvm.webm](https://github.com/user-attachments/assets/30c08d6c-00fa-46d5-b264-5697bc2a9be9)

After:

[after.webm](https://github.com/user-attachments/assets/429a0dfe-fb92-4e72-a9c7-41655022ac43)

[after-mvm.webm](https://github.com/user-attachments/assets/7005bccc-fc4b-4c2f-8154-cb5134c3287a)