### PR TITLE
[TF2] Fix Sydney Sleeper extinguishing teammates on unscoped hits

### DIFF
--- a/src/game/shared/tf/tf_player_shared.cpp
+++ b/src/game/shared/tf/tf_player_shared.cpp
@@ -10348,7 +10348,7 @@ void CTFPlayer::FireBullet( CTFWeaponBase *pWpn, const FireBulletsInfo_t &info, 
 				// put out fire for burning teammate
 				if ( nCustomDamageType == TF_DMG_CUSTOM_PENETRATE_NONBURNING_TEAMMATE )
 				{
-					if ( pTargetPlayer && GetTeamNumber() == pTargetPlayer->GetTeamNumber() && pTargetPlayer->m_Shared.InCond( TF_COND_BURNING ) && ToTFPlayer(GetActiveWeapon()->GetOwner())->m_Shared.InCond( TF_COND_AIMING ))
+					if ( pTargetPlayer && GetTeamNumber() == pTargetPlayer->GetTeamNumber() && pTargetPlayer->m_Shared.InCond( TF_COND_BURNING ) && m_Shared.InCond( TF_COND_AIMING ))
 					{
 						ExtinguishPlayer( GetActiveWeapon(), ToTFPlayer( GetActiveWeapon()->GetOwner() ), pTargetPlayer, GetActiveWeapon()->GetName() );
 					}

--- a/src/game/shared/tf/tf_player_shared.cpp
+++ b/src/game/shared/tf/tf_player_shared.cpp
@@ -10348,7 +10348,7 @@ void CTFPlayer::FireBullet( CTFWeaponBase *pWpn, const FireBulletsInfo_t &info, 
 				// put out fire for burning teammate
 				if ( nCustomDamageType == TF_DMG_CUSTOM_PENETRATE_NONBURNING_TEAMMATE )
 				{
-					if ( pTargetPlayer && GetTeamNumber() == pTargetPlayer->GetTeamNumber() && pTargetPlayer->m_Shared.InCond( TF_COND_BURNING ) )
+					if ( pTargetPlayer && GetTeamNumber() == pTargetPlayer->GetTeamNumber() && pTargetPlayer->m_Shared.InCond( TF_COND_BURNING ) && ToTFPlayer(GetActiveWeapon()->GetOwner())->m_Shared.InCond( TF_COND_AIMING ))
 					{
 						ExtinguishPlayer( GetActiveWeapon(), ToTFPlayer( GetActiveWeapon()->GetOwner() ), pTargetPlayer, GetActiveWeapon()->GetName() );
 					}


### PR DESCRIPTION
# Description
This change brings consistency to how the Sydney Sleeper interacts with both friendlies and enemies alike.
As Jarate is only applied to enemies upon scoped hits it also makes sense for extinguishing to only take place under the same conditions.

# Video
https://github.com/user-attachments/assets/3e3a05c6-bf5b-48f4-af27-b7b6bff5487b

