### PR TITLE
[TF2] Attempt to expose functionality for turning a team into robots outside of Man vs Machine

### DIFF
--- a/src/game/client/tf/c_tf_player.cpp
+++ b/src/game/client/tf/c_tf_player.cpp
@@ -1244,7 +1244,7 @@ void C_TFRagdoll::OnDataChanged( DataUpdateType_t type )
 					CreateTFHeadGib();
 					EmitSound( "TFPlayer.Decapitated" );
 
-					bool bBlood = true;
+					bool bBlood = !( pPlayer && IsRobotTeam( pPlayer->GetTeamNumber() ) );
 					if ( TFGameRules() && ( TFGameRules()->UseSillyGibs() || 
 											( TFGameRules()->IsMannVsMachineMode() && pPlayer && pPlayer->GetTeamNumber() == TF_TEAM_PVE_INVADERS ) ) )
 					{
@@ -5800,7 +5800,7 @@ bool C_TFPlayer::CanLightCigarette( void )
 	}
 
 	// don't light for MvM Spy robots
-	if ( TFGameRules() && TFGameRules()->IsMannVsMachineMode() && GetTeamNumber() == TF_TEAM_PVE_INVADERS )
+	if ( IsRobotTeam( GetTeamNumber() ) || ( TFGameRules() && TFGameRules()->IsMannVsMachineMode() && GetTeamNumber() == TF_TEAM_PVE_INVADERS ) )
 		return false;
 
 	// Don't light if we are invis.
@@ -10568,7 +10568,7 @@ void C_TFPlayer::UpdateKillStreakEffects( int iCount, bool bKillScored /* = fals
 
 void C_TFPlayer::UpdateMVMEyeGlowEffect( bool bVisible )
 {
-	if ( !TFGameRules() || !TFGameRules()->IsMannVsMachineMode() || GetTeamNumber() != TF_TEAM_PVE_INVADERS )
+	if ( !IsRobotTeam( GetTeamNumber() ) || !TFGameRules() || !TFGameRules()->IsMannVsMachineMode() || GetTeamNumber() != TF_TEAM_PVE_INVADERS )
 	{
 		return;
 	}

--- a/src/game/client/tf/tf_fx_impacts.cpp
+++ b/src/game/client/tf/tf_fx_impacts.cpp
@@ -65,7 +65,7 @@ void ImpactCallback( const CEffectData &data )
 		bool bPlaySound = true;
 		bool bIsRobotImpact = false;
 		
-		if ( bIsMVM && pPlayer && nApparentTeam == TF_TEAM_PVE_INVADERS )
+		if ( ( pPlayer && IsRobotTeam( nApparentTeam ) ) || ( bIsMVM && pPlayer && nApparentTeam == TF_TEAM_PVE_INVADERS ) )
 		{
 			bPlaySound = true;
 			bIsRobotImpact = true;

--- a/src/game/server/tf/bot/behavior/spy/tf_bot_spy_hide.cpp
+++ b/src/game/server/tf/bot/behavior/spy/tf_bot_spy_hide.cpp
@@ -70,7 +70,7 @@ ActionResult< CTFBot >	CTFBotSpyHide::Update( CTFBot *me, float interval )
 	if ( m_talkTimer.IsElapsed() )
 	{
 		m_talkTimer.Start( RandomFloat( 5.0f, 10.0f ) );
-		if ( TFGameRules()->IsMannVsMachineMode() && me->GetTeamNumber() == TF_TEAM_PVE_INVADERS )
+		if ( IsRobotTeam( me->GetTeamNumber() ) || ( TFGameRules()->IsMannVsMachineMode() && me->GetTeamNumber() == TF_TEAM_PVE_INVADERS ) )
 		{
 			me->EmitSound( "Spy.MVM_TeaseVictim" );
 		}

--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -1221,7 +1221,7 @@ void CTFPlayer::SetGrapplingHookTarget( CBaseEntity *pTarget, bool bShouldBleed 
 //-----------------------------------------------------------------------------
 bool CTFPlayer::CanBeForcedToLaugh( void )
 {
-	if ( TFGameRules() && TFGameRules()->IsMannVsMachineMode() && IsBot() && ( GetTeamNumber() == TF_TEAM_PVE_INVADERS ) )
+	if ( IsRobotTeam( GetTeamNumber() ) || ( TFGameRules() && ( TFGameRules()->IsMannVsMachineMode() && IsBot() && ( GetTeamNumber() == TF_TEAM_PVE_INVADERS ) ) ) )
 		return false;
 
 	return true;
@@ -10834,7 +10834,7 @@ int CTFPlayer::OnTakeDamage_Alive( const CTakeDamageInfo &info )
 			vDamagePos = WorldSpaceCenter();
 		}
 
-		if ( TFGameRules() && TFGameRules()->IsMannVsMachineMode() && GetTeamNumber() == TF_TEAM_PVE_INVADERS )
+		if ( IsRobotTeam( GetTeamNumber() ) || ( TFGameRules() && TFGameRules()->IsMannVsMachineMode() && GetTeamNumber() == TF_TEAM_PVE_INVADERS ) )
 		{
 			if ( ( IsMiniBoss() && static_cast< float >( GetHealth() ) / GetMaxHealth() > 0.3f ) || realDamage < 50 )
 			{
@@ -12420,7 +12420,7 @@ void CTFPlayer::Event_Killed( const CTakeDamageInfo &info )
 	SetGibbedOnLastDeath( bGib );
 
 	bool bIsMvMRobot = TFGameRules()->IsMannVsMachineMode() && IsBot();
-	if ( bGib && !bIsMvMRobot && IsPlayerClass( TF_CLASS_SCOUT ) && RandomInt( 1, 100 ) <= SCOUT_ADD_BIRD_ON_GIB_CHANCE )
+	if ( bGib && !bIsMvMRobot && !IsRobotTeam( GetTeamNumber() ) && IsPlayerClass( TF_CLASS_SCOUT ) && RandomInt( 1, 100 ) <= SCOUT_ADD_BIRD_ON_GIB_CHANCE )
 	{
 		Vector vecPos = WorldSpaceCenter();
 		SpawnClientsideFlyingBird( vecPos );
@@ -14721,6 +14721,22 @@ void CTFPlayer::ForceRespawn( void )
 	}
 
 	m_bSwitchedClass = false;
+
+	if ( IsRobotTeam( GetTeamNumber() ) )
+	{
+		const int nClassIndex = ( GetPlayerClass() ? GetPlayerClass()->GetClassIndex() : TF_CLASS_UNDEFINED );
+		if ( nClassIndex >= TF_CLASS_SCOUT && nClassIndex <= TF_CLASS_ENGINEER && g_pFullFileSystem->FileExists( g_szBotModels[ nClassIndex ] ) )
+			SetCustomModelWithClassAnimations( g_szBotModels[nClassIndex] );
+
+		SetBloodColor( DONT_BLEED );
+	}
+	else
+	{
+		if ( GetPlayerClass()->HasCustomModel() )
+			SetCustomModelWithClassAnimations( NULL );
+
+		SetBloodColor( BLOOD_COLOR_RED );
+	}
 }
 
 //-----------------------------------------------------------------------------
@@ -15156,7 +15172,16 @@ void CTFPlayer::PainSound( const CTakeDamageInfo &info )
 			TFPlayerClassData_t *pData = GetPlayerClass()->GetData();
 			if ( pData )
 			{
-				EmitSound( pData->GetDeathSound( DEATH_SOUND_GENERIC ) );
+				int deathSound = DEATH_SOUND_GENERIC;
+				if ( IsRobotTeam( GetTeamNumber() ) || ( TFGameRules() && TFGameRules()->IsMannVsMachineMode() && GetTeamNumber() == TF_TEAM_PVE_INVADERS ) )
+				{
+					deathSound = DEATH_SOUND_GENERIC_MVM;
+					if ( IsMiniBoss() )
+					{
+						deathSound = DEATH_SOUND_GENERIC_GIANT_MVM;
+					}
+				}
+				EmitSound( pData->GetDeathSound( deathSound ) );
 			}
 		}
 		return;
@@ -15258,7 +15283,7 @@ void CTFPlayer::DeathSound( const CTakeDamageInfo &info )
 
 	int nDeathSoundOffset = DEATH_SOUND_FIRST;
 
-	if ( TFGameRules() && TFGameRules()->IsMannVsMachineMode() && GetTeamNumber() == TF_TEAM_PVE_INVADERS )
+	if ( IsRobotTeam( GetTeamNumber() ) || ( TFGameRules() && ( TFGameRules()->IsMannVsMachineMode() && GetTeamNumber() == TF_TEAM_PVE_INVADERS ) ) )
 	{
 		nDeathSoundOffset = IsMiniBoss() ? DEATH_SOUND_GIANT_MVM_FIRST : DEATH_SOUND_MVM_FIRST;
 	}
@@ -15317,7 +15342,7 @@ void CTFPlayer::DeathSound( const CTakeDamageInfo &info )
 //-----------------------------------------------------------------------------
 const char* CTFPlayer::GetSceneSoundToken( void )
 {
-	if ( TFGameRules() && TFGameRules()->IsMannVsMachineMode() && GetTeamNumber() == TF_TEAM_PVE_INVADERS )
+	if ( IsRobotTeam( GetTeamNumber() ) || ( TFGameRules() && ( TFGameRules()->IsMannVsMachineMode() && GetTeamNumber() == TF_TEAM_PVE_INVADERS ) ) )
 	{
 		if ( IsMiniBoss() )
 		{

--- a/src/game/shared/tf/tf_gamerules.cpp
+++ b/src/game/shared/tf/tf_gamerules.cpp
@@ -918,6 +918,8 @@ ConVar tf_mvm_respec_credit_goal( "tf_mvm_respec_credit_goal", "2000", FCVAR_CHE
 ConVar tf_mvm_buybacks_method( "tf_mvm_buybacks_method", "0", FCVAR_REPLICATED | FCVAR_HIDDEN, "When set to 0, use the traditional, currency-based system.  When set to 1, use finite, charge-based system.", true, 0.0, true, 1.0 );
 ConVar tf_mvm_buybacks_per_wave( "tf_mvm_buybacks_per_wave", "3", FCVAR_REPLICATED | FCVAR_HIDDEN, "The fixed number of buybacks players can use per-wave." );
 
+ConVar tf_robot_team( "tf_robot_team", "1", FCVAR_GAMEDLL, "Whether to turn a given team into robots outside of Man vs Machine." );
+
 
 #ifdef GAME_DLL
 enum { kMVM_CurrencyPackMinSize = 1, };
@@ -1022,6 +1024,24 @@ bool IsCustomGameMode()
 	return IsCustomGameMode( STRING( gpGlobals->mapname ) );
 }
 #endif
+
+bool IsRobotTeam( int team )
+{
+	const int setting = tf_robot_team.GetInt();
+
+	if ( setting == 1 )
+	{
+		return true;
+	}
+	else if ( setting == 0 )
+	{
+		return false;
+	}
+	else
+	{
+		return team == setting;
+	}
+}
 
 // Fetch holiday setting taking into account convars, etc, but NOT
 // taking into consideration the current game rules, map, etc.
@@ -3550,7 +3570,7 @@ void CTFGameRules::Precache( void )
 		CMerasmus::PrecacheMerasmus();
 	}
 
-	if ( MapHasPrefix( STRING( gpGlobals->mapname ), "mvm_" ) )
+	if ( MapHasPrefix( STRING( gpGlobals->mapname ), "mvm_" ) || tf_robot_team.GetInt() != 0 )
 	{
 		CTFPlayer::PrecacheMvM();
 	}

--- a/src/game/shared/tf/tf_gamerules.h
+++ b/src/game/shared/tf/tf_gamerules.h
@@ -99,6 +99,10 @@ class CMannVsMachineUpgrades;
 extern ConVar tf_mvm_defenders_team_size;
 extern ConVar tf_mvm_max_invaders;
 
+extern ConVar tf_robot_team;
+
+extern bool IsRobotTeam( int );
+
 const int kLadder_TeamSize_6v6 = 6;
 const int kLadder_TeamSize_9v9 = 9;
 const int kLadder_TeamSize_12v12 = 12;

--- a/src/game/shared/tf/tf_player_shared.cpp
+++ b/src/game/shared/tf/tf_player_shared.cpp
@@ -11979,7 +11979,7 @@ void CTFPlayer::SetStepSoundTime( stepsoundtimes_t iStepSoundTime, bool bWalking
 const char *CTFPlayer::GetOverrideStepSound( const char *pszBaseStepSoundName )
 {
 
-	if( TFGameRules() && TFGameRules()->IsMannVsMachineMode() && GetTeamNumber() == TF_TEAM_PVE_INVADERS && !IsMiniBoss() && !m_Shared.InCond( TF_COND_DISGUISED ) )
+	if( IsRobotTeam( GetTeamNumber() ) || ( TFGameRules() && ( TFGameRules()->IsMannVsMachineMode() && GetTeamNumber() == TF_TEAM_PVE_INVADERS && !IsMiniBoss() && !m_Shared.InCond( TF_COND_DISGUISED ) ) ) )
 	{
 		return "MVM.BotStep";
 	}

--- a/src/game/shared/tf/tf_weaponbase_melee.cpp
+++ b/src/game/shared/tf/tf_weaponbase_melee.cpp
@@ -100,7 +100,7 @@ void CTFWeaponBaseMelee::Precache()
 {
 	BaseClass::Precache();
 
-	if ( TFGameRules() && TFGameRules()->IsMannVsMachineMode() )
+	if ( tf_robot_team.GetInt() != 0 && ( TFGameRules() && TFGameRules()->IsMannVsMachineMode() ) )
 	{
 		char szMeleeSoundStr[128] = "MVM_";
 		const char *shootsound = GetShootSound( MELEE_HIT );
@@ -570,9 +570,9 @@ bool CTFWeaponBaseMelee::OnSwingHit( trace_t &trace )
 
 		bool bPlayMvMHitOnly = false;
 		// handle hitting a robot	
-		if ( TFGameRules() && TFGameRules()->IsMannVsMachineMode() )
+		if ( tf_robot_team.GetInt() != 0 || ( TFGameRules() && TFGameRules()->IsMannVsMachineMode() ) )
 		{
-			if ( pTargetPlayer  && pTargetPlayer->GetTeamNumber() == TF_TEAM_PVE_INVADERS && !pTargetPlayer->IsPlayer() )
+			if ( pTargetPlayer  && ( IsRobotTeam( pTargetPlayer->GetTeamNumber() ) || ( pTargetPlayer->GetTeamNumber() == TF_TEAM_PVE_INVADERS && !pTargetPlayer->IsPlayer() ) ) )
 			{
 				bPlayMvMHitOnly = true;
 


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
Much of the code that turns every player (Fake or not) on a given team, though really just Blue in practice, into a robot is completely inaccessible to custom game modes. With the exception of calling SetCustomModelWithClassAnimations with a robot model and SetBloodColor(DONT_BLEED) in VScript, there is nothing that one can do to turn a team into robots, since that logic is completely locked behind hardcoded IsMannVsMachineMode calls. The result is that custom game types which want to use the robots have to do many extremely ugly hacks just to implement the rest of the robot details beyond the robot models and setting don't bleed to true, for instance, custom MVM missions where you play as Blue and fight robots on Red, which does not have any robot support from the game whatsoever, or something like Stop that Tank, or maybe a server owner just wants robots in casual and nothing else. But even with those hacks, a lot of things don't work, like robots still bleeding like a human when hit, and so on. Right now, the only way to accomplish this is to switch on the CNetworkVar m_bPlayingMannVsMachine but that enables a whole lot of extra Man vs Machine specific logic that you may not want, doesn't do anything in the case of when you want to turn a non\-Blue team into robots, and obviously cannot be switched on outside of actual Man vs Machine.

It would be helpful to custom modes and modders if this functionality is exposed somehow without all the extra Man vs Machine logic, for now just turning players into robots (Though enabling certain things like allowing the sapper to sap players but with a cooldown could be explored in a followup), ideally in a convenient "Setting this applies the changes across the whole game". This current implementation does this by making robot teams a ConVar (Though see below, I do not intend to merge this as is). Setting it to 0 means neither team are robots, 1 means both are, and a value matching TF\_TEAM\_BLUE and TF\_TEAM\_RED means the corresponding team will be robots.

The implementation here is only meant to get a discussion started on how best to do this. It is a complete wreck, and I do not intend to merge it in this state whatsoever. It is heavily broken and the robots do not make any sound at all, no speech, no damage sounds, not even death sounds (Their weapons and footsteps and impact sounds do work though), and when they gib the gibs don't appear at all, among other problems. I also don't know if I got everything either. The code in CTFPlayer::ForceRespawn is also just placeholder code so I can see the robot models during testing, I will leave whether that should be kept or whether it should be removed and modders should just call the available VScript functions up to discussion. I also am taking bikeshedding suggestions on whether to make the switch for enabling this a CNetworkVar, keep it as a ConVar or do something else, I don't know which way is best at the moment. I'm hoping to make the robot features easier for people and modders who want to access them in the future, try not to laugh at the terrible code :)