### PR TITLE
[TF2] Fix interaction between YER and disguise target switching teams

### DIFF
--- a/src/game/shared/tf/tf_player_shared.cpp
+++ b/src/game/shared/tf/tf_player_shared.cpp
@@ -8163,6 +8163,12 @@ void CTFPlayerShared::Disguise( int nTeam, int nClass, CTFPlayer* pDesiredTarget
 		return;
 	}
 
+	// If disguising due to 'Your Eternal Reward' backstab, ensure that disguise team is the opposing team
+	if (nRealTeam == nTeam && bOnKill)
+	{
+		nTeam = (nRealTeam == TF_TEAM_RED) ? TF_TEAM_BLUE : TF_TEAM_RED;
+	}
+
 	// we're not disguising as anything but ourselves (so reset everything)
 	if ( nRealTeam == nTeam && nRealClass == nClass )
 	{

--- a/src/game/shared/tf/tf_player_shared.cpp
+++ b/src/game/shared/tf/tf_player_shared.cpp
@@ -8162,8 +8162,9 @@ void CTFPlayerShared::Disguise( int nTeam, int nClass, CTFPlayer* pDesiredTarget
 		// not allowed to disguise while taunting
 		return;
 	}
-
+	
 	// If disguising due to 'Your Eternal Reward' backstab, ensure that disguise team is the opposing team
+	// Fixes issue with backstabbing an enemy that then gets autobalanced, disguising the spy as his own team
 	if (nRealTeam == nTeam && bOnKill)
 	{
 		nTeam = (nRealTeam == TF_TEAM_RED) ? TF_TEAM_BLUE : TF_TEAM_RED;


### PR DESCRIPTION
# Description
This PR seeks to fix a problem that occurs when a Spy using the Your Eternal Reward backstabs an enemy player that then proceeds to switch teams upon death. The Spy disguises as his own team (and in the case of backstabbing an enemy spy, loses his disguise completely)

Command used to mimic the above scenario: `alias bot_switch "+attack; wait 5; bot_changeteams; -attack"`

# Video
https://github.com/user-attachments/assets/530c007b-bb02-45f2-95c6-a5dc7393af5a


Fixes [Source-1-Games #2128](https://github.com/ValveSoftware/Source-1-Games/issues/2128)