### PR TITLE
[HL2MP] Only show sparks out of water

### DIFF
--- a/src/game/server/explode.cpp
+++ b/src/game/server/explode.cpp
@@ -352,8 +352,7 @@ void CEnvExplosion::InputExplode( inputdata_t &inputdata )
 	SetNextThink( gpGlobals->curtime + 0.3 );
 
 	// Only do these effects if we're not submerged
-	if ( UTIL_PointContents( GetAbsOrigin() ) & CONTENTS_WATER )
-	{
+	if ( !( UTIL_PointContents( GetAbsOrigin() ) & CONTENTS_WATER ) ) {
 		// draw sparks
 		if ( !( m_spawnflags & SF_ENVEXPLOSION_NOSPARKS ) )
 		{


### PR DESCRIPTION
Issue:
Explosions would show spark underwater. The check was inverted here.

Fix:
Invert back the check for if the explosion happened underwater.

This is simply re-submitting a previous PR that was closed without being merged because the original creator deleted their repo:

https://github.com/ValveSoftware/source-sdk-2013/pull/1112