### PR TITLE
Fix: scattergun that has knockback cannot be fired on preround

### DIFF
--- a/src/game/shared/tf/tf_weapon_shotgun.cpp
+++ b/src/game/shared/tf/tf_weapon_shotgun.cpp
@@ -318,14 +318,6 @@ void CTFScatterGun::FireBullet( CTFPlayer *pPlayer )
 {
 	if ( HasKnockback() )
 	{
-		// Perform some knock back.
-		CTFPlayer *pOwner = ToTFPlayer( GetPlayerOwner() );
-		if ( !pOwner )
-		{
-			BaseClass::FireBullet( pPlayer );
-			return;
-		}
-
 		// No knockback during pre-round freeze.
 		if ( TFGameRules() && (TFGameRules()->State_Get() == GR_STATE_PREROUND) )
 		{
@@ -334,35 +326,35 @@ void CTFScatterGun::FireBullet( CTFPlayer *pPlayer )
 		}
 
 		// Knock the firer back!
-		if ( !(pOwner->GetFlags() & FL_ONGROUND) && !pPlayer->m_Shared.m_bScattergunJump )
+		if ( !(pPlayer->GetFlags() & FL_ONGROUND) && !pPlayer->m_Shared.m_bScattergunJump )
 		{
 			pPlayer->m_Shared.m_bScattergunJump = true;
 
-			pOwner->m_Shared.StunPlayer( 0.3f, 1.f, TF_STUN_MOVEMENT | TF_STUN_MOVEMENT_FORWARD_ONLY );
+			pPlayer->m_Shared.StunPlayer( 0.3f, 1.f, TF_STUN_MOVEMENT | TF_STUN_MOVEMENT_FORWARD_ONLY );
 
-			float flForce = AirBurstDamageForce( pOwner->WorldAlignSize(), 60, 6.f );
+			float flForce = AirBurstDamageForce( pPlayer->WorldAlignSize(), 60, 6.f );
 
 			Vector vecForward;
-			AngleVectors( pOwner->EyeAngles(), &vecForward );
+			AngleVectors( pPlayer->EyeAngles(), &vecForward );
 			Vector vecForce = vecForward * -flForce;
 
 			VMatrix mtxPlayer;
-			mtxPlayer.SetupMatrixOrgAngles( pOwner->GetAbsOrigin(), pOwner->EyeAngles() );
-			Vector vecAbsVelocity = pOwner->GetAbsVelocity();
-			Vector vecAbsVelocityAsPoint = vecAbsVelocity + pOwner->GetAbsOrigin();
+			mtxPlayer.SetupMatrixOrgAngles( pPlayer->GetAbsOrigin(), pPlayer->EyeAngles() );
+			Vector vecAbsVelocity = pPlayer->GetAbsVelocity();
+			Vector vecAbsVelocityAsPoint = vecAbsVelocity + pPlayer->GetAbsOrigin();
 			Vector vecLocalVelocity = mtxPlayer.VMul4x3Transpose( vecAbsVelocityAsPoint );
 
 			vecLocalVelocity.x = -300;
 
 			vecAbsVelocityAsPoint = mtxPlayer.VMul4x3( vecLocalVelocity );
-			vecAbsVelocity = vecAbsVelocityAsPoint - pOwner->GetAbsOrigin();
-			pOwner->SetAbsVelocity( vecAbsVelocity );
+			vecAbsVelocity = vecAbsVelocityAsPoint - pPlayer->GetAbsOrigin();
+			pPlayer->SetAbsVelocity( vecAbsVelocity );
 
 			// Impulse an additional bit of Z push.
-			pOwner->ApplyAbsVelocityImpulse( Vector(0,0,50.f) );
+			pPlayer->ApplyAbsVelocityImpulse( Vector(0,0,50.f) );
 
 			// Slow player movement for a brief period of time.
-			pOwner->RemoveFlag( FL_ONGROUND );
+			pPlayer->RemoveFlag( FL_ONGROUND );
 		}
 	}
 

--- a/src/game/shared/tf/tf_weapon_shotgun.cpp
+++ b/src/game/shared/tf/tf_weapon_shotgun.cpp
@@ -321,11 +321,17 @@ void CTFScatterGun::FireBullet( CTFPlayer *pPlayer )
 		// Perform some knock back.
 		CTFPlayer *pOwner = ToTFPlayer( GetPlayerOwner() );
 		if ( !pOwner )
+		{
+			BaseClass::FireBullet( pPlayer );
 			return;
+		}
 
 		// No knockback during pre-round freeze.
 		if ( TFGameRules() && (TFGameRules()->State_Get() == GR_STATE_PREROUND) )
+		{
+			BaseClass::FireBullet( pPlayer );
 			return;
+		}
 
 		// Knock the firer back!
 		if ( !(pOwner->GetFlags() & FL_ONGROUND) && !pPlayer->m_Shared.m_bScattergunJump )


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->
# Description
- During the pre-round (before setup time finishes), the `CTFScattergun` with the `set_scattergun_has_knockback` attribute set to 1 cannot be fired because the code bypasses `BaseClass::FireBullet`. This PR fixes that behavior.
