### PR TITLE
Fix a crash when a networked entity is parented to a server-only entity

### DIFF
--- a/src/game/server/gameinterface.cpp
+++ b/src/game/server/gameinterface.cpp
@@ -2525,7 +2525,7 @@ void CServerGameEnts::CheckTransmit( CCheckTransmitInfo *pInfo, const unsigned s
 		{
 			// FIXME: Hey! Shouldn't this be using SetTransmit so as 
 			// to also force network down dependent entities?
-			while ( true )
+			while ( pEdict )
 			{
 				// mark entity for sending
 				pInfo->m_pTransmitEdict->Set( iEdict );

--- a/src/game/server/gameinterface.cpp
+++ b/src/game/server/gameinterface.cpp
@@ -2626,6 +2626,9 @@ void CServerGameEnts::CheckTransmit( CCheckTransmitInfo *pInfo, const unsigned s
 			}
 
 			edict_t *checkEdict = check->edict();
+			if ( !checkEdict ) // RaphelIT7: This can happen when a server-only entity is parented to a networked entity!
+				return;
+
 			int checkFlags = checkEdict->m_fStateFlags & (FL_EDICT_DONTSEND|FL_EDICT_ALWAYS|FL_EDICT_PVSCHECK|FL_EDICT_FULLCHECK);
 			if ( checkFlags & FL_EDICT_DONTSEND )
 				break;


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
In the case that a networked entity was parented to a server-only entity, it would have resulted in a crash.
This happened due to `pEnt-> GetNetworkParent ()` returning the server-only entity, but when `pEdict = pParent->edict();` is executed, `pEdict` would become `NULL` since it's server-only and on the next iteration it would crash when attempting to run `pEdict->GetNetworkable()`

This was originally shown to me by @legokidlogan and was fixed in GMod's dev branch after **he** reported it there, but I think this is something that should also be fixed here.

Example code to test it with (though I couldn't test it on the latest sdk build due to the engine.dll crashing on startup?)
```cpp
#if _DEBUG
void CC_Transmit_Crash( const CCommand& args )
{
	// Just some random server-only entity we can parent to
	CBaseEntity *fadeent = dynamic_cast< CBaseEntity * >( CreateEntityByName( "env_fade" ) );
	if ( !fadeent )
	{
		Warning( "Failed to create fade entity!\n" );
		return;
	}

	DispatchSpawn( fadeent );

	// We use the world since for our crash the networked entity MUST use FL_EDICT_ALWAYS
	GetWorldEntity()->SetParent( fadeent );
}
static ConCommand transmit_crash("transmit_crash", CC_Transmit_Crash, "", FCVAR_GAMEDLL);
#endif
```