### PR TITLE
[TF2] Fix Huntsman arrows not being extinguished in water

### DIFF
--- a/src/game/shared/tf/tf_weapon_compound_bow.cpp
+++ b/src/game/shared/tf/tf_weapon_compound_bow.cpp
@@ -649,7 +649,7 @@ bool CTFCompoundBow::CalcIsAttackCriticalHelper()
 //-----------------------------------------------------------------------------
 void CTFCompoundBow::SetArrowAlight( bool bAlight ) 
 { 
-	// Don't light arrows if we're still firing one or are currently underwater.
+	// Don't light arrows if we're still firing one.
 	if (GetActivity() != ACT_ITEM2_VM_PRIMARYATTACK ) 
 	{
 		m_bArrowAlight = bAlight; 

--- a/src/game/shared/tf/tf_weapon_compound_bow.cpp
+++ b/src/game/shared/tf/tf_weapon_compound_bow.cpp
@@ -474,6 +474,11 @@ void CTFCompoundBow::ItemPostFrame( void )
 	{
 		WeaponIdle();
 	}
+
+	if (pOwner->GetWaterLevel() == WL_Eyes && m_bArrowAlight)
+	{
+		SetArrowAlight(false);
+	}
 }
 
 //-----------------------------------------------------------------------------
@@ -644,7 +649,7 @@ bool CTFCompoundBow::CalcIsAttackCriticalHelper()
 //-----------------------------------------------------------------------------
 void CTFCompoundBow::SetArrowAlight( bool bAlight ) 
 { 
-	// Don't light arrows if we're still firing one.
+	// Don't light arrows if we're still firing one or are currently underwater.
 	if (GetActivity() != ACT_ITEM2_VM_PRIMARYATTACK ) 
 	{
 		m_bArrowAlight = bAlight; 


### PR DESCRIPTION
This PR makes ignited Huntsman arrows become extinguished when you go underwater, bringing this interaction in line with others of a similar nature. (Players being extinguished when going underwater as well as the Pyro's flamethrower not working underwater)



https://github.com/user-attachments/assets/44cde043-7f60-4b43-9b01-968713a12a77

