### PR TITLE
[TF2] Fix attachments on dropped weapons having broken textures for certain war paints / skins

### DIFF
--- a/src/game/shared/tf/tf_dropped_weapon.cpp
+++ b/src/game/shared/tf/tf_dropped_weapon.cpp
@@ -286,6 +286,16 @@ bool CTFDroppedWeapon::OnInternalDrawModel( ClientModelRenderInfo_t *pInfo )
 	if ( !BaseClass::OnInternalDrawModel( pInfo ) )
 		return false;
 
+	// This flag says we should turn off the material overrides for attachments. 
+	IMaterial* pMaterialOverride = NULL;
+	OverrideType_t nMaterialOverrideType = OVERRIDE_NORMAL;
+
+	if ((pInfo->flags & STUDIO_NO_OVERRIDE_FOR_ATTACH) != 0)
+	{
+		modelrender->GetMaterialOverride(&pMaterialOverride, &nMaterialOverrideType);
+		modelrender->ForcedMaterialOverride(NULL, nMaterialOverrideType);
+	}
+
 	// Draw Attached Models
 	// Draw our attached models as well
 	for ( int i = 0; i < m_vecAttachedModels.Size(); i++ )
@@ -312,6 +322,9 @@ bool CTFDroppedWeapon::OnInternalDrawModel( ClientModelRenderInfo_t *pInfo )
 			DoInternalDrawModel( &infoAttached, ( bMarkAsDrawn && ( infoAttached.flags & STUDIO_RENDER ) ) ? &state : NULL, pBoneToWorld );
 		}
 	}
+
+	if (pMaterialOverride != NULL)
+		modelrender->ForcedMaterialOverride(pMaterialOverride, nMaterialOverrideType);
 
 	return true;
 }


### PR DESCRIPTION
Dropped weapons that have attachments on them can have broken textures on the attachments if the weapons are Decorated/War Painted with skins that use "material_override" -- including War Paints using the Macaw Masked materials (colloquially referred to as "albedo tint" skins). The override gets applied to the attachments when the weapon is dropped on death, causing the textures to break.

This fixes that issue for dropped weapons.

This issue appears most prominently for festivizers on weapons with these skins, but also breaks the pilot lights on flamethrowers, and the screens on rescue rangers.

![ft](https://github.com/user-attachments/assets/d228e552-ea27-4d03-b3a0-41668ea6d9e5)
![rr](https://github.com/user-attachments/assets/6ad2f480-6b14-4acc-b1a5-b2ad750fa8fe)

Tangentially, this fix removes the only obstacle to adding festivizer support to the Golden Wrench (which also uses material_override to apply its unique skin) -- this bug is the only reason the Golden Wrench wasn't in the "easy adds" pile for festivizers so with this fix it can be implemented in its items_game definition ("169") with the standard "can_be_festivized" tag and "attached_models_festive" block in the visuals section (models/weapons/c_models/c_wrench/c_wrench_festivizer.mdl can be reused for this with no changes)

![gw](https://github.com/user-attachments/assets/1589e255-4b65-4465-8da2-8cea4fecd8d0)

(re-make of pull 1845, requested merge of wrong source branch, no functional change)