### PR TITLE
[TF2] Fix Mannpower rune interactions with flamethrowers, Half-Zatoichi, and holiday lights

### DIFF
--- a/src/game/client/c_rope.cpp
+++ b/src/game/client/c_rope.cpp
@@ -646,7 +646,7 @@ bool CRopeManager::IsHolidayLightMode( void )
 	{
 		// We don't want to draw the lights for the grapple.
 		// They get left behind for a while and look bad.
-		if ( TFGameRules()->IsPowerupMode() || !TFGameRules()->GetRopesHolidayLightsAllowed() )
+		if ( TFGameRules()->IsPowerupMode() || TFGameRules()->IsUsingGrapplingHook() || !TFGameRules()->GetRopesHolidayLightsAllowed() )
 		{
 			return false;
 		}

--- a/src/game/shared/tf/tf_weapon_flamethrower.cpp
+++ b/src/game/shared/tf/tf_weapon_flamethrower.cpp
@@ -824,6 +824,8 @@ void CTFFlameThrower::PrimaryAttack()
 		flFiringInterval = tf_flamethrower_new_flame_fire_delay;
 	}
 
+	flFiringInterval = ApplyFireDelay( flFiringInterval );
+
 	// Don't attack if we're underwater
 	if ( pOwner->GetWaterLevel() != WL_Eyes )
 	{
@@ -1039,6 +1041,10 @@ void CTFFlameThrower::FireAirBlast( int iAmmoPerShot )
 	if ( pOwner->m_Shared.GetCarryingRuneType() == RUNE_HASTE )
 	{
 		fAirblastRefireTimeScale *= 0.5f;
+	}
+	else if ( pOwner->m_Shared.GetCarryingRuneType() == RUNE_KING || pOwner->m_Shared.InCond( TF_COND_KING_BUFFED ) )
+	{
+		fAirblastRefireTimeScale *= 0.75f;
 	}
 
 	m_flNextSecondaryAttack = gpGlobals->curtime + (0.75f * fAirblastRefireTimeScale);	

--- a/src/game/shared/tf/tf_weapon_sword.cpp
+++ b/src/game/shared/tf/tf_weapon_sword.cpp
@@ -561,7 +561,7 @@ float CTFKatana::GetMeleeDamage( CBaseEntity *pTarget, int* piDamageType, int* p
 			// If our victim is wielding the weapon we're looking for, bump the damage way up.
 			if ( pTFPlayerTarget->GetActiveTFWeapon() && pTFPlayerTarget->GetActiveTFWeapon()->IsHonorBound() )
 			{
-				fDamage = MAX( fDamage, pTFPlayerTarget->GetHealth() * 3 );
+				fDamage = MAX( fDamage, pTFPlayerTarget->GetHealth() * 10 );
 				*piDamageType |= DMG_DONT_COUNT_DAMAGE_TOWARDS_CRIT_RATE;
 			}
 		}


### PR DESCRIPTION
Three Mannpower gameplay fixes.

### 1. Flamethrower fire rate ignores Haste and King runes
Fixes ValveSoftware/Source-1-Games#4899

`CTFFlameThrower::PrimaryAttack()` hardcodes the firing interval without calling `ApplyFireDelay()`, bypassing rune fire rate multipliers. Airblast also only checks Haste, missing King.

### 2. Half-Zatoichi honor kill survivable with damage reduction runes
Fixes ValveSoftware/Source-1-Games#6974

Honor-bound damage uses `GetHealth() * 3`, which the Resist rune's 0.5x downstream multiplier can reduce below lethal. Changed to `* 10`.

### 3. Holiday lights not disabled with `tf_grapplinghook_enable`
Fixes ValveSoftware/Source-1-Games#4092

`IsHolidayLightMode()` only checks `IsPowerupMode()`, not `IsUsingGrapplingHook()`, so holiday lights still render on grapple ropes on non-Mannpower servers.