### PR TITLE
[TF2] Modify check in `CTFGameRules::GetAssister`

### DIFF
--- a/src/game/shared/tf/tf_gamerules.cpp
+++ b/src/game/shared/tf/tf_gamerules.cpp
@@ -12707,7 +12707,8 @@ CBasePlayer *CTFGameRules::GetAssister( CBasePlayer *pVictim, CBasePlayer *pScor
 		CTFPlayer *pHealer = ToTFPlayer( pTFScorer->m_Shared.GetFirstHealer() );
 		// Must be a medic to receive a healing assist, otherwise engineers get credit for assists from dispensers doing healing.
 		// Also don't give an assist for healing if the inflictor was a sentry gun, otherwise medics healing engineers get assists for the engineer's sentry kills.
-		if ( pHealer && ( TF_CLASS_MEDIC == pHealer->GetPlayerClass()->GetClassIndex() ) && ( NULL == dynamic_cast<CObjectSentrygun *>( pInflictor ) ) )
+		// And also don't give an assist for healing if the healer was the victim otherwise medics get assists from dying to a disguised spy they are healing.
+		if ( pHealer && ( TF_CLASS_MEDIC == pHealer->GetPlayerClass()->GetClassIndex() ) && ( NULL == dynamic_cast<CObjectSentrygun *>( pInflictor ) ) && ( pHealer != pTFVictim ) )
 		{
 			return pHealer;
 		}


### PR DESCRIPTION
This modifies the existing medic check in `CTFGameRules::GetAssister` to make sure the medic is not the victim which without the check can result in medics getting an assist when they get killed by a disguised spy they were healing

https://github.com/user-attachments/assets/5afb01e1-e6e4-4438-b269-a5b4f579607d