### PR TITLE
Fix all known broken spy disguises

### DIFF
--- a/src/game/shared/tf/tf_item_wearable.cpp
+++ b/src/game/shared/tf/tf_item_wearable.cpp
@@ -10,6 +10,7 @@
 #include "tf_gamerules.h"
 #include "animation.h"
 #include "basecombatweapon_shared.h"
+#include "tf_weapon_mechanical_arm.h"
 #ifdef CLIENT_DLL
 #include "c_tf_player.h"
 #include "model_types.h"
@@ -578,6 +579,19 @@ bool CTFWearable::UpdateBodygroups( CBaseCombatCharacter* pOwner, int iState )
 		{
 			// We must use team 0 for disguise weapons.
 			UpdateDisguiseBodygroups( pTFOwner, pDisguiseTarget, pItem, 0, iState );
+
+			CTFMechanicalArm* pMechArm = dynamic_cast<CTFMechanicalArm*>(pDisguiseWeapon);
+			if (pMechArm) {
+				// Hack, Short circuit is special case and should be off if it is the disguise weapon.
+				// Directly set the bodygroup since UpdateDisguiseBodygroups doesn't work for this weapon
+				int iDisguiseBody = pTFOwner->m_Shared.GetDisguiseBody();
+				int iBodyGroup = pDisguiseTarget->FindBodygroupByName("rightarm");
+				if (iBodyGroup != -1)
+				{
+					::SetBodygroup(pDisguiseTarget->GetModelPtr(), iDisguiseBody, iBodyGroup, 2);
+					pTFOwner->m_Shared.SetDisguiseBody(iDisguiseBody);
+				}
+			}
 		}
 	}
 

--- a/src/game/shared/tf/tf_item_wearable.cpp
+++ b/src/game/shared/tf/tf_item_wearable.cpp
@@ -517,6 +517,32 @@ void CTFWearable::ValidateModelIndex( void )
 #endif
 
 //-----------------------------------------------------------------------------
+// Purpose: Helper to apply bodygroups from an item to a disguise target.
+//-----------------------------------------------------------------------------
+void CTFWearable::UpdateDisguiseBodygroups( CTFPlayer *pTFOwner, CTFPlayer *pDisguiseTarget, CEconItemView *pItem, int iTeam, int iState )
+{
+	if ( !pTFOwner || !pDisguiseTarget || !pItem )
+		return;
+
+	int iDisguiseBody = pTFOwner->m_Shared.GetDisguiseBody();
+	int iNumBodyGroups = pItem->GetStaticData()->GetNumModifiedBodyGroups( iTeam );
+
+	for ( int i = 0; i < iNumBodyGroups; ++i )
+	{
+		int iBody = 0;
+		const char *pszBodyGroup = pItem->GetStaticData()->GetModifiedBodyGroup( iTeam, i, iBody );
+		int iBodyGroup = pDisguiseTarget->FindBodygroupByName( pszBodyGroup );
+
+		if ( iBodyGroup == -1 )
+			continue;
+
+		::SetBodygroup( pDisguiseTarget->GetModelPtr(), iDisguiseBody, iBodyGroup, iState );
+	}
+
+	pTFOwner->m_Shared.SetDisguiseBody( iDisguiseBody );
+}
+
+//-----------------------------------------------------------------------------
 // Purpose: Hides or shows masked bodygroups associated with this item.
 //-----------------------------------------------------------------------------
 bool CTFWearable::UpdateBodygroups( CBaseCombatCharacter* pOwner, int iState )
@@ -529,28 +555,30 @@ bool CTFWearable::UpdateBodygroups( CBaseCombatCharacter* pOwner, int iState )
 	if ( bBaseUpdate && m_bDisguiseWearable )
 	{
 		CEconItemView *pItem = GetAttributeContainer()->GetItem(); // Safe. Checked in base class call.
-
 		CTFPlayer *pDisguiseTarget = pTFOwner->m_Shared.GetDisguiseTarget();
 		if ( !pDisguiseTarget )
 			return false;
 
-		// Update our disguise bodygroup.
-		int iDisguiseBody = pTFOwner->m_Shared.GetDisguiseBody();
 		int iTeam = pTFOwner->m_Shared.GetDisguiseTeam();
-		int iNumBodyGroups = pItem->GetStaticData()->GetNumModifiedBodyGroups( iTeam );
-		for ( int i=0; i<iNumBodyGroups; ++i )
+		UpdateDisguiseBodygroups( pTFOwner, pDisguiseTarget, pItem, iTeam, iState );
+	}
+
+	// CEconEntity::UpdateBodygroups is broken for disguise weapons and wearables.
+	// Additionally it is missing most of the infrastructure needed to set up this function there.
+	// As such, we set up the disguise weapon along with the other wearables since this is the only place
+	// they are actually handled correctly.
+	CTFWeaponBase *pDisguiseWeapon = pTFOwner->m_Shared.GetDisguiseWeapon();
+	if ( pDisguiseWeapon )
+	{
+		CAttributeContainer *pCont = pDisguiseWeapon->GetAttributeContainer();
+		CEconItemView *pItem = pCont ? pCont->GetItem() : NULL;
+		CTFPlayer *pDisguiseTarget = pTFOwner->m_Shared.GetDisguiseTarget();
+
+		if ( pItem && pDisguiseTarget )
 		{
-			int iBody = 0;
-			const char *pszBodyGroup = pItem->GetStaticData()->GetModifiedBodyGroup( iTeam, i, iBody );
-			int iBodyGroup = pDisguiseTarget->FindBodygroupByName( pszBodyGroup );
-
-			if ( iBodyGroup == -1 )
-				continue;
-
-			::SetBodygroup( pDisguiseTarget->GetModelPtr(), iDisguiseBody, iBodyGroup, iState );
+			// We must use team 0 for disguise weapons.
+			UpdateDisguiseBodygroups( pTFOwner, pDisguiseTarget, pItem, 0, iState );
 		}
-
-		pTFOwner->m_Shared.SetDisguiseBody( iDisguiseBody );
 	}
 
 	CEconItemView *pItem = GetAttributeContainer() ? GetAttributeContainer()->GetItem() : NULL;

--- a/src/game/shared/tf/tf_item_wearable.h
+++ b/src/game/shared/tf/tf_item_wearable.h
@@ -18,6 +18,10 @@
 #if defined( CLIENT_DLL )
 #define CTFWearable C_TFWearable
 #define CTFWearableVM C_TFWearableVM
+class C_TFPlayer;
+#define CTFPlayer C_TFPlayer
+#else
+class CTFPlayer;
 #endif
 
 
@@ -74,8 +78,8 @@ public:
 protected:
 	virtual void		InternalSetPlayerDisplayModel( void );
 
-
 private:
+	void				UpdateDisguiseBodygroups( CTFPlayer *pTFOwner, CTFPlayer *pDisguiseTarget, CEconItemView *pItem, int iTeam, int iState );
 	CNetworkVar( bool, m_bDisguiseWearable );
 	CNetworkHandle( CBaseEntity, m_hWeaponAssociatedWith );
 

--- a/src/game/shared/tf/tf_player_shared.cpp
+++ b/src/game/shared/tf/tf_player_shared.cpp
@@ -1459,6 +1459,7 @@ void CTFPlayerShared::OnDataChanged( void )
 	{
 		m_hDisguiseWeapon->UpdateVisibility();
 		m_hDisguiseWeapon->UpdateParticleSystems();
+		m_hDisguiseWeapon->UpdateAttachmentModels();
 	}
 
 	// XXX(JohnS): This is not the right place to do these things, SetWeaponVisible on the *client* is just stomping
@@ -7196,6 +7197,8 @@ void CTFPlayerShared::OnRemoveDisguising( void )
 void CTFPlayerShared::OnRemoveDisguised( void )
 {
 #ifdef CLIENT_DLL
+	// Save the disguise target before clearing it, so we can mark bodygroups dirty.
+	CTFPlayer *pOldDisguiseTarget = ToTFPlayer( m_hDisguiseTarget.Get() );
 
 	if ( m_pOuter->GetPredictable() && ( !prediction->IsFirstTimePredicted() || m_bSyncingConditions ) )
 		return;
@@ -7220,7 +7223,14 @@ void CTFPlayerShared::OnRemoveDisguised( void )
 	UpdateCritBoostEffect( kCritBoost_ForceRefresh );
 	m_pOuter->UpdateSpyStateChange();
 
+	// Mark the old disguise target's bodygroups as dirty so they'll be recalculated.
+	if ( pOldDisguiseTarget )
+	{
+		pOldDisguiseTarget->SetBodygroupsDirty();
+	}
+
 #else
+
 	m_nDisguiseTeam  = TF_SPY_UNDEFINED;
 	m_nDisguiseClass.Set( TF_CLASS_UNDEFINED );
 	m_nDisguiseSkinOverride = 0;
@@ -8190,6 +8200,15 @@ void CTFPlayerShared::Disguise( int nTeam, int nClass, CTFPlayer* pDesiredTarget
 		}
 	}
 
+#ifdef CLIENT_DLL
+	// Save the old disguise target before changing disguise, so we can clean up bodygroups.
+	CTFPlayer *pOldDisguiseTarget = ToTFPlayer( m_hDisguiseTarget.Get() );
+	if ( pOldDisguiseTarget )
+	{
+		pOldDisguiseTarget->SetBodygroupsDirty();
+	}
+#endif
+
 	m_hDesiredDisguiseTarget.Set( pDesiredTarget );
 	m_nDesiredDisguiseClass = nClass;
 	m_nDesiredDisguiseTeam = nTeam;
@@ -8369,6 +8388,7 @@ void CTFPlayerShared::DetermineDisguiseWeapon( bool bForcePrimary )
 	{
 		CTFWeaponBase *pLastDisguiseWeapon = m_hDisguiseWeapon;
 		CTFWeaponBase *pFirstValidWeapon = NULL;
+
 		// Cycle through the target's weapons and see if we have a match.
 		// Note that it's possible the disguise target doesn't have a weapon in the slot we want,
 		// for example if they have replaced it with an unlockable that isn't a weapon (wearable).
@@ -8472,6 +8492,7 @@ void CTFPlayerShared::DetermineDisguiseWeapon( bool bForcePrimary )
 			m_hDisguiseWeapon->m_bDisguiseWeapon = true;
 			m_hDisguiseWeapon->SetContextThink( &CTFWeaponBase::DisguiseWeaponThink, gpGlobals->curtime + 0.5, "DisguiseWeaponThink" );
 
+			m_hDisguiseWeapon->UpdateExtraWearables();
 
 			// Ammo/clip state is displayed to attached medics
 			m_iDisguiseAmmo = 0;
@@ -8506,14 +8527,31 @@ void CTFPlayerShared::DetermineDisguiseWeapon( bool bForcePrimary )
 void CTFPlayerShared::DetermineDisguiseWearables()
 {
 	CTFPlayer *pDisguiseTarget = ToTFPlayer( m_hDisguiseTarget.Get() );
-	if ( !pDisguiseTarget )
-		return;
 
 	// Remove any existing disguise wearables.
 	RemoveDisguiseWearables();
 
-	if ( GetDisguiseClass() != pDisguiseTarget->GetPlayerClass()->GetClassIndex() )
+	if ( !pDisguiseTarget )
+	{
+		// No target exists, reset disguise body to default state.
+		SetDisguiseBody( 0 );
 		return;
+	}
+
+	if ( GetDisguiseClass() != pDisguiseTarget->GetPlayerClass()->GetClassIndex() )
+	{
+		// Class mismatch, reset disguise body to default.
+		SetDisguiseBody( 0 );
+#ifdef CLIENT_DLL
+		// Mark bodygroups dirty even when not copying wearables (class mismatch).
+		pDisguiseTarget->SetBodygroupsDirty();
+#endif
+		return;
+	}
+
+	// Reset disguise body to default before applying new wearables.
+	// This ensures old bodygroup modifications don't carry over.
+	SetDisguiseBody( 0 );
 
 	// Equip us with copies of our disguise target's wearables.
 	int iPlayerSkinOverride = 0;
@@ -8559,6 +8597,11 @@ void CTFPlayerShared::DetermineDisguiseWearables()
 	}
 
 	m_nDisguiseSkinOverride = iPlayerSkinOverride;
+
+#ifdef CLIENT_DLL
+	// Mark bodygroups dirty after creating disguise wearables.
+	pDisguiseTarget->SetBodygroupsDirty();
+#endif
 }
 
 void CTFPlayerShared::RemoveDisguiseWearables()

--- a/src/game/shared/tf/tf_weaponbase.cpp
+++ b/src/game/shared/tf/tf_weaponbase.cpp
@@ -980,7 +980,7 @@ void CTFWeaponBase::UpdateExtraWearables()
 				// Precaching may be needed here, because we allow virtually everything to be loaded on demand now.
 				pExtraWearableItem->PrecacheModel( pEconItemView->GetExtraWearableViewModel() );
 			}
-
+			pExtraWearableItem->SetDisguiseWearable(m_bDisguiseWeapon);
 			pExtraWearableItem->AddSpawnFlags( SF_NORESPAWN );
 			pExtraWearableItem->SetAlwaysAllow( true );
 			DispatchSpawn( pExtraWearableItem );
@@ -1006,6 +1006,7 @@ void CTFWeaponBase::UpdateExtraWearables()
 				pExtraWearableItem->PrecacheModel( pEconItemView->GetExtraWearableModel() );
 			}
 
+			pExtraWearableItem->SetDisguiseWearable(m_bDisguiseWeapon);
 			pExtraWearableItem->AddSpawnFlags( SF_NORESPAWN );
 			pExtraWearableItem->SetAlwaysAllow( true );
 			DispatchSpawn( pExtraWearableItem );
@@ -3296,6 +3297,87 @@ bool CTFWeaponBase::OnInternalDrawModel( ClientModelRenderInfo_t *pInfo )
 	}
 
 	return BaseClass::OnInternalDrawModel( pInfo );
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: Override for disguise weapons to use team 0 for attachment lookups
+//-----------------------------------------------------------------------------
+void CTFWeaponBase::UpdateAttachmentModels( void )
+{
+#ifdef CLIENT_DLL
+	// For disguise weapons, we need to use the disguise target's team when fetching attachment models
+	// because GetTeamNumber() returns the spy's team, not the disguised target's team.
+	if ( m_bDisguiseWeapon )
+	{
+		C_TFPlayer *pOwner = ToTFPlayer( GetOwnerEntity() );
+		if ( !pOwner )
+		{
+			BaseClass::UpdateAttachmentModels();
+			return;
+		}
+
+		C_TFPlayer *pDisguiseTarget = pOwner->m_Shared.GetDisguiseTarget();
+		int iTeamNumber = pDisguiseTarget ? pDisguiseTarget->GetTeamNumber() : 0;
+
+		CEconItemView *pItem = GetAttributeContainer()->GetItem();
+		GameItemDefinition_t *pItemDef = pItem && pItem->IsValid() ? pItem->GetStaticData() : NULL;
+
+		// Update the state of additional model attachments
+		m_vecAttachedModels.Purge();
+		if ( pItemDef && AttachmentModelsShouldBeVisible() )
+		{
+			{
+				int iAttachedModels = pItemDef->GetNumAttachedModels( iTeamNumber );
+				for ( int i = 0; i < iAttachedModels; i++ )
+				{
+					attachedmodel_t	*pModel = pItemDef->GetAttachedModelData( iTeamNumber, i );
+
+					int iModelIndex = modelinfo->GetModelIndex( pModel->m_pszModelName );
+					if ( iModelIndex >= 0 )
+					{
+						AttachedModelData_t attachedModelData;
+						attachedModelData.m_pModel			   = modelinfo->GetModel( iModelIndex );
+						attachedModelData.m_iModelDisplayFlags = pModel->m_iModelDisplayFlags;
+						m_vecAttachedModels.AddToTail( attachedModelData );
+					}
+				}
+			}
+
+			// Check for Festive attachedmodels for festivized weapons
+			{
+				int iAttachedModels = pItemDef->GetNumAttachedModelsFestivized( iTeamNumber );
+				if ( iAttachedModels )
+				{
+					int iFestivized = 0;
+					CALL_ATTRIB_HOOK_INT( iFestivized, is_festivized );
+					if ( iFestivized )
+					{
+						for ( int i = 0; i < iAttachedModels; i++ )
+						{
+							attachedmodel_t	*pModel = pItemDef->GetAttachedModelDataFestivized( iTeamNumber, i );
+
+							int iModelIndex = modelinfo->GetModelIndex( pModel->m_pszModelName );
+							if ( iModelIndex >= 0 )
+							{
+								AttachedModelData_t attachedModelData;
+								attachedModelData.m_pModel = modelinfo->GetModel( iModelIndex );
+								attachedModelData.m_iModelDisplayFlags = pModel->m_iModelDisplayFlags;
+								m_vecAttachedModels.AddToTail( attachedModelData );
+							}
+						}
+					}
+				}
+			}
+		}
+		// Note: We skip the viewmodel attachment section (ShouldAttachToHands) because
+		// disguise weapons are world models only and don't need viewmodel attachments.
+	}
+	else
+	{
+		// Normal weapons use the base class implementation
+		BaseClass::UpdateAttachmentModels();
+	}
+#endif
 }
 
 void CTFWeaponBase::ProcessMuzzleFlashEvent( void )

--- a/src/game/shared/tf/tf_weaponbase.h
+++ b/src/game/shared/tf/tf_weaponbase.h
@@ -586,6 +586,7 @@ class CTFWeaponBase : public CBaseCombatWeapon, public IHasOwner, public IHasGen
 	virtual	float	CalcViewmodelBob( void );
 	BobState_t		*GetBobState();
 	virtual bool	AttachmentModelsShouldBeVisible( void ) OVERRIDE { return (m_iState == WEAPON_IS_ACTIVE) && !IsBeingRepurposedForTaunt(); }
+	virtual void	UpdateAttachmentModels( void ) OVERRIDE;
 
 	virtual bool ShouldEjectBrass() { return true; }
 


### PR DESCRIPTION
# Description

This commit solves almost all bugs related to spy disguises. Particularly this solves:

* Wearables for weapons that have "extraWearables". Upon pressing last disguise on the relevant item slot, The spy will receive the wearable until he switches his class disguise even if he switches disguise weapons. This version of the fix increases the skill ceiling of spy while reducing code blast radius. This was leaked checked and extra wearables are cleaned up correctly. 

* Bad body group settings for weapons like the quickfix and vaccinator. In the medigun case this results in correct backpacks being placed for all mediguns for disguised spies. 

* Weapon attachment models. The Kritzkrieg now renders correctly. Festivizers and botkillers should also now work (not tested due to item test limitations)

* Bodygroups are now cleaned up on disguise change and removal. This removes several bugs resulting in headless pyro, footless scout, footless demo. This was tested by spawning a scout with the bat hat which removes the head body group from pyro + the feet bodygroup from demo. I believe body groups from the target player were being transferred over  even if the player wasnt the right class. I also believe disguise body groups weren't cleaned up on change. 

Tested and confirmed:
* The QuickFix
* Battalions Back up
* Buff Banner
* Thermal thruster (Only inactive state, but this allows for additional valid disguises so is an improvement)
* Councheror
* Vaccinator
* Base Jumper
* Kritzkrieg
* Huntsman (only if the target or the spy has a wearable)
*  sydney sleeper (only if the target or the spy has a wearable)
*  Gunslinger (only if the target or the spy has a wearable)
* short circuit  (only if the target or the spy has a wearable) + this should be your last weapon disguise as engi to avoid body group issues
*  GRU + other heavy melees (only if the target or the spy has a wearable) + this should be your last weapon disguise as Heavy to avoid body group issues
* Fixed body groups for pyro head, demo feet, scout feet

None of these conditions are regression and should cover 99% of disguises in game



**Before fix:**
<img width="3440" height="1440" alt="Screenshot (2)" src="https://github.com/user-attachments/assets/0f8c014e-7175-43cd-9c30-d87b3b4d1259" />
<img width="1880" height="1439" alt="Screenshot 2026-03-04 195150" src="https://github.com/user-attachments/assets/3f2e275b-b924-4754-8b62-52b78783e0d8" />
![440_1585](https://github.com/user-attachments/assets/bc328e42-e05c-4faf-af8b-d616a01ca24e)

![440_1587](https://github.com/user-attachments/assets/9dd94917-a1f4-4c28-80d0-68c42cd897ee)


**After fix:**
<img width="3440" height="1440" alt="Screenshot (10)" src="https://github.com/user-attachments/assets/d9622341-7ee9-47fe-9593-c1d73de443e2" />
<img width="3440" height="1440" alt="Screenshot (12)" src="https://github.com/user-attachments/assets/d3b000fc-25fd-458c-9e9c-cd63797c8239" />
<img width="3440" height="1440" alt="Screenshot (11)" src="https://github.com/user-attachments/assets/00efaa1d-fcf3-4aa5-8068-3d7df3c60ea0" />
<img width="3439" height="1429" alt="Screenshot 2026-03-04 205357" src="https://github.com/user-attachments/assets/4e59eb83-efd1-4a43-8315-3a777857ac7a" />
<img width="3439" height="1439" alt="Screenshot 2026-03-04 194425" src="https://github.com/user-attachments/assets/4a337427-7f6d-46b1-a4fe-85564579b0e8" />
<img width="3439" height="1439" alt="Screenshot 2026-03-04 194212" src="https://github.com/user-attachments/assets/78d7b4c9-91c6-42c7-ac90-3cf6997db42c" />
<img width="3439" height="1439" alt="Screenshot 2026-03-04 194115" src="https://github.com/user-attachments/assets/22e0de01-6faf-47b9-bb94-d9980c3f6154" />
<img width="3115" height="1319" alt="Screenshot 2026-03-04 174719" src="https://github.com/user-attachments/assets/bd64cb3b-5f40-48d5-a822-91d139c78529" />

Testing:

Testing was done in item test for both teams. Swaps were done to other disguise to test against regressions. Leaks were tested for with report_entities. I did not find a regression and this results in many more valid disguises. 

 I got a fix for every visual bug listed on the wiki https://wiki.teamfortress.com/wiki/Disguise_Kit.

closes https://github.com/ValveSoftware/Source-1-Games/issues/275
closes https://github.com/ValveSoftware/Source-1-Games/issues/5883
closes https://github.com/ValveSoftware/Source-1-Games/issues/7498

  Short circuit is a bit of a hack :) 

 These commits are merged to prevent regressions involving bodygroups, since bodygroups are actually processed. Code Hygiene was enforced with the help of Claude. These bug fixes were done to the best of my ability.  A prior version of this PR was here and will be closed. https://github.com/ValveSoftware/source-sdk-2013/pull/1599