### PR TITLE
[TF2] Fix Sniper Rifle charge sound being spammed when client has high ping

### DIFF
--- a/src/game/shared/tf/tf_weapon_sniperrifle.cpp
+++ b/src/game/shared/tf/tf_weapon_sniperrifle.cpp
@@ -23,6 +23,7 @@
 #include "input.h"
 #include "client_virtualreality.h"
 #include "sourcevr/isourcevirtualreality.h"
+#include "prediction.h"
 
 // forward declarations
 void ToolFramework_RecordMaterialParams( IMaterial *pMaterial );
@@ -385,7 +386,7 @@ void CTFSniperRifle::ItemPostFrame( void )
 
 #ifdef CLIENT_DLL
 			// play the recharged bell if we're fully charged
-			if ( IsFullyCharged() && !m_bPlayedBell )
+			if ( IsFullyCharged() && !m_bPlayedBell && ( !prediction->InPrediction() || prediction->IsFirstTimePredicted() ) )
 			{
 				m_bPlayedBell = true;
 				if ( tf_sniper_fullcharge_bell.GetBool() )
@@ -1930,7 +1931,7 @@ void CTFSniperRifleClassic::ItemPostFrame( void )
 
 #ifdef CLIENT_DLL
 		// play the recharged bell if we're fully charged
-		if ( IsFullyCharged() && !m_bPlayedBell )
+		if ( IsFullyCharged() && !m_bPlayedBell && ( !prediction->InPrediction() || prediction->IsFirstTimePredicted() ) )
 		{
 			m_bPlayedBell = true;
 			if ( tf_sniper_fullcharge_bell.GetBool() )


### PR DESCRIPTION
This PR fixes an issue with how prediction and high ping interacts with the "fully charged" sound cue, for both the Classic and all other applicable rifles.


**BOTH TESTS WERE DONE WITH NET_FAKELAG 250 ON A LOCAL LISTEN SERVER**

### **before:**

https://github.com/user-attachments/assets/d15a4388-0187-494e-b2dd-66de261cd621

### **after:**

https://github.com/user-attachments/assets/aa5aaea4-590b-4e79-ac15-027d0021df9e


fixes [ValveSoftware/Source-1-Games #2580](https://github.com/ValveSoftware/Source-1-Games/issues/2580)
