### PR TITLE
[TF2] Fix holiday lights not disabled when grappling hooks are enabled outside Mannpower

### DIFF
--- a/src/game/client/c_rope.cpp
+++ b/src/game/client/c_rope.cpp
@@ -646,7 +646,7 @@ bool CRopeManager::IsHolidayLightMode( void )
 	{
 		// We don't want to draw the lights for the grapple.
 		// They get left behind for a while and look bad.
-		if ( TFGameRules()->IsPowerupMode() || !TFGameRules()->GetRopesHolidayLightsAllowed() )
+		if ( TFGameRules()->IsPowerupMode() || TFGameRules()->IsUsingGrapplingHook() || !TFGameRules()->GetRopesHolidayLightsAllowed() )
 		{
 			return false;
 		}


### PR DESCRIPTION
Fixes ValveSoftware/Source-1-Games#4092

`IsHolidayLightMode()` only checks `IsPowerupMode()`, so holiday lights still render on grapple ropes when `tf_grapplinghook_enable 1` is set on non-Mannpower maps. Added `IsUsingGrapplingHook()` check.