### PR TITLE
[MP] Globalize -unrestricted_maxplayers behavior across all mods

### DIFF
--- a/src/game/client/client_hl2mp.vpc
+++ b/src/game/client/client_hl2mp.vpc
@@ -8,6 +8,10 @@ $Macro SRCDIR		"..\.."
 $Macro GAMENAME 	"hl2mp" [!$SOURCESDK]
 $Macro GAMENAME 	"mod_hl2mp" [$SOURCESDK]
 
+// Allows higher player counts on mp games
+// This turns on flag UNRESTRICTED_MAXPLAYERS across the entire project
+$Conditional UNRESTRICTED_MAXPLAYERS_ENABLE 1
+
 $Include "$SRCDIR\game\client\client_base.vpc"
 
 $Configuration

--- a/src/game/client/client_tf.vpc
+++ b/src/game/client/client_tf.vpc
@@ -11,6 +11,10 @@ $Macro GAMENAME 	"mod_tf" [$SOURCESDK]
 // This code currently only builds on Windows (itemtest_lib and dependencies)
 $Conditional WORKSHOP_IMPORT_ENABLE	1 [$WINDOWS && !$SOURCESDK]
 
+// Allows higher player counts on mp games
+// This turns on flag UNRESTRICTED_MAXPLAYERS across the entire project
+$Conditional UNRESTRICTED_MAXPLAYERS_ENABLE 1
+
 $Include "$SRCDIR\game\client\client_base.vpc"
 $include "$SRCDIR\game\shared\tf\tf_gcmessages_include.vpc"
 $include "$SRCDIR\game\shared\tf\tf_proto_def_messages_include.vpc"

--- a/src/game/server/base_gameinterface.cpp
+++ b/src/game/server/base_gameinterface.cpp
@@ -11,29 +11,31 @@
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"
 
-void CServerGameClients::GetPlayerLimits( int& minplayers, int& maxplayers, int &defaultMaxPlayers ) const
+void CServerGameClients::GetPlayerLimits(int& minplayers, int& maxplayers, int& defaultMaxPlayers) const
 {
 	minplayers = defaultMaxPlayers = 1;
 
 	// Pivot (25/02/2026): If targeting amd64 platforms AND conditional UNRESTRICTED_MAXPLAYERS_ENABLE
 	// set to 1 in game project vpc, raise to MAX_PLAYERS limit specified in game/shared/shareddefs.h.
-	
+
 	// Code adapted from game/server/tf/tf_gameinterface.cpp
-#if defined( PLATFORM_64BITS ) && defined( UNRESTRICTED_MAXPLAYERS )	// Assuming amd64
+#ifdef UNRESTRICTED_MAXPLAYERS
+#ifdef PLATFORM_64BITS	// Assuming amd64
 	maxplayers = MAX_PLAYERS;
-#elif !defined ( PLATFORM_64BITS ) && defined( UNRESTRICTED_MAXPLAYERS )	// Assuming x86/i686
-	if ( CommandLine()->HasParm("-unrestricted_maxplayers") )
+#else	// Assuming x86/i686
+	if (CommandLine()->HasParm("-unrestricted_maxplayers"))
 	{
 		static bool s_bWarned = false;
-		if ( !s_bWarned )
+		if (!s_bWarned)
 		{
-			Warning( "The use of -unrestricted_maxplayers is NOT supported and definitely NOT recommended and may be unstable.\n" );
+			Warning("The use of -unrestricted_maxplayers is NOT supported and definitely NOT recommended and may be unstable.\n");
 			s_bWarned = true;
 		}
 		maxplayers = MAX_PLAYERS;
 	}
 	else
 		maxplayers = 33;	// Accounting for one extra SourceTV client.
+#endif
 #else 
 	maxplayers = MAX_PLAYERS;	// MAX_PLAYERS = 33
 #endif
@@ -44,6 +46,6 @@ void CServerGameClients::GetPlayerLimits( int& minplayers, int& maxplayers, int 
 // Mod-specific CServerGameDLL implementation.
 // -------------------------------------------------------------------------------------------- //
 
-void CServerGameDLL::LevelInit_ParseAllEntities( const char *pMapEntities )
+void CServerGameDLL::LevelInit_ParseAllEntities(const char* pMapEntities)
 {
 }

--- a/src/game/server/base_gameinterface.cpp
+++ b/src/game/server/base_gameinterface.cpp
@@ -13,8 +13,30 @@
 
 void CServerGameClients::GetPlayerLimits( int& minplayers, int& maxplayers, int &defaultMaxPlayers ) const
 {
-	minplayers = defaultMaxPlayers = 1; 
+	minplayers = defaultMaxPlayers = 1;
+
+	// Pivot (25/02/2026): If targeting amd64 platforms AND conditional UNRESTRICTED_MAXPLAYERS_ENABLE
+	// set to 1 in game project vpc, raise to MAX_PLAYERS limit specified in game/shared/shareddefs.h.
+	
+	// Code adapted from game/server/tf/tf_gameinterface.cpp
+#if defined( PLATFORM_64BITS ) && defined( UNRESTRICTED_MAXPLAYERS )	// Assuming amd64
 	maxplayers = MAX_PLAYERS;
+#elif !defined ( PLATFORM_64BITS ) && defined( UNRESTRICTED_MAXPLAYERS )	// Assuming x86/i686
+	if ( CommandLine()->HasParm("-unrestricted_maxplayers") )
+	{
+		static bool s_bWarned = false;
+		if ( !s_bWarned )
+		{
+			Warning( "The use of -unrestricted_maxplayers is NOT supported and definitely NOT recommended and may be unstable.\n" );
+			s_bWarned = true;
+		}
+		maxplayers = MAX_PLAYERS;
+	}
+	else
+		maxplayers = 33;	// Accounting for one extra SourceTV client.
+#else 
+	maxplayers = MAX_PLAYERS;	// MAX_PLAYERS = 33
+#endif
 }
 
 

--- a/src/game/server/hl2mp/hl2mp_gameinterface.cpp
+++ b/src/game/server/hl2mp/hl2mp_gameinterface.cpp
@@ -20,9 +20,12 @@
 void CServerGameClients::GetPlayerLimits( int& minplayers, int& maxplayers, int &defaultMaxPlayers ) const
 {
 	minplayers = 2;
-#ifdef PLATFORM_64BITS
+	
+	// Pivot (25/02/2026): If targeting amd64 platforms AND conditional UNRESTRICTED_MAXPLAYERS_ENABLE
+	// set to 1 in game project vpc, raise to MAX_PLAYERS limit specified in game/shared/shareddefs.h.
+#if defined( PLATFORM_64BITS ) && defined( UNRESTRICTED_MAXPLAYERS )	// Assuming amd64
 	maxplayers = MAX_PLAYERS;
-#else
+#elif !defined ( PLATFORM_64BITS ) && defined( UNRESTRICTED_MAXPLAYERS )	// Assuming x86/i686
 	if ( CommandLine()->HasParm("-unrestricted_maxplayers") )
 	{
 		static bool s_bWarned = false;
@@ -34,7 +37,9 @@ void CServerGameClients::GetPlayerLimits( int& minplayers, int& maxplayers, int 
 		maxplayers = MAX_PLAYERS;
 	}
 	else
-		maxplayers = 33;
+		maxplayers = 33;	// Accounting for one extra SourceTV client.
+#else 
+	maxplayers = MAX_PLAYERS;	// MAX_PLAYERS = 33
 #endif
 	defaultMaxPlayers = 16; // misyl: Was 2... but why would the default be 2?! Is there some very intimate HL2DM going on?
 }

--- a/src/game/server/hl2mp/hl2mp_gameinterface.cpp
+++ b/src/game/server/hl2mp/hl2mp_gameinterface.cpp
@@ -23,10 +23,11 @@ void CServerGameClients::GetPlayerLimits( int& minplayers, int& maxplayers, int 
 	
 	// Pivot (25/02/2026): If targeting amd64 platforms AND conditional UNRESTRICTED_MAXPLAYERS_ENABLE
 	// set to 1 in game project vpc, raise to MAX_PLAYERS limit specified in game/shared/shareddefs.h.
-#if defined( PLATFORM_64BITS ) && defined( UNRESTRICTED_MAXPLAYERS )	// Assuming amd64
+#ifdef UNRESTRICTED_MAXPLAYERS 
+#ifdef PLATFORM_64BITS 	// Assuming amd64
 	maxplayers = MAX_PLAYERS;
-#elif !defined ( PLATFORM_64BITS ) && defined( UNRESTRICTED_MAXPLAYERS )	// Assuming x86/i686
-	if ( CommandLine()->HasParm("-unrestricted_maxplayers") )
+#else	// Assuming x86/i686
+	if ( CommandLine()->HasParm( "-unrestricted_maxplayers" ) )
 	{
 		static bool s_bWarned = false;
 		if ( !s_bWarned )
@@ -38,6 +39,7 @@ void CServerGameClients::GetPlayerLimits( int& minplayers, int& maxplayers, int 
 	}
 	else
 		maxplayers = 33;	// Accounting for one extra SourceTV client.
+#endif
 #else 
 	maxplayers = MAX_PLAYERS;	// MAX_PLAYERS = 33
 #endif

--- a/src/game/server/server_hl2mp.vpc
+++ b/src/game/server/server_hl2mp.vpc
@@ -8,6 +8,10 @@ $Macro SRCDIR		"..\.."
 $Macro GAMENAME 	"hl2mp" [!$SOURCESDK]
 $Macro GAMENAME 	"mod_hl2mp" [$SOURCESDK]
 
+// Allows higher player counts on mp games
+// This turns on flag UNRESTRICTED_MAXPLAYERS across the entire project
+$Conditional UNRESTRICTED_MAXPLAYERS_ENABLE 1
+
 $Include "$SRCDIR\game\server\server_base.vpc"
 $Include "$SRCDIR\game\server\nav_mesh.vpc"
 

--- a/src/game/server/server_tf.vpc
+++ b/src/game/server/server_tf.vpc
@@ -8,6 +8,10 @@ $Macro SRCDIR		"..\.."
 $Macro GAMENAME 	"tf" [!$SOURCESDK]
 $Macro GAMENAME 	"mod_tf" [$SOURCESDK]
 
+// Allows higher player counts on mp games
+// This turns on flag UNRESTRICTED_MAXPLAYERS across the entire project
+$Conditional UNRESTRICTED_MAXPLAYERS_ENABLE 1
+
 $Include "$SRCDIR\game\server\server_base.vpc"
 $Include "$SRCDIR\game\server\server_econ_base.vpc"
 $include "$SRCDIR\game\shared\tf\tf_gcmessages_include.vpc"

--- a/src/game/server/tf/tf_gameinterface.cpp
+++ b/src/game/server/tf/tf_gameinterface.cpp
@@ -23,10 +23,11 @@ void CServerGameClients::GetPlayerLimits( int& minplayers, int& maxplayers, int 
 	
 	// Pivot (25/02/2026): If targeting amd64 platforms AND conditional UNRESTRICTED_MAXPLAYERS_ENABLE
 	// set to 1 in game project vpc, raise to MAX_PLAYERS limit specified in game/shared/shareddefs.h.
-#if defined( PLATFORM_64BITS ) && defined( UNRESTRICTED_MAXPLAYERS )	// Assuming amd64
+#ifdef UNRESTRICTED_MAXPLAYERS 
+#ifdef PLATFORM_64BITS 	// Assuming amd64
 	maxplayers = MAX_PLAYERS;
-#elif !defined ( PLATFORM_64BITS ) && defined ( UNRESTRICTED_MAXPLAYERS )	// Assuming x86/i686
-	if ( CommandLine()->HasParm("-unrestricted_maxplayers") )
+#else	// Assuming x86/i686
+	if ( CommandLine()->HasParm( "-unrestricted_maxplayers" ) )
 	{
 		static bool s_bWarned = false;
 		if ( !s_bWarned )
@@ -38,6 +39,7 @@ void CServerGameClients::GetPlayerLimits( int& minplayers, int& maxplayers, int 
 	}
 	else
 		maxplayers = 33;	// Accounting for one extra SourceTV client.
+#endif
 #else 
 	maxplayers = MAX_PLAYERS;	// MAX_PLAYERS = 33
 #endif

--- a/src/game/server/tf/tf_gameinterface.cpp
+++ b/src/game/server/tf/tf_gameinterface.cpp
@@ -20,9 +20,12 @@ void CServerGameClients::GetPlayerLimits( int& minplayers, int& maxplayers, int 
 	///             servers that want to have the 33rd slot can trivially do so, so just don't clamp it beyond what we
 	///             support.
 	minplayers = 2;  // Force multiplayer.
-#ifdef PLATFORM_64BITS
+	
+	// Pivot (25/02/2026): If targeting amd64 platforms AND conditional UNRESTRICTED_MAXPLAYERS_ENABLE
+	// set to 1 in game project vpc, raise to MAX_PLAYERS limit specified in game/shared/shareddefs.h.
+#if defined( PLATFORM_64BITS ) && defined( UNRESTRICTED_MAXPLAYERS )	// Assuming amd64
 	maxplayers = MAX_PLAYERS;
-#else
+#elif !defined ( PLATFORM_64BITS ) && defined ( UNRESTRICTED_MAXPLAYERS )	// Assuming x86/i686
 	if ( CommandLine()->HasParm("-unrestricted_maxplayers") )
 	{
 		static bool s_bWarned = false;
@@ -34,7 +37,9 @@ void CServerGameClients::GetPlayerLimits( int& minplayers, int& maxplayers, int 
 		maxplayers = MAX_PLAYERS;
 	}
 	else
-		maxplayers = 33;
+		maxplayers = 33;	// Accounting for one extra SourceTV client.
+#else 
+	maxplayers = MAX_PLAYERS;	// MAX_PLAYERS = 33
 #endif
 	defaultMaxPlayers = 24;
 }

--- a/src/game/shared/shareddefs.h
+++ b/src/game/shared/shareddefs.h
@@ -253,8 +253,6 @@ enum CastVote
 	#define MAX_PLAYERS				65  // Absolute max players supported (64 humans + 1 SourceTV client)
 #elif defined( UNRESTRICTED_MAXPLAYERS )	// Pivot (25/02/2026): This is now controlled by a conditional in the vpc project build scripts.
 	#define MAX_PLAYERS				101
-#elif not defined( HL2MP_DLL ) && ( defined( HL2_DLL ) || defined ( HL2_EPISODIC ) || defined ( PORTAL ) ) // Pivot (25/02/2026): Forced to 1 by singleplayer-only mods (hl2, episodic, portal).
-	#define MAX_PLAYERS				1	// Only one player for SP.
 #else
 	#define MAX_PLAYERS				33  // Absolute max players supported (32 humans + 1 SourceTV client)
 #endif

--- a/src/game/shared/shareddefs.h
+++ b/src/game/shared/shareddefs.h
@@ -250,11 +250,13 @@ enum CastVote
 //This is ok since MAX_PLAYERS is used for code specific things like arrays and loops, but it doesn't really means that this is the max number of players allowed
 //Since this is decided by the gamerules (and it can be whatever number as long as its less than MAX_PLAYERS).
 #if defined( CSTRIKE_DLL )
-	#define MAX_PLAYERS				65  // Absolute max players supported
-#elif defined( TF_DLL ) || defined ( TF_CLIENT_DLL ) || defined( HL2MP )
+	#define MAX_PLAYERS				65  // Absolute max players supported (64 humans + 1 SourceTV client)
+#elif defined( UNRESTRICTED_MAXPLAYERS )	// Pivot (25/02/2026): This is now controlled by a conditional in the vpc project build scripts.
 	#define MAX_PLAYERS				101
+#elif not defined( HL2MP_DLL ) && ( defined( HL2_DLL ) || defined ( HL2_EPISODIC ) || defined ( PORTAL_DLL ) ) // Pivot (25/02/2026): Forced to 1 by singleplayer-only mods (hl2, episodic, portal).
+	#define MAX_PLAYERS				1	// Only one player for SP.
 #else
-	#define MAX_PLAYERS				33  // Absolute max players supported
+	#define MAX_PLAYERS				33  // Absolute max players supported (32 humans + 1 SourceTV client)
 #endif
 
 // Josh: Accounts for code that may index this array by an entindex

--- a/src/game/shared/shareddefs.h
+++ b/src/game/shared/shareddefs.h
@@ -253,7 +253,7 @@ enum CastVote
 	#define MAX_PLAYERS				65  // Absolute max players supported (64 humans + 1 SourceTV client)
 #elif defined( UNRESTRICTED_MAXPLAYERS )	// Pivot (25/02/2026): This is now controlled by a conditional in the vpc project build scripts.
 	#define MAX_PLAYERS				101
-#elif not defined( HL2MP_DLL ) && ( defined( HL2_DLL ) || defined ( HL2_EPISODIC ) || defined ( PORTAL_DLL ) ) // Pivot (25/02/2026): Forced to 1 by singleplayer-only mods (hl2, episodic, portal).
+#elif not defined( HL2MP_DLL ) && ( defined( HL2_DLL ) || defined ( HL2_EPISODIC ) || defined ( PORTAL ) ) // Pivot (25/02/2026): Forced to 1 by singleplayer-only mods (hl2, episodic, portal).
 	#define MAX_PLAYERS				1	// Only one player for SP.
 #else
 	#define MAX_PLAYERS				33  // Absolute max players supported (32 humans + 1 SourceTV client)

--- a/src/game/shared/shareddefs.h
+++ b/src/game/shared/shareddefs.h
@@ -249,10 +249,10 @@ enum CastVote
 //You might be wondering why these aren't multiple of 2. Well the reason is that if servers decide to have HLTV or Replay enabled we need the extra slot.
 //This is ok since MAX_PLAYERS is used for code specific things like arrays and loops, but it doesn't really means that this is the max number of players allowed
 //Since this is decided by the gamerules (and it can be whatever number as long as its less than MAX_PLAYERS).
-#if defined( CSTRIKE_DLL )
+#if defined( UNRESTRICTED_MAXPLAYERS )	// Pivot (25/02/2026): This is now controlled by a conditional in the vpc project build scripts.
+	#define MAX_PLAYERS				101	// Absolute max players supported (100 humans + 1 SourceTV client)
+#elif defined( CSTRIKE_DLL )
 	#define MAX_PLAYERS				65  // Absolute max players supported (64 humans + 1 SourceTV client)
-#elif defined( UNRESTRICTED_MAXPLAYERS )	// Pivot (25/02/2026): This is now controlled by a conditional in the vpc project build scripts.
-	#define MAX_PLAYERS				101
 #else
 	#define MAX_PLAYERS				33  // Absolute max players supported (32 humans + 1 SourceTV client)
 #endif

--- a/src/vpc_scripts/source_base.vpc
+++ b/src/vpc_scripts/source_base.vpc
@@ -20,6 +20,7 @@ $Configuration "Debug"
 		$PreprocessorDefinitions		"$BASE;USE_MEM_DEBUG" [$USE_MEM_DEBUG]
 		$PreprocessorDefinitions		"$BASE;SOURCESDK" [$SOURCESDK]
 		$PreprocessorDefinitions		"$BASE;SOURCE_HAS_FREETYPE"
+		$PreprocessorDefinitions		"$BASE;UNRESTRICTED_MAXPLAYERS" [$UNRESTRICTED_MAXPLAYERS_ENABLE]	// Pivot (25/02/2026): Allows higher player counts on mp games
 	}
 }
 
@@ -31,5 +32,6 @@ $Configuration "Release"
 		$PreprocessorDefinitions		"VPC"
 		$PreprocessorDefinitions		"$BASE;SOURCESDK" [$SOURCESDK]
 		$PreprocessorDefinitions		"$BASE;SOURCE_HAS_FREETYPE"
+		$PreprocessorDefinitions		"$BASE;UNRESTRICTED_MAXPLAYERS" [$UNRESTRICTED_MAXPLAYERS_ENABLE]	// Pivot (25/02/2026): Allows higher player counts on mp games
 	}
 }


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
This PR eliminates the janky per-mod maxplayers `#ifdef`s in `shareddefs.h` by adding VPC conditional var `UNRESTRICTED_MAXPLAYERS_ENABLE` for all mp mod projects, which enables C++ preprocessor block `UNRESTRICTED_MAXPLAYERS`. Doing this required a slight refactor of the gameinterface object files to account for the more flexible maxplayers restrictions on amd64 and x86/i686, including the `-unrestricted_maxplayers` launch arg that is only exclusive to 32-bit builds. Mods can choose to opt-in or out of this by (not) including this conditional var. It is enabled by default in TF and HL2MP mods.

Note that this PR requires applying the same gameinterface code rewrites for other mods that do not have public source code, particularly `cstrike` and `dod` (the latter of which is exactly why this PR was made in the first place - this is essentially a cleaner way of implementing #1815, but the changes here apply to ALL games).

`UNRESTRICTED_MAXPLAYERS_ENABLE == 0` on amd64:

<img width="1920" height="846" alt="VPC var UNRESTRICTED_MAXPLAYERS_ENABLE disabled on hl2mp mod" src="https://github.com/user-attachments/assets/d13489ef-95d5-4ce0-8ffb-dabc943b6946" />

`UNRESTRICTED_MAXPLAYERS_ENABLE == 1` on amd64:

<img width="1920" height="848" alt="VPC var UNRESTRICTED_MAXPLAYERS_ENABLE enabled on hl2mp mod" src="https://github.com/user-attachments/assets/ffabf9f6-2693-4361-a2df-819d979a7cd6" />
