### PR TITLE
[TF2] Prevent bot from realizing spy on bump while disguised as own team

### DIFF
--- a/src/game/server/tf/bot/tf_bot.cpp
+++ b/src/game/server/tf/bot/tf_bot.cpp
@@ -1449,7 +1449,7 @@ void CTFBot::Touch( CBaseEntity *pOther )
 	CTFPlayer *them = ToTFPlayer( pOther );
 	if ( them && IsEnemy( them ) )
 	{
-		if ( them->m_Shared.IsStealthed() || them->m_Shared.InCond( TF_COND_DISGUISED ) )
+		if ( them->m_Shared.IsStealthed() || ( them->m_Shared.InCond( TF_COND_DISGUISED ) && them->m_Shared.GetDisguiseTeam() == GetTeamNumber() ) )
 		{
 			// bumped a spy - they are discovered!
 			if ( TFGameRules()->IsMannVsMachineMode() )	// we have to build up to knowing that they are a spy in MvM


### PR DESCRIPTION
This prevents bots from realizing an enemy spy when making contact with them while the spy is disguised as his own team, as the bump rule does not indicate whether they are a spy in this case.

Note that the `nb_blind` console variable is changed in the videos to prevent the bot from prematurely realizing that the player is a spy after seeing them disguise. The bot is also not attacking the player because the round is in the setup phase.

Before:

[before.webm](https://github.com/user-attachments/assets/b1111dcd-9ecf-43f5-8fcd-2df9865d4630)

After:

[after.webm](https://github.com/user-attachments/assets/3c3837a1-c8d8-4458-8110-21dea9439547)