### PR TITLE
[HL2MP] Fix Headcrab canister precache

### DIFF
--- a/src/game/server/hl2/env_headcrabcanister.cpp
+++ b/src/game/server/hl2/env_headcrabcanister.cpp
@@ -314,7 +314,9 @@ void CEnvHeadcrabCanister::Spawn( void )
 void CEnvHeadcrabCanister::UpdateOnRemove()
 {
 	BaseClass::UpdateOnRemove();
-	StopSound( "HeadcrabCanister.AfterLanding" );
+	if ( m_bLanded || m_bOpened )
+		StopSound( "HeadcrabCanister.AfterLanding" );
+	
 	if ( m_hTrail )
 	{
 		UTIL_Remove( m_hTrail );


### PR DESCRIPTION
Issue:
On dm_runoff, the console spams SV_StartSound: npc/env_headcrabcanister/hiss.wav not precached (0).

Fix:
Detect when the headcrab canister has landed or opened.

This is simply re-submitting a previous PR that was closed without being merged because the original creator deleted their repo:

https://github.com/ValveSoftware/source-sdk-2013/pull/1099