### PR TITLE
[TF2] Fix multiple disruptive Manmelter issues

### DIFF
--- a/src/game/shared/tf/tf_usermessages.cpp
+++ b/src/game/shared/tf/tf_usermessages.cpp
@@ -129,6 +129,8 @@ void RegisterUserMessages()
 
 	usermessages->Register( "BuiltObject", 3 ); // object type, object mode (entrance vs. exit), index
 
+	usermessages->Register( "ManmelterExtinguishedPlayer", -1 );
+
 	// NVNT register haptic user messages
 	RegisterHapticMessages();
 	RegisterScriptMessages();

--- a/src/game/shared/tf/tf_usermessages.cpp
+++ b/src/game/shared/tf/tf_usermessages.cpp
@@ -129,8 +129,6 @@ void RegisterUserMessages()
 
 	usermessages->Register( "BuiltObject", 3 ); // object type, object mode (entrance vs. exit), index
 
-	usermessages->Register( "ManmelterExtinguishedPlayer", -1 );
-
 	// NVNT register haptic user messages
 	RegisterHapticMessages();
 	RegisterScriptMessages();

--- a/src/game/shared/tf/tf_weapon_flaregun.cpp
+++ b/src/game/shared/tf/tf_weapon_flaregun.cpp
@@ -12,7 +12,6 @@
 #include "c_tf_player.h"
 #include "soundenvelope.h"
 #include "prediction.h"
-#include "usermessages.h"
 // Server specific.
 #else
 #include "tf_gamestats.h"

--- a/src/game/shared/tf/tf_weapon_flaregun.cpp
+++ b/src/game/shared/tf/tf_weapon_flaregun.cpp
@@ -425,7 +425,9 @@ bool CTFFlareGun_Revenge::Holster( CBaseCombatWeapon *pSwitchingTo )
 #endif
 
 	StopCharge();
-
+#ifdef CLIENT_DLL
+	gameeventmanager->RemoveListener(this);
+#endif
 	return BaseClass::Holster( pSwitchingTo );
 }
 
@@ -440,6 +442,8 @@ bool CTFFlareGun_Revenge::Deploy( void )
 	{
 		pOwner->m_Shared.AddCond( TF_COND_CRITBOOSTED );
 	}
+#elif defined( CLIENT_DLL )
+	gameeventmanager->AddListener(this, "player_extinguished", false);
 #endif
 
 	StopCharge();
@@ -582,12 +586,6 @@ void CTFFlareGun_Revenge::ChargePostFrame( void )
 						// Grant revenge crits
 						pOwner->m_Shared.SetRevengeCrits( pOwner->m_Shared.GetRevengeCrits() + 1 );
 
-						// Send UserMessage to owner to spawn absorb effect
-						CSingleUserRecipientFilter filter(pOwner);
-						filter.MakeReliable();
-						UserMessageBegin(filter, "ManmelterExtinguishedPlayer");
-						MessageEnd();
-
 						// Return health to the Pyro.
 						int iRestoreHealthOnExtinguish = 0;
 						CALL_ATTRIB_HOOK_INT( iRestoreHealthOnExtinguish, extinguish_restores_health );
@@ -638,17 +636,19 @@ bool CTFFlareGun_Revenge::ExtinguishPlayerInternal( CTFPlayer *pTarget, CTFPlaye
 }
 
 #ifdef CLIENT_DLL
-USER_MESSAGE( ManmelterExtinguishedPlayer )
+void CTFFlareGun_Revenge::FireGameEvent( IGameEvent *event )
 {
-	C_TFPlayer* pPlayer = C_TFPlayer::GetLocalTFPlayer();
-	if (!pPlayer)
-		return;
+	if (FStrEq(event->GetName(), "player_extinguished"))
+	{
+		C_TFPlayer* pLocalPlayer = C_TFPlayer::GetLocalTFPlayer();
+		if (!pLocalPlayer)
+			return;
 
-	CTFFlareGun_Revenge* pWeapon = dynamic_cast<CTFFlareGun_Revenge*>( pPlayer->GetActiveWeapon() );
-	if (!pWeapon)
-		return;
+		if (event->GetInt("healer") != pLocalPlayer->entindex())
+			return;
 
-	pWeapon->DoAbsorbEffect();
+		DoAbsorbEffect();
+	}
 }
 
 void CTFFlareGun_Revenge::OnDataChanged( DataUpdateType_t type )

--- a/src/game/shared/tf/tf_weapon_flaregun.cpp
+++ b/src/game/shared/tf/tf_weapon_flaregun.cpp
@@ -127,7 +127,7 @@ void CTFFlareGun::PrimaryAttack( void )
 	if ( pOwner->GetWaterLevel() != WL_Eyes )
 	{
 		BaseClass::PrimaryAttack();
-		}
+	}
 	else
 	{
 		if ( gpGlobals->curtime > m_flLastDenySoundTime )
@@ -488,23 +488,23 @@ void CTFFlareGun_Revenge::PrimaryAttack()
 	// Lets steal the base CTFFlareGun::PrimaryAttack checks and emulate it here, calling CTFFlareGun::PrimaryAttack and doing our checks afterwards can cause problems!
 
 	// Get the player owning the weapon.
-	CTFPlayer* pOwner = ToTFPlayer(GetPlayerOwner());
-	if (!pOwner)
+	CTFPlayer* pOwner = ToTFPlayer( GetPlayerOwner() );
+	if ( !pOwner )
 		return;
 
-	if (m_flChargeBeginTime > 0.0f)
+	if ( m_flChargeBeginTime > 0.0f )
 		return;
 
 	// Don't attack if we're underwater
-	if (pOwner->GetWaterLevel() != WL_Eyes)
+	if ( pOwner->GetWaterLevel() != WL_Eyes )
 	{
 		CTFWeaponBaseGun::PrimaryAttack();
 	}
 	else
 	{
-		if (gpGlobals->curtime > m_flLastDenySoundTime)
+		if ( gpGlobals->curtime > m_flLastDenySoundTime )
 		{
-			WeaponSound(SPECIAL2);
+			WeaponSound( SPECIAL2 );
 			m_flLastDenySoundTime = gpGlobals->curtime + 1.0f;
 		}
 	}
@@ -637,13 +637,13 @@ bool CTFFlareGun_Revenge::ExtinguishPlayerInternal( CTFPlayer *pTarget, CTFPlaye
 #ifdef CLIENT_DLL
 void CTFFlareGun_Revenge::FireGameEvent( IGameEvent *event )
 {
-	if (FStrEq(event->GetName(), "player_extinguished"))
+	if ( FStrEq( event->GetName(), "player_extinguished" ) )
 	{
 		C_TFPlayer* pLocalPlayer = C_TFPlayer::GetLocalTFPlayer();
-		if (!pLocalPlayer)
+		if ( !pLocalPlayer )
 			return;
 
-		if (event->GetInt("healer") != pLocalPlayer->entindex())
+		if ( event->GetInt( "healer" ) != pLocalPlayer->entindex() )
 			return;
 
 		DoAbsorbEffect();

--- a/src/game/shared/tf/tf_weapon_flaregun.cpp
+++ b/src/game/shared/tf/tf_weapon_flaregun.cpp
@@ -11,6 +11,8 @@
 #ifdef CLIENT_DLL
 #include "c_tf_player.h"
 #include "soundenvelope.h"
+#include "prediction.h"
+#include "usermessages.h"
 // Server specific.
 #else
 #include "tf_gamestats.h"
@@ -126,7 +128,7 @@ void CTFFlareGun::PrimaryAttack( void )
 	if ( pOwner->GetWaterLevel() != WL_Eyes )
 	{
 		BaseClass::PrimaryAttack();
-	}
+		}
 	else
 	{
 		if ( gpGlobals->curtime > m_flLastDenySoundTime )
@@ -480,12 +482,39 @@ void CTFFlareGun_Revenge::PrimaryAttack()
 {
 	if ( !CanAttack() )
 		return;
+	// Lets steal the base CTFFlareGun::PrimaryAttack checks and emulate it here, calling CTFFlareGun::PrimaryAttack and doing our checks afterwards can cause problems!
 
-	BaseClass::PrimaryAttack();
+	// Get the player owning the weapon.
+	CTFPlayer* pOwner = ToTFPlayer(GetPlayerOwner());
+	if (!pOwner)
+		return;
 
-	// Lower the reveng crit count
-	CTFPlayer *pOwner = ToTFPlayer( GetPlayerOwner() );
+	if (m_flChargeBeginTime > 0.0f)
+		return;
+
+	// Don't attack if we're underwater
+	if (pOwner->GetWaterLevel() != WL_Eyes)
+	{
+		CTFWeaponBaseGun::PrimaryAttack();
+	}
+	else
+	{
+		if (gpGlobals->curtime > m_flLastDenySoundTime)
+		{
+			WeaponSound(SPECIAL2);
+			m_flLastDenySoundTime = gpGlobals->curtime + 1.0f;
+		}
+	}
+
+#ifdef CLIENT_DLL
+	m_bReadyToFire = false;
+
+	// Lower the revenge crit count
+	if ( pOwner && ( !prediction->InPrediction() || prediction->IsFirstTimePredicted() ) )
+#elif defined( GAME_DLL )
 	if ( pOwner )
+#endif
+
 	{
 		int iNewRevengeCrits = MAX( pOwner->m_Shared.GetRevengeCrits() - 1, 0 );
 		pOwner->m_Shared.SetRevengeCrits( iNewRevengeCrits );
@@ -553,6 +582,12 @@ void CTFFlareGun_Revenge::ChargePostFrame( void )
 						// Grant revenge crits
 						pOwner->m_Shared.SetRevengeCrits( pOwner->m_Shared.GetRevengeCrits() + 1 );
 
+						// Send UserMessage to owner to spawn absorb effect
+						CSingleUserRecipientFilter filter(pOwner);
+						filter.MakeReliable();
+						UserMessageBegin(filter, "ManmelterExtinguishedPlayer");
+						MessageEnd();
+
 						// Return health to the Pyro.
 						int iRestoreHealthOnExtinguish = 0;
 						CALL_ATTRIB_HOOK_INT( iRestoreHealthOnExtinguish, extinguish_restores_health );
@@ -603,20 +638,22 @@ bool CTFFlareGun_Revenge::ExtinguishPlayerInternal( CTFPlayer *pTarget, CTFPlaye
 }
 
 #ifdef CLIENT_DLL
+USER_MESSAGE( ManmelterExtinguishedPlayer )
+{
+	C_TFPlayer* pPlayer = C_TFPlayer::GetLocalTFPlayer();
+	if (!pPlayer)
+		return;
+
+	CTFFlareGun_Revenge* pWeapon = dynamic_cast<CTFFlareGun_Revenge*>( pPlayer->GetActiveWeapon() );
+	if (!pWeapon)
+		return;
+
+	pWeapon->DoAbsorbEffect();
+}
+
 void CTFFlareGun_Revenge::OnDataChanged( DataUpdateType_t type )
 {
 	BaseClass::OnDataChanged( type );
-
-	CTFPlayer *pOwner = ToTFPlayer( GetPlayerOwner() );
-	if ( pOwner )
-	{
-		if ( m_nOldRevengeCrits < pOwner->m_Shared.GetRevengeCrits() )
-		{
-			DoAbsorbEffect();
-		}
-		
-		m_nOldRevengeCrits = pOwner->m_Shared.GetRevengeCrits();
-	}
 }
 
 void CTFFlareGun_Revenge::DoAbsorbEffect( void )

--- a/src/game/shared/tf/tf_weapon_flaregun.cpp
+++ b/src/game/shared/tf/tf_weapon_flaregun.cpp
@@ -610,7 +610,7 @@ void CTFFlareGun_Revenge::OnDataChanged( DataUpdateType_t type )
 	CTFPlayer *pOwner = ToTFPlayer( GetPlayerOwner() );
 	if ( pOwner )
 	{
-		if ( m_nOldRevengeCrits < pOwner->m_Shared.GetRevengeCrits() )
+		if (pOwner->m_Shared.GetRevengeCrits() == ( m_nOldRevengeCrits + 1 ) && !( m_nOldRevengeCrits == 0 ) )
 		{
 			DoAbsorbEffect();
 		}

--- a/src/game/shared/tf/tf_weapon_flaregun.cpp
+++ b/src/game/shared/tf/tf_weapon_flaregun.cpp
@@ -610,7 +610,7 @@ void CTFFlareGun_Revenge::OnDataChanged( DataUpdateType_t type )
 	CTFPlayer *pOwner = ToTFPlayer( GetPlayerOwner() );
 	if ( pOwner )
 	{
-		if (pOwner->m_Shared.GetRevengeCrits() == ( m_nOldRevengeCrits + 1 ) && !( m_nOldRevengeCrits == 0 ) )
+		if ( m_nOldRevengeCrits < pOwner->m_Shared.GetRevengeCrits() )
 		{
 			DoAbsorbEffect();
 		}

--- a/src/game/shared/tf/tf_weapon_flaregun.h
+++ b/src/game/shared/tf/tf_weapon_flaregun.h
@@ -153,6 +153,7 @@ public:
 #ifdef CLIENT_DLL
 	virtual void OnDataChanged( DataUpdateType_t type );
 	void DoAbsorbEffect( void );
+	virtual void FireGameEvent(IGameEvent *event) OVERRIDE;
 #endif
 
 private:

--- a/src/game/shared/tf/tf_weapon_flaregun.h
+++ b/src/game/shared/tf/tf_weapon_flaregun.h
@@ -84,6 +84,12 @@ protected:
 	int										m_iFlareCount;
 #endif
 
+	float m_flLastDenySoundTime;
+	CNetworkVar(float, m_flChargeBeginTime);
+#ifdef CLIENT_DLL
+	bool m_bReadyToFire;
+#endif
+
 protected:
 	void StartChargeStartTime() { m_flChargeBeginTime = gpGlobals->curtime; }
 
@@ -97,14 +103,11 @@ protected:
 
 private:
 
-	CNetworkVar( float, m_flChargeBeginTime );
 
 	bool m_bEffectsThinking;
-	float m_flLastDenySoundTime;
 
 #if defined( CLIENT_DLL )
 	CSoundPatch	*m_pChargeLoop;
-	bool m_bReadyToFire;
 #endif
 
 	CTFFlareGun( const CTFFlareGun & ) {}


### PR DESCRIPTION
# Description
This PR seeks to fix multiple issues with the Manmelter and hopefully improve the weapon's usability.

**Issue 1**
If the Manmelter has more than 1 crit stored up and the player fires the weapon, the "absorbing fire" particle effect intended for use when extinguishing other players is spawned and obscures a large amount of the player's screen. This is clearly unintentional.

**Issue 2**
If the player holds down both +attack and +attack2 simultaneously then the currently stored crits get expended extremely fast without the weapon being fired. This oversight breaks one of the main benefits of the whole weapon. (This effect also occurs if the weapon is fired underwater)

**Issue 3**
This issue is not as big of a problem as the other two but still notable. In some scenarios the crit counter will appear to deplete rapidly before being "reset" to its true value once the server catches up. (This issue is more prevalent on high-latency connections)
# Videos

**Particle bug demonstration**
https://streamable.com/akm2o6

**Crit loss bug demonstration** (take note of the crit counter in the bottom right)
https://streamable.com/8unzeh

# Issues
Fixes [Source-1-Games #6059](https://github.com/ValveSoftware/Source-1-Games/issues/6059)
Partially fixes [Source-1-Games #4022](https://github.com/ValveSoftware/Source-1-Games/issues/4022)

# Related PRs
If this is merged I would also recommend that #1724 is merged as it also relates to the Manmelter and other flare guns.