### PR TITLE
[TF2] Fix Haste and King rune fire rate not affecting flamethrowers

### DIFF
--- a/src/game/shared/tf/tf_weapon_flamethrower.cpp
+++ b/src/game/shared/tf/tf_weapon_flamethrower.cpp
@@ -824,6 +824,8 @@ void CTFFlameThrower::PrimaryAttack()
 		flFiringInterval = tf_flamethrower_new_flame_fire_delay;
 	}
 
+	flFiringInterval = ApplyFireDelay( flFiringInterval );
+
 	// Don't attack if we're underwater
 	if ( pOwner->GetWaterLevel() != WL_Eyes )
 	{
@@ -1039,6 +1041,10 @@ void CTFFlameThrower::FireAirBlast( int iAmmoPerShot )
 	if ( pOwner->m_Shared.GetCarryingRuneType() == RUNE_HASTE )
 	{
 		fAirblastRefireTimeScale *= 0.5f;
+	}
+	else if ( pOwner->m_Shared.GetCarryingRuneType() == RUNE_KING || pOwner->m_Shared.InCond( TF_COND_KING_BUFFED ) )
+	{
+		fAirblastRefireTimeScale *= 0.75f;
 	}
 
 	m_flNextSecondaryAttack = gpGlobals->curtime + (0.75f * fAirblastRefireTimeScale);	


### PR DESCRIPTION
Fixes ValveSoftware/Source-1-Games#4899

`CTFFlameThrower::PrimaryAttack()` hardcodes the firing interval without calling `ApplyFireDelay()`, so Haste and King rune fire rate multipliers have no effect on primary fire. Airblast also only checks Haste, missing King.

- Call `ApplyFireDelay()` on the primary fire interval
- Add King rune / King buff check to airblast refire time