### PR TITLE
[TF2] Fix next-map vote UI becoming unresponsive to mouse input

### DIFF
--- a/src/game/client/tf/vgui/tf_matchmaking_dashboard_next_map_voting.cpp
+++ b/src/game/client/tf/vgui/tf_matchmaking_dashboard_next_map_voting.cpp
@@ -87,7 +87,7 @@ public:
 		}
 	}
 
-	virtual bool ShouldBeActve() const OVERRIDE
+	virtual bool ShouldBeActive() const OVERRIDE
 	{
 
 		if ( engine->IsInGame() &&
@@ -123,6 +123,7 @@ public:
 	virtual void FireGameEvent( IGameEvent *pEvent )
 	{
 		if ( FStrEq( pEvent->GetName(), "player_next_map_vote_change" ) &&
+			 TFGameRules() &&
 			 TFGameRules()->GetCurrentNextMapVotingState() == CTFGameRules::NEXT_MAP_VOTE_STATE_WAITING_FOR_USERS_TO_VOTE )
 		{
 			ShowVoteByOtherPlayer( pEvent->GetInt( "map_index" ) );
@@ -139,8 +140,11 @@ public:
 
 	virtual void OnEnter() OVERRIDE
 	{
+		// Needs to be here so the InvalidateLayout below runs with input enabled
+		SetMouseInputEnabled( true );
+
 		// To get the voting options setup how they're supposed to be
-		InvalidateLayout( true, false);
+		InvalidateLayout( true, false );
 
 		SetHidden( false );
 
@@ -180,6 +184,11 @@ private:
 			EditablePanel* pMapChoice = FindControl< EditablePanel >( CFmtStr( "MapChoice%d", nIndex ), true );
 			if ( pMapChoice )
 			{
+				// VGUI's SetMouseInputEnabled does not propagate to children, so when
+				// CMMDashboardParentManager reparents this panel, sub-panels can end up
+				// with mouse input disabled
+				pMapChoice->SetMouseInputEnabled( true );
+
 				ScalableImagePanel* pMapImage = pMapChoice->FindControl< ScalableImagePanel >( "MapImage", true );
 			
 				// The image

--- a/src/game/client/tf/vgui/tf_matchmaking_dashboard_next_map_winner.cpp
+++ b/src/game/client/tf/vgui/tf_matchmaking_dashboard_next_map_winner.cpp
@@ -32,14 +32,17 @@ public:
 		BaseClass::ApplySchemeSettings( pScheme );
 	}
 
-	virtual bool ShouldBeActve() const OVERRIDE
+	virtual bool ShouldBeActive() const OVERRIDE
 	{
+		if ( !TFGameRules() )
+		{
+			return false;
+		}
 
 		int nVotes[ CTFGameRules::EUserNextMapVote::NUM_VOTE_STATES ];
 		CTFGameRules::EUserNextMapVote eWinningVote = TFGameRules()->GetWinningVote( nVotes );
 
 		if ( BInEndOfMatch() &&
-			 TFGameRules() &&
 			 TFGameRules()->GetCurrentNextMapVotingState() == CTFGameRules::NEXT_MAP_VOTE_STATE_MAP_CHOSEN_PAUSE &&
 			 eWinningVote != CTFGameRules::USER_NEXT_MAP_VOTE_UNDECIDED && 
 			 GTFGCClientSystem()->BConnectedToMatchServer( false ) )

--- a/src/game/client/tf/vgui/tf_matchmaking_dashboard_popup.cpp
+++ b/src/game/client/tf/vgui/tf_matchmaking_dashboard_popup.cpp
@@ -99,13 +99,18 @@ void CTFMatchmakingPopup::OnThink()
 	{
 		OnUpdate();
 	}
+
+	// Doing this in OnThink rather than OnTick closes the window
+	// where reparenting between ticks could leave the UI unresponsive
+	SetMouseInputEnabled( m_bActive );
+	SetKeyBoardInputEnabled( false ); // Never
 }
 
 void CTFMatchmakingPopup::OnTick()
 {
 	BaseClass::OnTick();
 
-	bool bShouldBeActive = ShouldBeActve();
+	bool bShouldBeActive = ShouldBeActive();
 	if ( bShouldBeActive != m_bActive )
 	{
 		if ( bShouldBeActive )
@@ -119,16 +124,13 @@ void CTFMatchmakingPopup::OnTick()
 			OnExit();
 		}
 	}
-
-	SetMouseInputEnabled( ShouldBeActve() );
-	SetKeyBoardInputEnabled( false ); // Never
 }
 
 void CTFMatchmakingPopup::FireGameEvent( IGameEvent *pEvent )
 {
 	if ( FStrEq( pEvent->GetName(), "party_updated" ) )
 	{
-		if ( ShouldBeActve() )
+		if ( ShouldBeActive() )
 		{
 			Update();
 		}

--- a/src/game/client/tf/vgui/tf_matchmaking_dashboard_popup.h
+++ b/src/game/client/tf/vgui/tf_matchmaking_dashboard_popup.h
@@ -42,7 +42,7 @@ public:
 	virtual void FireGameEvent( IGameEvent *pEvent ) OVERRIDE;
 
 private:
-	virtual bool ShouldBeActve() const = 0;
+	virtual bool ShouldBeActive() const = 0;
 	void UpdateRematchtime();
 	void UpdateAutoJoinTime();
 


### PR DESCRIPTION
# Description

Fixes the bug in Casual mode where the next-map voting panel becomes unresponsive to mouse input (no hover highlights, no clicks) for all players on the server. Players are unable to interact with the vote user interface, but it is still visible, and the timer and percentages are still updating. Using `next_map_vote <0/1/2>` in the console is a known workaround.

https://github.com/user-attachments/assets/ba26226e-2d2b-4052-b83b-e78836955cd7

# Fix
Tested on live Casual servers using memory injection. In a match where the UI became unresponsive for the entire server (confirmed via a party member playing on a stock game client), the patched client worked as expected.