### PR TITLE
[TF2] Fix incorrect coloring on death animation when dying to friendly Cow Mangler

### DIFF
--- a/src/game/client/tf/c_tf_player.cpp
+++ b/src/game/client/tf/c_tf_player.cpp
@@ -1598,29 +1598,16 @@ void C_TFRagdoll::DissolveEntity( CBaseEntity* pEnt )
 
 		Vector vColor;
 		C_TFPlayer *pLocalPlayer = C_TFPlayer::GetLocalTFPlayer();
+		bool bIsSuicide = pLocalPlayer ? pLocalPlayer->IsDeathSuicide() : NULL;
 		// If a player kills themselves with a weapon that dissolves ragdolls, set dissolving color to their own team
 		if ( m_iTeam == TF_TEAM_BLUE )
 		{
-			if (pLocalPlayer)
-			{
-				vColor = ( pLocalPlayer->IsDeathSuicide() ) ? TF_PARTICLE_WEAPON_BLUE_1 * 255 : TF_PARTICLE_WEAPON_RED_1 * 255;
-			}
-			else // Fallback to original code if pLocalPlayer is invalid
-			{
-				vColor = TF_PARTICLE_WEAPON_RED_1 * 255;
-			}
+			vColor = ( bIsSuicide ) ? TF_PARTICLE_WEAPON_BLUE_1 * 255 : TF_PARTICLE_WEAPON_RED_1 * 255;
 			pDissolve->SetEffectColor( vColor );
 		}
 		else
 		{
-			if (pLocalPlayer)
-			{
-				vColor = ( pLocalPlayer->IsDeathSuicide() ) ? TF_PARTICLE_WEAPON_RED_1 * 255 : TF_PARTICLE_WEAPON_BLUE_1 * 255;
-			}
-			else // Fallback to original code if pLocalPlayer is invalid
-			{
-				vColor = TF_PARTICLE_WEAPON_BLUE_1 * 255;
-			}
+			vColor = ( bIsSuicide ) ? TF_PARTICLE_WEAPON_RED_1 * 255 : TF_PARTICLE_WEAPON_BLUE_1 * 255;
 			pDissolve->SetEffectColor( vColor );
 		}
 
@@ -3992,6 +3979,8 @@ C_TFPlayer::C_TFPlayer() :
 	m_pPasstimeAskForBallReticle = NULL;
 
 	m_iPlayerSkinOverride = 0;
+
+	m_bIsSuicide = false;
 
 	ListenForGameEvent( "player_hurt" );
 	ListenForGameEvent( "hltv_changed_mode" );
@@ -11202,11 +11191,11 @@ void C_TFPlayer::FireGameEvent( IGameEvent *event )
 	else if (FStrEq(event->GetName(), "player_death" ) )
 	{
 		m_bIsSuicide = false;
-		const int iAttacker = engine->GetPlayerForUserID(event->GetInt("attacker"));
-		C_TFPlayer* pAttacker = ToTFPlayer(UTIL_PlayerByIndex(iAttacker));
+		const int iAttacker = engine->GetPlayerForUserID( event->GetInt( "attacker" ) );
+		C_TFPlayer* pAttacker = ToTFPlayer( UTIL_PlayerByIndex( iAttacker ) );
 
-		const int iVictim = engine->GetPlayerForUserID(event->GetInt("userid"));
-		C_TFPlayer* pVictim = ToTFPlayer(UTIL_PlayerByIndex(iVictim));
+		const int iVictim = engine->GetPlayerForUserID( event->GetInt( "userid" ) );
+		C_TFPlayer* pVictim = ToTFPlayer( UTIL_PlayerByIndex( iVictim) );
 
 		if ( !pVictim )
 			return;

--- a/src/game/client/tf/c_tf_player.cpp
+++ b/src/game/client/tf/c_tf_player.cpp
@@ -1603,7 +1603,7 @@ void C_TFRagdoll::DissolveEntity( CBaseEntity* pEnt )
 		{
 			if (pLocalPlayer)
 			{
-				vColor = (pLocalPlayer->GetIsSuicide()) ? TF_PARTICLE_WEAPON_BLUE_1 * 255 : TF_PARTICLE_WEAPON_RED_1 * 255;
+				vColor = ( pLocalPlayer->IsDeathSuicide() ) ? TF_PARTICLE_WEAPON_BLUE_1 * 255 : TF_PARTICLE_WEAPON_RED_1 * 255;
 			}
 			else // Fallback to original code if pLocalPlayer is invalid
 			{
@@ -1615,7 +1615,7 @@ void C_TFRagdoll::DissolveEntity( CBaseEntity* pEnt )
 		{
 			if (pLocalPlayer)
 			{
-				vColor = (pLocalPlayer->GetIsSuicide()) ? TF_PARTICLE_WEAPON_RED_1 * 255 : TF_PARTICLE_WEAPON_BLUE_1 * 255;
+				vColor = ( pLocalPlayer->IsDeathSuicide() ) ? TF_PARTICLE_WEAPON_RED_1 * 255 : TF_PARTICLE_WEAPON_BLUE_1 * 255;
 			}
 			else // Fallback to original code if pLocalPlayer is invalid
 			{

--- a/src/game/client/tf/c_tf_player.cpp
+++ b/src/game/client/tf/c_tf_player.cpp
@@ -1597,16 +1597,30 @@ void C_TFRagdoll::DissolveEntity( CBaseEntity* pEnt )
 		pDissolve->SetRenderColor( 255, 255, 255, 255 );
 
 		Vector vColor;
+		C_TFPlayer *pLocalPlayer = C_TFPlayer::GetLocalTFPlayer();
+
 		if ( m_iTeam == TF_TEAM_BLUE )
 		{
-			// vColor = TF_PARTICLE_WEAPON_RED_1 * 255;
-			vColor = TF_PARTICLE_WEAPON_BLUE_1 * 255;
+			if (pLocalPlayer)
+			{
+				vColor = (pLocalPlayer->GetIsSuicide()) ? TF_PARTICLE_WEAPON_BLUE_1 * 255 : TF_PARTICLE_WEAPON_RED_1 * 255;
+			}
+			else
+			{
+				vColor = TF_PARTICLE_WEAPON_RED_1 * 255;
+			}
 			pDissolve->SetEffectColor( vColor );
 		}
 		else
 		{
-			// vColor = TF_PARTICLE_WEAPON_BLUE_1 * 255;
-			vColor = TF_PARTICLE_WEAPON_RED_1 * 255;
+			if (pLocalPlayer)
+			{
+				vColor = (pLocalPlayer->GetIsSuicide()) ? TF_PARTICLE_WEAPON_RED_1 * 255 : TF_PARTICLE_WEAPON_BLUE_1 * 255;
+			}
+			else
+			{
+				vColor = TF_PARTICLE_WEAPON_BLUE_1 * 255;
+			}
 			pDissolve->SetEffectColor( vColor );
 		}
 
@@ -3995,6 +4009,7 @@ C_TFPlayer::C_TFPlayer() :
 	ListenForGameEvent( "player_abandoned_match" );
 	ListenForGameEvent( "rocketpack_launch" );
 	ListenForGameEvent( "rocketpack_landed" );
+	ListenForGameEvent( "player_death" );
 
 	//AddPhonemeFile
 	engine->AddPhonemeFile( "scripts/game_sounds_vo_phonemes.txt" );
@@ -11182,6 +11197,23 @@ void C_TFPlayer::FireGameEvent( IGameEvent *event )
 					pHudChat->ChatPrintf( pLocalPlayer->entindex(), CHAT_FILTER_SERVERMSG, "%s", szLocalized );
 				}
 			}
+		}
+	}
+	else if (FStrEq(event->GetName(), "player_death" ) )
+	{
+		m_bIsSuicide = false;
+		const int iAttacker = engine->GetPlayerForUserID(event->GetInt("attacker"));
+		C_TFPlayer* pAttacker = ToTFPlayer(UTIL_PlayerByIndex(iAttacker));
+
+		const int iVictim = engine->GetPlayerForUserID(event->GetInt("userid"));
+		C_TFPlayer* pVictim = ToTFPlayer(UTIL_PlayerByIndex(iVictim));
+
+		if ( !pVictim )
+			return;
+
+		if ( !pAttacker || pAttacker == pVictim )
+		{
+			m_bIsSuicide = true;
 		}
 	}
 	BaseClass::FireGameEvent( event );

--- a/src/game/client/tf/c_tf_player.cpp
+++ b/src/game/client/tf/c_tf_player.cpp
@@ -1598,14 +1598,14 @@ void C_TFRagdoll::DissolveEntity( CBaseEntity* pEnt )
 
 		Vector vColor;
 		C_TFPlayer *pLocalPlayer = C_TFPlayer::GetLocalTFPlayer();
-
+		// If a player kills themselves with a weapon that dissolves ragdolls, set dissolving color to their own team
 		if ( m_iTeam == TF_TEAM_BLUE )
 		{
 			if (pLocalPlayer)
 			{
 				vColor = (pLocalPlayer->GetIsSuicide()) ? TF_PARTICLE_WEAPON_BLUE_1 * 255 : TF_PARTICLE_WEAPON_RED_1 * 255;
 			}
-			else
+			else // Fallback to original code if pLocalPlayer is invalid
 			{
 				vColor = TF_PARTICLE_WEAPON_RED_1 * 255;
 			}
@@ -1617,7 +1617,7 @@ void C_TFRagdoll::DissolveEntity( CBaseEntity* pEnt )
 			{
 				vColor = (pLocalPlayer->GetIsSuicide()) ? TF_PARTICLE_WEAPON_RED_1 * 255 : TF_PARTICLE_WEAPON_BLUE_1 * 255;
 			}
-			else
+			else // Fallback to original code if pLocalPlayer is invalid
 			{
 				vColor = TF_PARTICLE_WEAPON_BLUE_1 * 255;
 			}

--- a/src/game/client/tf/c_tf_player.cpp
+++ b/src/game/client/tf/c_tf_player.cpp
@@ -1599,12 +1599,14 @@ void C_TFRagdoll::DissolveEntity( CBaseEntity* pEnt )
 		Vector vColor;
 		if ( m_iTeam == TF_TEAM_BLUE )
 		{
-			vColor = TF_PARTICLE_WEAPON_RED_1 * 255;
+			// vColor = TF_PARTICLE_WEAPON_RED_1 * 255;
+			vColor = TF_PARTICLE_WEAPON_BLUE_1 * 255;
 			pDissolve->SetEffectColor( vColor );
 		}
 		else
 		{
-			vColor = TF_PARTICLE_WEAPON_BLUE_1 * 255;
+			// vColor = TF_PARTICLE_WEAPON_BLUE_1 * 255;
+			vColor = TF_PARTICLE_WEAPON_RED_1 * 255;
 			pDissolve->SetEffectColor( vColor );
 		}
 

--- a/src/game/client/tf/c_tf_player.cpp
+++ b/src/game/client/tf/c_tf_player.cpp
@@ -11199,14 +11199,8 @@ void C_TFPlayer::FireGameEvent( IGameEvent *event )
 
 		if ( !pVictim )
 			return;
-		// Attacker cant be found.. could still be a suicide though, lets treat it as one!
-		if ( !pAttacker )
-		{
-			m_bIsFriendlyFireOrSuicide = true;
-			return;	
-		}
-
-		if ( pAttacker->GetTeamNumber() == pVictim->GetTeamNumber() )
+		// If attacker can't be found lets treat it as a suicide
+		if ( !pAttacker || pAttacker->GetTeamNumber() == pVictim->GetTeamNumber() )
 		{
 			m_bIsFriendlyFireOrSuicide = true;
 		}

--- a/src/game/client/tf/c_tf_player.cpp
+++ b/src/game/client/tf/c_tf_player.cpp
@@ -1598,16 +1598,16 @@ void C_TFRagdoll::DissolveEntity( CBaseEntity* pEnt )
 
 		Vector vColor;
 		C_TFPlayer *pLocalPlayer = C_TFPlayer::GetLocalTFPlayer();
-		bool bIsSuicide = pLocalPlayer ? pLocalPlayer->IsDeathSuicide() : NULL;
-		// If a player kills themselves with a weapon that dissolves ragdolls, set dissolving color to their own team
+		bool bIsFriendlyFireOrSuicide = pLocalPlayer ? pLocalPlayer->IsDeathFriendlyFireOrSuicide() : NULL;
+		// If a player kills themselves or a teammate with a weapon that dissolves ragdolls, set dissolving color to their own team
 		if ( m_iTeam == TF_TEAM_BLUE )
 		{
-			vColor = ( bIsSuicide ) ? TF_PARTICLE_WEAPON_BLUE_1 * 255 : TF_PARTICLE_WEAPON_RED_1 * 255;
+			vColor = ( bIsFriendlyFireOrSuicide ) ? TF_PARTICLE_WEAPON_BLUE_1 * 255 : TF_PARTICLE_WEAPON_RED_1 * 255;
 			pDissolve->SetEffectColor( vColor );
 		}
 		else
 		{
-			vColor = ( bIsSuicide ) ? TF_PARTICLE_WEAPON_RED_1 * 255 : TF_PARTICLE_WEAPON_BLUE_1 * 255;
+			vColor = ( bIsFriendlyFireOrSuicide ) ? TF_PARTICLE_WEAPON_RED_1 * 255 : TF_PARTICLE_WEAPON_BLUE_1 * 255;
 			pDissolve->SetEffectColor( vColor );
 		}
 
@@ -3980,7 +3980,7 @@ C_TFPlayer::C_TFPlayer() :
 
 	m_iPlayerSkinOverride = 0;
 
-	m_bIsSuicide = false;
+	m_bIsFriendlyFireOrSuicide = false;
 
 	ListenForGameEvent( "player_hurt" );
 	ListenForGameEvent( "hltv_changed_mode" );
@@ -11190,19 +11190,25 @@ void C_TFPlayer::FireGameEvent( IGameEvent *event )
 	}
 	else if (FStrEq(event->GetName(), "player_death" ) )
 	{
-		m_bIsSuicide = false;
+		m_bIsFriendlyFireOrSuicide = false;
 		const int iAttacker = engine->GetPlayerForUserID( event->GetInt( "attacker" ) );
 		C_TFPlayer* pAttacker = ToTFPlayer( UTIL_PlayerByIndex( iAttacker ) );
 
 		const int iVictim = engine->GetPlayerForUserID( event->GetInt( "userid" ) );
-		C_TFPlayer* pVictim = ToTFPlayer( UTIL_PlayerByIndex( iVictim) );
+		C_TFPlayer* pVictim = ToTFPlayer( UTIL_PlayerByIndex( iVictim ) );
 
 		if ( !pVictim )
 			return;
-
-		if ( !pAttacker || pAttacker == pVictim )
+		// Attacker cant be found.. could still be a suicide though, lets treat it as one!
+		if ( !pAttacker )
 		{
-			m_bIsSuicide = true;
+			m_bIsFriendlyFireOrSuicide = true;
+			return;	
+		}
+
+		if ( pAttacker->GetTeamNumber() == pVictim->GetTeamNumber() )
+		{
+			m_bIsFriendlyFireOrSuicide = true;
 		}
 	}
 	BaseClass::FireGameEvent( event );

--- a/src/game/client/tf/c_tf_player.h
+++ b/src/game/client/tf/c_tf_player.h
@@ -626,7 +626,7 @@ public:
 // Called by shared code.
 public:
 	float GetClassChangeTime() const { return m_flChangeClassTime; }
-	bool IsDeathSuicide() const { return m_bIsSuicide; }
+	bool IsDeathFriendlyFireOrSuicide() const { return m_bIsFriendlyFireOrSuicide; }
 	void SetFootStamps( int nFootStamps ) { m_nFootStamps = nFootStamps; }
 
 	void DoAnimationEvent( PlayerAnimEvent_t event, int nData = 0 );
@@ -676,7 +676,7 @@ public:
 	bool			m_bSaveMeParity;
 	bool			m_bOldSaveMeParity;
 	bool			m_bIsCoaching;
-	bool			m_bIsSuicide;
+	bool			m_bIsFriendlyFireOrSuicide;
 
 private:
 	void			UpdateTauntItem();

--- a/src/game/client/tf/c_tf_player.h
+++ b/src/game/client/tf/c_tf_player.h
@@ -626,6 +626,7 @@ public:
 // Called by shared code.
 public:
 	float GetClassChangeTime() const { return m_flChangeClassTime; }
+	bool GetIsSuicide() const { return m_bIsSuicide; }
 	void SetFootStamps( int nFootStamps ) { m_nFootStamps = nFootStamps; }
 
 	void DoAnimationEvent( PlayerAnimEvent_t event, int nData = 0 );
@@ -675,6 +676,7 @@ public:
 	bool			m_bSaveMeParity;
 	bool			m_bOldSaveMeParity;
 	bool			m_bIsCoaching;
+	bool			m_bIsSuicide;
 
 private:
 	void			UpdateTauntItem();

--- a/src/game/client/tf/c_tf_player.h
+++ b/src/game/client/tf/c_tf_player.h
@@ -626,7 +626,7 @@ public:
 // Called by shared code.
 public:
 	float GetClassChangeTime() const { return m_flChangeClassTime; }
-	bool GetIsSuicide() const { return m_bIsSuicide; }
+	bool IsDeathSuicide() const { return m_bIsSuicide; }
 	void SetFootStamps( int nFootStamps ) { m_nFootStamps = nFootStamps; }
 
 	void DoAnimationEvent( PlayerAnimEvent_t event, int nData = 0 );
@@ -676,7 +676,7 @@ public:
 	bool			m_bSaveMeParity;
 	bool			m_bOldSaveMeParity;
 	bool			m_bIsCoaching;
-	bool			m_bIsSuicide;
+	bool			m_bIsSuicide = false;
 
 private:
 	void			UpdateTauntItem();

--- a/src/game/client/tf/c_tf_player.h
+++ b/src/game/client/tf/c_tf_player.h
@@ -676,7 +676,7 @@ public:
 	bool			m_bSaveMeParity;
 	bool			m_bOldSaveMeParity;
 	bool			m_bIsCoaching;
-	bool			m_bIsSuicide = false;
+	bool			m_bIsSuicide;
 
 private:
 	void			UpdateTauntItem();


### PR DESCRIPTION
# Description
When a player dies to the Cow Mangler, their ragdoll enters a dissolving/fizzling animation using the color of the opposing team. This behavior also occurs even if the player is dying to friendly Cow Mangler shots. This is because the function uses the color of the player's opposing team without any further checks.


This PR creates a new variable called ~`m_bIsSuicide`~ `m_bIsFriendlyFireOrSuicide` and utilises the `player_death` GameEvent to determine whether or not the death was caused by friendly fire/suicide. This variable is then incorporated into the ragdoll dissolving function.

# Video
https://github.com/user-attachments/assets/5bb16b83-dbbc-4c09-90da-b31ef6cb9a3b