### PR TITLE
[TF2] Allow bots to realize decloaking spies

### DIFF
--- a/src/game/server/tf/bot/tf_bot_vision.cpp
+++ b/src/game/server/tf/bot/tf_bot_vision.cpp
@@ -277,7 +277,7 @@ bool CTFBotVision::IsIgnored( CBaseEntity *subject ) const
 			return true;
 		}
 
-		if ( enemy->m_Shared.IsStealthed() )
+		if ( !enemy->m_Shared.IsFullyVisible() )
 		{
 			if ( enemy->m_Shared.GetPercentInvisible() < 0.75f )
 			{
@@ -372,7 +372,7 @@ bool CTFBotVision::IsVisibleEntityNoticed( CBaseEntity *subject ) const
 			return false;
 		}
 
-		if ( player->m_Shared.IsStealthed() )
+		if ( !player->m_Shared.IsFullyVisible() )
 		{
 			if ( player->m_Shared.GetPercentInvisible() < 0.75f )
 			{

--- a/src/game/shared/tf/tf_player_shared.h
+++ b/src/game/shared/tf/tf_player_shared.h
@@ -466,7 +466,7 @@ public:
 	float	GetLastStealthExposedTime( void ) { return m_flLastStealthExposeTime; }
 	void	SetNextStealthTime( float flTime ) { m_flStealthNextChangeTime = flTime; }
 	bool	IsFullyInvisible( void ) { return ( GetPercentInvisible() == 1.f ); }
-
+	bool	IsFullyVisible( void ) { return ( GetPercentInvisible() == 0.f ); }
 	bool	IsEnteringOrExitingFullyInvisible( void );
 
 	bool	CanRuneCharge() const;


### PR DESCRIPTION
This allows bots to realize a spy that is decloaking. Currently, bots will only realize a spy that is cloaking, due to `TF_COND_STEALTHED` being removed immediately when decloaking.

This replaces the condition check with the new proposed `CTFPlayerShared::IsFullyVisible`, which will check if the spy is either partially or fully cloaked.

Please note that the comparison videos shown below require audio to be unmuted to hear the bot call the player a spy. The bot does not attack the player due to the round being in the setup phase.

Before:

[before.webm](https://github.com/user-attachments/assets/3da3ece1-a1ee-4ac1-bc11-c578688a7bcc)

After:

[after.webm](https://github.com/user-attachments/assets/54b5eb14-e72a-4fb1-b03e-ff159f3f3da7)
