### PR TITLE
[TF2] Fix Lightning Ball Spell constantly phasing players in and out of Purgatory

### DIFF
--- a/src/game/shared/tf/halloween/tf_weapon_spellbook.cpp
+++ b/src/game/shared/tf/halloween/tf_weapon_spellbook.cpp
@@ -3006,7 +3006,9 @@ public:
 				pEntity->SetGroundChangeTime( gpGlobals->curtime + 0.5f );
 			}
 
-			pEntity->Teleport( NULL, NULL, &vecVelocity );
+			pEntity->SetAbsVelocity( vecVelocity );
+			pEntity->SetBaseVelocity( vec3_origin );
+
 		}
 
 		SetContextThink( &CTFProjectile_SpellLightningOrb::VortexThink, gpGlobals->curtime + 0.2f, "VortexThink" );


### PR DESCRIPTION
Currently, a player hit with the Lightning Ball spell while in Purgatory will repeatedly gain and lose the TF_COND_PURGATORY condition for as long as they're in the spell's effective radius, which will cause them to stay ubered and kritzed for the duration, while the whole server is constantly spammed with the "escaped the underworld" chat alert and bell sound.

This is because the lightning ball spell calls the "teleport" function on players inside its radius, passing only a velocity vector, to continually re-apply an absolute velocity and draw those players toward its center.  Mechanically, it's only setting velocity on the player, but because it's technically teleporting them it has other side effects, including apparently re-triggering trigger_add_tf_player_condition entities they're inside of and thus removing/re-applying the condition.  This is noticeable for the TF_COND_PURGATORY condition, which applies the uber, kritz, server-wide sound alert and chat alert upon its removal.

Having the Lightning Ball spell set the velocity directly instead of unnecessarily teleporting the player (calling the same functions teleport would call for velocity) fixes this issue.

See below demonstration on pd_pit_of_death_event (sound on).

https://github.com/user-attachments/assets/5f64a350-32a2-4f34-980f-16713f375a1e

edit: fixes ValveSoftware/Source-1-Games#4492