### PR TITLE
[TF2] Fix Paintkit Tool Canvas preview not using the right material for Macaw-tinted War Paints

### DIFF
--- a/src/game/shared/econ/econ_paintkit.cpp
+++ b/src/game/shared/econ/econ_paintkit.cpp
@@ -81,6 +81,15 @@ const char* CPaintKitDefinition::GetMaterialOverride( item_definition_index_t iD
 		}
 	}
 
+	//paintkit tool's iDefIndex will come in here as different for every different paint
+	//and is different from the index that comes up when generating the supported items below
+	//BUT if we're getting asked for the override for an item thats not in the supported items
+	//and the paint CAN render a paintkit tool, this is surely asking for the paintkit override
+	if (m_bHasPaintKitTool && m_pszPaintKitOverride && *m_pszPaintKitOverride)
+	{
+		return m_pszPaintKitOverride;
+	}
+
 	return NULL;
 }
 
@@ -91,7 +100,8 @@ void CPaintKitDefinition::GenerateSupportedItems() const
 		CUtlVector< SupportedItem_t > tempVec;
 		const CMsgPaintKit_Definition *pPaintKitDef = static_cast< const CMsgPaintKit_Definition * >( GetMsg() );
 		bool bHasPaintKitTool = false;
-		auto lambdaGenerateSupportedItems = [ pPaintKitDef, &tempVec, &bHasPaintKitTool ]( const google::protobuf::Message* pMsgVar, const google::protobuf::FieldDescriptor* pField, const CMsgFieldID& fieldID )->bool
+		const char *pszPaintKitOverride = NULL;
+		auto lambdaGenerateSupportedItems = [ pPaintKitDef, &tempVec, &bHasPaintKitTool, &pszPaintKitOverride]( const google::protobuf::Message* pMsgVar, const google::protobuf::FieldDescriptor* pField, const CMsgFieldID& fieldID )->bool
 		{
 			if ( !BMessagesTypesAreTheSame( pMsgVar->GetDescriptor(), CMsgPaintKit_Definition_Item::descriptor() ) )
 			{
@@ -113,6 +123,7 @@ void CPaintKitDefinition::GenerateSupportedItems() const
 				if ( pItemDefMsg->item_definition_index() == pPaintkitToolItemDef->GetDefinitionIndex() )
 				{
 					bHasPaintKitTool = true;
+					pszPaintKitOverride = pItemMsg->data().material_override().c_str();
 				}
 			}
 
@@ -145,6 +156,9 @@ void CPaintKitDefinition::GenerateSupportedItems() const
 
 		m_vecSupportedItems.AddVectorToTail( tempVec );
 		m_bHasPaintKitTool = bHasPaintKitTool;
+		if (bHasPaintKitTool) {
+			m_pszPaintKitOverride = pszPaintKitOverride && *pszPaintKitOverride ? pszPaintKitOverride : NULL;
+		}
 	}
 }
 

--- a/src/game/shared/econ/econ_paintkit.h
+++ b/src/game/shared/econ/econ_paintkit.h
@@ -90,6 +90,7 @@ private:
 	};
 	mutable CUtlVector< SupportedItem_t > m_vecSupportedItems;
 	mutable bool m_bHasPaintKitTool;
+	mutable const char* m_pszPaintKitOverride;
 };
 
 #ifdef CLIENT_DLL


### PR DESCRIPTION
Some War Paints, sometimes referred to as "Macaw-Tinted" war paints (or occasionally "albedo tinted"), use a material_override to replace the normal weapon material with a separate shiny/metallic material; a special VMT exists for each weapon these paints can yield.

There exists a matching VMT for the paintkit tool canvas preview model as well, which has a similar metallic sheen as the weapons these paints can produce, made presumably with the intent of being used when previewing these paints.  However, this VMT is unused; The game does not read the material_override for the paintkit tool even if one is specified in the war paint definition.

This PR fixes that issue, allowing the game to load the material_override for a paintkit tool if one is specified, so that the preview canvas for these war paints can have a similar shine to the weapons the paints yield.


https://github.com/user-attachments/assets/38c8a342-4a8c-470f-b713-bc69ae0fb1fa

<img width="1303" height="751" alt="beforeafterimage" src="https://github.com/user-attachments/assets/4059296f-be65-492a-bd87-f1defd11616d" />

----------------

Please note: this fix requires additional changes to non-public War Paint definitions files (the unencrypted protodefs files are not publically visible).

This PR fixes this issue as-is for the following Macaw-tinted paints:
-Macaw Masked
-Smissmas Camo
-Helldriver
-Raving Dead
-Saccharine Striped
-Elfin Enamel
-Starlight Serenity
-Broken Bones
-Polterguised
-Kiln & Conquer
-Sunriser
-Bonzo Gnawed
-Steel Brushed
-Krak-coated
-Die'n Dasher
-Bomb Carrier
-Deadly Dragon
-Team Detail
-Gobi Glazed
-Team Charged

However the following Macaw-tinted paints, while they use the macaw materials set for the weapons themselves, are missing the material_override for the paintkit tool in their paint definitions (and nobody noticed since it was broken for all of them anyway) -- they'd need "models/paintkits/macaw/paintkit_tool" added as the "material_override" under their paintkit_tool definition (as is done in Macaw Masked and the others) to fix them like the others:
-Yeti Coated (defindex 300)
-Winterland Wrapped (defindex 254)
-Swashbuckled (defindex 285)
-Party Phantoms (defindex 294)
-Necromanced (defindex 297)
-Sacred Slayer (defindex 403)
-Business Class (defindex 415)
-Warborn (defindex 418)
-Stealth Specialist (defindex 426)
-Blackout (defindex 431)
-Sandwich Diner (defindex 433)
-Beachy Boy (defindex 434)
-Ocean Mapped (defindex 437)
-Team Union (defindex 439)
-Sideshow (defindex 440)

The Dragon Slayer war paint also specifies its own material_override for the War Paint which is also unused; this should fix that as well with no additional changes.