### PR TITLE
[TF2] Use correct activity in C_BaseObject placement hack

### DIFF
--- a/src/game/client/tf/c_baseobject.cpp
+++ b/src/game/client/tf/c_baseobject.cpp
@@ -420,15 +420,18 @@ void C_BaseObject::Simulate( void )
 	}
 	else if ( !IsPlacing() && !IsCarried() && m_iLastPlacementPosValid == 0 )
 	{
-		// HACK HACK: This sentry has been placed, but was placed on the server before the client updated
+		float flPlaybackRate = GetPlaybackRate();
+
+		// HACK HACK: This object has been placed, but was placed on the server before the client updated
 		// from the carry position to see that was a valid placement.
 		// It missed its chance to set the correct activity, so we're doing it now.
-		SetActivity( ACT_OBJ_RUNNING );
+		SetActivity( IsBuilding() ? ACT_OBJ_ASSEMBLING : ACT_OBJ_RUNNING );
+		SetPlaybackRate( flPlaybackRate );
 
 		// Check if the activity was valid because it might have still been using the older placement model
 		if ( GetActivity() != ACT_INVALID )
 		{
-			// Remember to retest our placement, but don't keep forcing the running activity
+			// Remember to retest our placement, but don't keep forcing the new activity
 			m_iLastPlacementPosValid = -1;
 		}
 	}


### PR DESCRIPTION
This modifies an existing hack in `C_BaseObject::Simulate` to set the correct activity on the client when an object is placed on the server before the client knows that it was a valid placement position. It also restores its animation playback rate prior to setting the activity, since setting an activity resets the playback rate to `1.0`.

Currently, the hack sets the `ACT_OBJ_RUNNING` activity, which makes objects appear dormant while they're being built. This modification sets `ACT_OBJ_ASSEMBLING` if the object is currently being built, otherwise it uses `ACT_OBJ_RUNNING`.

This also prevents another related issue in MvM where a teleporter will start playing its spin animation after being placed in this particular edge case, even when its matching teleporter isn't online.

Before:

[before.webm](https://github.com/user-attachments/assets/6f5abea2-d11e-4a0c-92c2-c82bd72c382d)

[before-mvm.webm](https://github.com/user-attachments/assets/08c04832-d9b7-4262-809b-aea379fc2568)

After:

[after.webm](https://github.com/user-attachments/assets/e2f0cf89-f500-47aa-9966-555ff9ec4360)

[after-mvm.webm](https://github.com/user-attachments/assets/a2c0d2ca-57ec-46fe-8830-ccc5b881eb9a)