### PR TITLE
[TF2] Fix cl_muzzleflash_dlight_1st and disable it by default.

### DIFF
--- a/src/game/client/tf/tf_fx_muzzleflash.cpp
+++ b/src/game/client/tf/tf_fx_muzzleflash.cpp
@@ -32,7 +32,7 @@ CLIENTEFFECT_REGISTER_BEGIN( PrecacheEffect_TF_MuzzleFlash )
 	CLIENTEFFECT_MATERIAL( "effects/muzzleflash4" )
 CLIENTEFFECT_REGISTER_END()
 
-ConVar cl_muzzleflash_dlight_1st( "cl_muzzleflash_dlight_1st", "1" );
+ConVar cl_muzzleflash_dlight_1st( "cl_muzzleflash_dlight_1st", "0", FCVAR_ARCHIVE );
 
 void TE_DynamicLight( IRecipientFilter& filter, float delay,
 	const Vector* org, int r, int g, int b, int exponent, float radius, float time, float decay, int nLightIndex = LIGHT_INDEX_TE_DYNAMIC );

--- a/src/game/shared/tf/tf_weapon_minigun.cpp
+++ b/src/game/shared/tf/tf_weapon_minigun.cpp
@@ -35,6 +35,10 @@
 #define TF_MINIGUN_SPINUP_TIME 0.75f
 #define TF_MINIGUN_PENALTY_PERIOD 1.f
 
+#ifdef CLIENT_DLL
+extern ConVar cl_muzzleflash_dlight_1st;
+#endif
+
 //=============================================================================
 //
 // Weapon Minigun tables.
@@ -365,6 +369,32 @@ void CTFMinigun::SharedAttack()
 					// NVNT the local player fired a shot. notify the haptics system.
 					if ( haptics )
 						haptics->ProcessHapticEvent(2,"Weapons","minigun_fire");
+
+
+					if ( cl_muzzleflash_dlight_1st.GetBool() == true && IsFirstPersonView() )
+					{
+						Vector vecOrigin;
+						QAngle angAngles;
+						void TE_DynamicLight( IRecipientFilter& filter, float delay,
+							const Vector* org, int r, int g, int b, int exponent, float radius, float time, float decay, int nLightIndex = LIGHT_INDEX_TE_DYNAMIC );
+
+						m_hMuzzleEffectWeapon = GetWeaponForEffect();
+
+						// Try and setup the attachment point if it doesn't already exist.
+						// This caching will mess up if we go third person from first - we only do this in taunts and don't fire so we should
+						// be okay for now.
+						if ( m_iMuzzleAttachment <= 0 )
+						{
+							m_iMuzzleAttachment = m_hMuzzleEffectWeapon->LookupAttachment( "muzzle" );
+						}
+						m_hMuzzleEffectWeapon->GetAttachment( m_iMuzzleAttachment, vecOrigin, angAngles );
+
+						if ( m_iMuzzleAttachment > 0 )
+						{
+							CLocalPlayerFilter filter;
+							TE_DynamicLight( filter, 0.0f, &vecOrigin, 255, 192, 64, 5, 70.0f, 0.2f, 70.0f / 0.2f, LIGHT_INDEX_MUZZLEFLASH );
+						}
+					}
 				}
 #endif
 				CalcIsAttackCritical();

--- a/src/game/shared/tf/tf_weaponbase.cpp
+++ b/src/game/shared/tf/tf_weaponbase.cpp
@@ -92,6 +92,7 @@ extern ConVar tf_weapon_criticals_bucket_bottom;
 
 #ifdef CLIENT_DLL
 extern ConVar cl_crosshair_file;
+extern ConVar cl_muzzleflash_dlight_1st;
 #endif
 
 //=============================================================================
@@ -3130,10 +3131,11 @@ void CTFWeaponBase::CreateMuzzleFlashEffects( C_BaseEntity *pAttachEnt, int nInd
 		pAttachEnt->GetAttachment( iMuzzleFlashAttachment, vecOrigin, angAngles );
 
 		// Muzzleflash light
-/*
-		CLocalPlayerFilter filter;
-		TE_DynamicLight( filter, 0.0f, &vecOrigin, 255, 192, 64, 5, 70.0f, 0.05f, 70.0f / 0.05f, LIGHT_INDEX_MUZZLEFLASH );
-*/
+		if ( cl_muzzleflash_dlight_1st.GetBool() == true && IsFirstPersonView() )
+		{
+			CLocalPlayerFilter filter;
+			TE_DynamicLight( filter, 0.0f, &vecOrigin, 255, 192, 64, 5, 70.0f, 0.05f, 70.0f / 0.05f, LIGHT_INDEX_MUZZLEFLASH );
+		}
 
 		if ( pszMuzzleFlashEffect )
 		{


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

Fixes cl_muzzleflash_dlight_1st, making the muzzleflash dynamic light appear in first person, and disables it by default. The Minigun muzzleflash dynamic light dissipates slower to match the "fire rate" better.

https://github.com/user-attachments/assets/54f0cc1d-2d7f-4b52-8342-6c497d6c1e9c

https://github.com/user-attachments/assets/a1976f7e-787d-4fdb-a542-576ba5bd2766

