### PR TITLE
[TF2] Allow MvM gate captures to stun bots under the effects of Bonk! and Quick-Fix ubers

### DIFF
--- a/src/game/shared/tf/tf_player_shared.cpp
+++ b/src/game/shared/tf/tf_player_shared.cpp
@@ -9711,14 +9711,17 @@ void CTFPlayerShared::StunPlayer( float flTime, float flReductionAmount, int iSt
 		return;
 #endif
 
-	if ( InCond( TF_COND_PHASE ) || InCond( TF_COND_PASSTIME_INTERCEPTION ) )
-		return;
+	if ( !InCond( TF_COND_MVM_BOT_STUN_RADIOWAVE ) )
+	{
+		if ( InCond( TF_COND_PHASE ) || InCond( TF_COND_PASSTIME_INTERCEPTION ) )
+			return;
 
-	if ( InCond( TF_COND_MEGAHEAL ) )
-		return;
+		if ( InCond( TF_COND_MEGAHEAL ) )
+			return;
 
-	if ( InCond( TF_COND_INVULNERABLE_HIDE_UNLESS_DAMAGED ) && !InCond( TF_COND_MVM_BOT_STUN_RADIOWAVE ) )
-		return;
+		if ( InCond( TF_COND_INVULNERABLE_HIDE_UNLESS_DAMAGED ) )
+			return;
+	}
 
 #ifdef GAME_DLL
 	if ( pAttacker && TFGameRules() && TFGameRules()->IsTruceActive() && pAttacker->IsTruceValidForEnt() )


### PR DESCRIPTION
`CTFPlayerShared::StunPlayer()` has a check for `TF_COND_MVM_BOT_STUN_RADIOWAVE` (gate capture stun) that allows stuns to be applied even while under `TF_COND_INVULNERABLE_HIDE_UNLESS_DAMAGED` (spawn uber).

However, this check is not extended to other stun-immune conditions like `TF_COND_PHASE` (Bonk!) and `TF_COND_MEGAHEAL` (Quick-Fix uber), which causes bots like `T_TFBot_Scout_Bonk` (small Bonk! Bat Scouts) to not be properly stunned, even though they still show the stun particle.

This PR moves the check to occur before all of the stun immune conditions, rather than only for `TF_COND_INVULNERABLE_HIDE_UNLESS_DAMAGED`.

Before -> After:

https://github.com/user-attachments/assets/6af4b671-c1d1-48dc-8be2-b71608ce0a98


