### PR TITLE
[TF2] Fix overheal particles revealing dead ringer feigns

### DIFF
--- a/src/game/client/tf/c_tf_player.cpp
+++ b/src/game/client/tf/c_tf_player.cpp
@@ -10041,7 +10041,14 @@ void C_TFPlayer::UpdateOverhealEffect( void )
 	{
 		if ( m_pOverHealedEffect )
 		{
-			ParticleProp()->StopEmission( m_pOverHealedEffect );
+			if ( m_Shared.InCond( TF_COND_FEIGN_DEATH ) )
+			{
+				ParticleProp()->StopEmissionAndDestroyImmediately( m_pOverHealedEffect );
+			}
+			else
+			{
+				ParticleProp()->StopEmission( m_pOverHealedEffect );
+			}
 			m_pOverHealedEffect = NULL;
 		}
 	}


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Current behaviour

When a spy feigns while emitting overheal particles, emission of new overheal particles stop, but the existing particles follow the spy until their end of life. This is one of the most universal "dead ringer tells" in the game, since especially with the kunai, spies are quote often overhealed. Anyone who knows to look for it can see the spy's position for a second after the feign.

https://github.com/user-attachments/assets/3b6fe1b9-a63f-456d-b18c-f8f3746b6588


# Proposed behaviour

The spy's overheal particles are immediately destroyed upon feigning.

https://github.com/user-attachments/assets/aac0e7aa-54f0-4aa2-b74c-bb86d89003f0