### PR TITLE
[TF2] Fixed crits being ignored with australium weapons on killfeed

### DIFF
--- a/src/game/client/tf/hud_basedeathnotice.cpp
+++ b/src/game/client/tf/hud_basedeathnotice.cpp
@@ -489,19 +489,19 @@ void CHudBaseDeathNotice::FireGameEvent( IGameEvent *event )
 			bLocalPlayerInvolved = true;
 		}
 
-		if (event->GetInt("damagebits") & DMG_CRITICAL)
+		if ( event->GetInt( "damagebits" ) & DMG_CRITICAL )
 		{
 			m_DeathNotices[iMsg].bCrit = true;
-			m_DeathNotices[iMsg].iconCritDeath = GetIcon("d_crit", bLocalPlayerInvolved ? kDeathNoticeIcon_Inverted : kDeathNoticeIcon_Standard);
+			m_DeathNotices[iMsg].iconCritDeath = GetIcon( "d_crit", bLocalPlayerInvolved ? kDeathNoticeIcon_Inverted : kDeathNoticeIcon_Standard );
 		}
 		else if ( event->GetInt( "death_flags" ) & TF_DEATH_AUSTRALIUM )
 		{
-			m_DeathNotices[iMsg].bCrit= false;
+			m_DeathNotices[iMsg].bCrit = false;
 			m_DeathNotices[iMsg].iconCritDeath = GetIcon( "d_australium", bLocalPlayerInvolved ? kDeathNoticeIcon_Inverted : kDeathNoticeIcon_Standard );
 		}
 		else
 		{
-			m_DeathNotices[iMsg].bCrit= false;
+			m_DeathNotices[iMsg].bCrit = false;
 			m_DeathNotices[iMsg].iconCritDeath = NULL;
 		}
 


### PR DESCRIPTION
Fixes issues [#4503](https://github.com/ValveSoftware/Source-1-Games/issues/4503) and [#7924](https://github.com/ValveSoftware/Source-1-Games/issues/7924).

Changes:
- Swapped australium and crit logic, where crit takes priority.
- Australium logic block no longer sets `bCrit= true`.
- Checking only `iconCritDeath` when drawing "glow" icon.

Result:
- Differentiates between crit and non-crit hit on killfeed when using australium weapons.
- Australium crit kills show up with red glow, australium non-crit kills show up with golden glow.
- Prevents incorrectly printing `(crit)` in console for australium weapons.