### PR TITLE
[TF2/HL2MP] Fixes for Sixense (Razer Hydra) Support (Draft)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -502,8 +502,3 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
-/game
-/src/game/client/client_tf.vpc
-/src/createhl2dmprojects.bat
-/src/createtfprojects.bat
-/src/thirdparty/sixensesdk/include

--- a/.gitignore
+++ b/.gitignore
@@ -502,3 +502,4 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+/src/thirdparty/sixensesdk/include

--- a/.gitignore
+++ b/.gitignore
@@ -502,3 +502,8 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+/game
+/src/game/client/client_tf.vpc
+/src/createhl2dmprojects.bat
+/src/createtfprojects.bat
+/src/thirdparty/sixensesdk/include

--- a/.gitignore
+++ b/.gitignore
@@ -502,4 +502,3 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
-/src/thirdparty/sixensesdk/include

--- a/src/game/client/client_hl2mp.vpc
+++ b/src/game/client/client_hl2mp.vpc
@@ -16,6 +16,7 @@ $Configuration
 	{
 		$AdditionalIncludeDirectories		"$BASE;hl2mp\ui,.\hl2mp,$SRCDIR\game\shared\hl2mp,.\hl2,.\hl2\elements,$SRCDIR\game\shared\hl2"
 		$PreprocessorDefinitions			"$BASE;HL2MP;HL2_CLIENT_DLL;NEXT_BOT"
+		$PreprocessorDefinitions            "$BASE;SIXENSE" [!$SOURCESDK]
 	}
 }
 

--- a/src/game/client/sixense/in_sixense.cpp
+++ b/src/game/client/sixense/in_sixense.cpp
@@ -36,7 +36,7 @@ extern const char *COM_GetModDirectory();
 #include "c_cs_player.h"
 #endif
 
-#include <isixense.h>
+#include <sixense.h>
 #include <sixense_math.hpp>
 #include <sixense_utils/interfaces.hpp>
 
@@ -68,6 +68,8 @@ using sixenseMath::Line;
 #include "tf_hud_menu_engy_build.h"
 #include "tf_hud_menu_engy_destroy.h"
 #include "tf_hud_menu_spy_disguise.h"
+#include "tf_hud_menu_taunt_selection.h"
+#include "tf_hud_menu_eureka_teleport.h"
 #endif 
 
 #ifdef PORTAL2
@@ -376,25 +378,63 @@ bool SixenseInput::LoadModules()
 	if( m_bModulesLoaded ) 
 		return true;
 
-	// Try to load the sixense DLLs
+	// Try to load the sixense DLLs/libraries
 
-	g_pSixenseModule = Sys_LoadModule( "sixense" );
+	#if defined(_WIN64)
+		Msg("Attempting to load sixense_x64.dll \n");
+		g_pSixenseModule = Sys_LoadModule( "sixense_x64.dll" );
+		if( !g_pSixenseModule )
+		{
+			Msg("Failed to load sixense_x64.dll \n");
+			return false;
+		}
+	#elif defined(__linux__) && defined(__x86_64__)
+		Msg("Attempting to load libsixense_x64.so \n");
+		g_pSixenseModule = Sys_LoadModule( "libsixense_x64.so" );
+		if( !g_pSixenseModule )
+		{
+			Msg("Failed to load libsixense_x64.so \n");
+			Msg("dlerror: %s\n", dlerror());
+			return false;
+		}
+	#else //WIN32
+		Msg("Attempting to load sixense.dll \n");
+		g_pSixenseModule = Sys_LoadModule( "sixense.dll" );
+		if( !g_pSixenseModule )
+		{
+			Msg("Failed to load sixense.dll \n");
+			return false;
+		}
+	#endif
 
-	if( !g_pSixenseModule )
-	{
-		Msg("Failed to load sixense.dll\n");
-		return false;
-	}
+	#if defined(_WIN64)
+		Msg("Attempting to load sixense_utils_x64.dll \n");
+		g_pSixenseUtilsModule = Sys_LoadModule( "sixense_utils_x64.dll" );
+		if( !g_pSixenseModule )
+		{
+			Msg("Failed to load sixense_utils_x64.dll \n");
+			return false;
+		}
+	#elif defined(__linux__) && defined(__x86_64__)
+		Msg("Attempting to load libsixense_utils_x64.so \n");
+		g_pSixenseUtilsModule = Sys_LoadModule( "libsixense_utils_x64.so" );
+		if( !g_pSixenseModule )
+		{
+			Msg("Failed to load libsixense_utils_x64.so \n");
+			Msg("dlerror: %s\n", dlerror());
+			return false;
+		}
+	#else //WIN32
+		Msg("Attempting to load sixense_utils.dll \n");
+		g_pSixenseUtilsModule = Sys_LoadModule( "sixense_utils.dll" );
+		if( !g_pSixenseModule )
+		{
+			Msg("Failed to load sixense_utils.dll \n");
+			return false;
+		}
+	#endif
 
-	g_pSixenseUtilsModule = Sys_LoadModule( "sixense_utils" );
-
-	if( !g_pSixenseUtilsModule )
-	{
-		Msg("Failed to load sixense_utils.dll\n");
-		return false;
-	}
-
-	Msg("Successfully loaded sixense modules.\n");
+	Msg("Successfully found sixense modules.\n");
 
 	bool found_objects = false;
 
@@ -415,7 +455,7 @@ bool SixenseInput::LoadModules()
 
 	if( !found_objects ) 
 	{
-		Msg("Failed to find factory in sixense.dll\n");
+		Msg("Failed to find factory in sixense module\n");
 		return false;
 	}
 
@@ -455,7 +495,7 @@ bool SixenseInput::LoadModules()
 
 	if( !found_objects ) 
 	{
-		Msg("Failed to find factory in sixense_utils.dll\n");
+		Msg("Failed to find factory in sixense_utils module\n");
 		return false;
 	}
 
@@ -465,6 +505,7 @@ bool SixenseInput::LoadModules()
 
 	// We can't set the mode until modules are loaded, so do it now
 	SetMode( sixense_mode.GetInt() );
+	Msg("Successfully initialized sixense modules.\n");
 
 	return true;
 }
@@ -629,7 +670,7 @@ ConCommand sixense_autosave( "sixense_autosave", SixenseAutosave );
 #ifdef INPUT_EVENTS
 static void sendMouseClick( int click, int release )
 {
-#ifdef WIN32
+#if defined WIN32
 	// Set up the input event struct
 	INPUT input_ev[1]; 
 
@@ -682,7 +723,7 @@ static void sendMouseClick( int click, int release )
 
 static void sendKeyState( char key, int press, int release )
 {
-#ifdef WIN32
+#if defined WIN32
 	// Set up the input event struct
 	INPUT input_ev[1];
 
@@ -717,7 +758,7 @@ static void sendKeyState( char key, int press, int release )
 
 static void sendAbsoluteMouseMove( float x, float y ) 
 {
-#ifdef WIN32
+#if defined WIN32
 	// Set up the input event struct
 	INPUT input_ev[1];
 
@@ -2815,6 +2856,70 @@ void SixenseInput::SixenseUpdateKeys( float flFrametime, CUserCmd *pCmd )
 		}
 	}
 
+	CHudEurekaEffectTeleportMenu *pEurekaEffectTeleportMenu = ( CHudEurekaEffectTeleportMenu * )GET_HUDELEMENT( CHudEurekaEffectTeleportMenu );
+	if (pEurekaEffectTeleportMenu->IsVisible())
+	{
+		if( m_pRightButtonStates->buttonJustPressed( SIXENSE_BUTTON_3 ))
+		{
+			pEurekaEffectTeleportMenu->HudElementKeyInput( 1, KEY_1, "eureka_teleport 0" );
+		}
+		if( m_pRightButtonStates->buttonJustPressed( SIXENSE_BUTTON_4 ))
+		{
+			pEurekaEffectTeleportMenu->HudElementKeyInput( 1, KEY_2, "eureka_teleport 1" );
+		}
+		if( m_pRightButtonStates->stickJustPressed(sixenseUtils::IButtonStates::DIR_DOWN ) )
+		{
+			engine->ClientCmd( "lastinv" );
+		}
+	}
+
+	CHudMenuTauntSelection *pTauntSelection = ( CHudMenuTauntSelection * )GET_HUDELEMENT( CHudMenuTauntSelection );
+	if (pTauntSelection->IsVisible())
+	{
+		if( m_pLeftButtonStates->buttonJustPressed( SIXENSE_BUTTON_3 ) )
+		{
+			pTauntSelection->HudElementKeyInput( 1, KEY_1, "slot1" );
+		}
+		if( m_pLeftButtonStates->buttonJustPressed( SIXENSE_BUTTON_1 ) )
+		{
+			pTauntSelection->HudElementKeyInput( 1, KEY_2, "slot2" );
+		}
+		if( m_pLeftButtonStates->buttonJustPressed( SIXENSE_BUTTON_2 ) )
+		{
+			pTauntSelection->HudElementKeyInput( 1, KEY_3, "slot3" );
+		}
+		if( m_pLeftButtonStates->buttonJustPressed( SIXENSE_BUTTON_4 ) )
+		{
+			pTauntSelection->HudElementKeyInput( 1, KEY_4, "slot4" );
+		}
+		if( m_pRightButtonStates->buttonJustPressed( SIXENSE_BUTTON_3 ) )
+		{
+			pTauntSelection->HudElementKeyInput( 1, KEY_5, "slot5" );
+		}
+		if( m_pRightButtonStates->buttonJustPressed( SIXENSE_BUTTON_1 ) )
+		{
+			pTauntSelection->HudElementKeyInput( 1, KEY_6, "slot6" );
+		}
+		if( m_pRightButtonStates->buttonJustPressed( SIXENSE_BUTTON_2 ) )
+		{
+			pTauntSelection->HudElementKeyInput( 1, KEY_7, "slot7" );
+		}
+		if( m_pRightButtonStates->buttonJustPressed( SIXENSE_BUTTON_4 ) )
+		{
+			pTauntSelection->HudElementKeyInput( 1, KEY_8, "slot8" );
+		}
+		if( m_pRightButtonStates->buttonJustPressed( SIXENSE_BUTTON_BUMPER ) )
+		{
+			engine->ExecuteClientCmd( "taunt" );
+		}
+		if( m_pRightButtonStates->stickJustPressed( sixenseUtils::IButtonStates::DIR_DOWN ) )
+		{
+			//	engine->ExecuteClientCmd( "lastinv" );  This solution does not work with the taunt menu specifically. Hacky workaround implemented.
+			::sendKeyState(0x16, 0, 1); // 0x16 == Q key scancode
+			//  SetShowHudMenuTauntSelection( false );
+		}
+	}
+
 	if ( TFGameRules() && TFGameRules()->IsInTraining() )
 	{
 		if( m_pLeftButtonStates->absoluteTiltJustStarted( sixenseUtils::IButtonStates::DIR_UP ) )
@@ -4032,6 +4137,18 @@ bool SixenseInput::AreBindingsDisabled()
 
 	CHudMenuEngyDestroy *pEngDestroyMenu = ( CHudMenuEngyDestroy * )GET_HUDELEMENT( CHudMenuEngyDestroy );
 	if( pEngDestroyMenu->IsVisible() ) 
+	{
+		return true;
+	}
+
+	CHudMenuTauntSelection* pTauntSelection = (CHudMenuTauntSelection*)GET_HUDELEMENT(CHudMenuTauntSelection);
+	if (pTauntSelection->IsVisible())
+	{
+		return true;
+	}
+
+	CHudEurekaEffectTeleportMenu* pEurekaEffectTeleportMenu = (CHudEurekaEffectTeleportMenu*)GET_HUDELEMENT(CHudEurekaEffectTeleportMenu);
+	if (pEurekaEffectTeleportMenu->IsVisible())
 	{
 		return true;
 	}

--- a/src/game/client/sixense/in_sixense.cpp
+++ b/src/game/client/sixense/in_sixense.cpp
@@ -2914,9 +2914,12 @@ void SixenseInput::SixenseUpdateKeys( float flFrametime, CUserCmd *pCmd )
 		}
 		if( m_pRightButtonStates->stickJustPressed( sixenseUtils::IButtonStates::DIR_DOWN ) )
 		{
-				engine->ExecuteClientCmd( "lastinv" );  // This solution does not work with the taunt menu specifically. 
-			//::sendKeyState(0x16, 0, 1); // 0x16 == Q key scancode
-			//  SetShowHudMenuTauntSelection( false );
+			//engine->ExecuteClientCmd("taunt"); Does not work with taunt menu specifically, so we're doing what the Steam Controller does to close the taunt menu instead. 
+			CTFPlayer* pPlayer = C_TFPlayer::GetLocalTFPlayer();
+			if (pPlayer)
+			{
+				pPlayer->SetShowHudMenuTauntSelection(false);
+			}
 		}
 	}
 

--- a/src/game/client/sixense/in_sixense.cpp
+++ b/src/game/client/sixense/in_sixense.cpp
@@ -2914,8 +2914,8 @@ void SixenseInput::SixenseUpdateKeys( float flFrametime, CUserCmd *pCmd )
 		}
 		if( m_pRightButtonStates->stickJustPressed( sixenseUtils::IButtonStates::DIR_DOWN ) )
 		{
-			//	engine->ExecuteClientCmd( "lastinv" );  This solution does not work with the taunt menu specifically. Hacky workaround implemented.
-			::sendKeyState(0x16, 0, 1); // 0x16 == Q key scancode
+				engine->ExecuteClientCmd( "lastinv" );  // This solution does not work with the taunt menu specifically. 
+			//::sendKeyState(0x16, 0, 1); // 0x16 == Q key scancode
 			//  SetShowHudMenuTauntSelection( false );
 		}
 	}

--- a/src/game/client/sixense/in_sixense.cpp
+++ b/src/game/client/sixense/in_sixense.cpp
@@ -434,12 +434,11 @@ bool SixenseInput::LoadModules()
 		}
 	#endif
 
-	Msg("Successfully found sixense modules.\n");
-
 	bool found_objects = false;
 
 	if(g_pSixenseModule)
 	{
+		Msg("Successfully found sixense module.\n");
 		CreateInterfaceFn factory = Sys_GetFactory( g_pSixenseModule );
 
 		if( factory ) 
@@ -465,6 +464,7 @@ bool SixenseInput::LoadModules()
 
 	if(g_pSixenseUtilsModule)
 	{
+		Msg("Successfully found sixense_utils module.\n");
 		CreateInterfaceFn factory = Sys_GetFactory( g_pSixenseUtilsModule );
 
 		if( factory ) 

--- a/src/game/client/sixense/in_sixense.cpp
+++ b/src/game/client/sixense/in_sixense.cpp
@@ -378,58 +378,58 @@ bool SixenseInput::LoadModules()
 	if( m_bModulesLoaded ) 
 		return true;
 
-	// Try to load the sixense DLLs/libraries
+	// Try to load the sixense libraries
 
 	#if defined(_WIN64)
-		Msg("Attempting to load sixense_x64.dll \n");
+		Msg( "Attempting to load sixense_x64.dll \n" );
 		g_pSixenseModule = Sys_LoadModule( "sixense_x64.dll" );
 		if( !g_pSixenseModule )
 		{
-			Msg("Failed to load sixense_x64.dll \n");
+			Msg( "Failed to load sixense_x64.dll \n" );
 			return false;
 		}
 	#elif defined(__linux__) && defined(__x86_64__)
-		Msg("Attempting to load libsixense_x64.so \n");
+		Msg( "Attempting to load libsixense_x64.so \n" );
 		g_pSixenseModule = Sys_LoadModule( "libsixense_x64.so" );
 		if( !g_pSixenseModule )
 		{
-			Msg("Failed to load libsixense_x64.so \n");
-			Msg("dlerror: %s\n", dlerror());
+			Msg( "Failed to load libsixense_x64.so \n" );
+			Msg( "dlerror: %s\n", dlerror() );
 			return false;
 		}
 	#else //WIN32
-		Msg("Attempting to load sixense.dll \n");
+		Msg( "Attempting to load sixense.dll \n" );
 		g_pSixenseModule = Sys_LoadModule( "sixense.dll" );
 		if( !g_pSixenseModule )
 		{
-			Msg("Failed to load sixense.dll \n");
+			Msg( "Failed to load sixense.dll \n );
 			return false;
 		}
 	#endif
 
 	#if defined(_WIN64)
-		Msg("Attempting to load sixense_utils_x64.dll \n");
+		Msg( "Attempting to load sixense_utils_x64.dll \n" );
 		g_pSixenseUtilsModule = Sys_LoadModule( "sixense_utils_x64.dll" );
 		if( !g_pSixenseModule )
 		{
-			Msg("Failed to load sixense_utils_x64.dll \n");
+			Msg( "Failed to load sixense_utils_x64.dll \n" );
 			return false;
 		}
 	#elif defined(__linux__) && defined(__x86_64__)
-		Msg("Attempting to load libsixense_utils_x64.so \n");
+		Msg( "Attempting to load libsixense_utils_x64.so \n ");
 		g_pSixenseUtilsModule = Sys_LoadModule( "libsixense_utils_x64.so" );
 		if( !g_pSixenseModule )
 		{
-			Msg("Failed to load libsixense_utils_x64.so \n");
-			Msg("dlerror: %s\n", dlerror());
+			Msg( "Failed to load libsixense_utils_x64.so \n" );
+			Msg( "dlerror: %s\n", dlerror() );
 			return false;
 		}
 	#else //WIN32
-		Msg("Attempting to load sixense_utils.dll \n");
+		Msg( "Attempting to load sixense_utils.dll \n" );
 		g_pSixenseUtilsModule = Sys_LoadModule( "sixense_utils.dll" );
 		if( !g_pSixenseModule )
 		{
-			Msg("Failed to load sixense_utils.dll \n");
+			Msg( "Failed to load sixense_utils.dll \n" );
 			return false;
 		}
 	#endif
@@ -438,7 +438,7 @@ bool SixenseInput::LoadModules()
 
 	if(g_pSixenseModule)
 	{
-		Msg("Successfully found sixense module.\n");
+		Msg( "Successfully found sixense module.\n" );
 		CreateInterfaceFn factory = Sys_GetFactory( g_pSixenseModule );
 
 		if( factory ) 
@@ -454,7 +454,7 @@ bool SixenseInput::LoadModules()
 
 	if( !found_objects ) 
 	{
-		Msg("Failed to find factory in sixense module\n");
+		Msg( "Failed to find factory in sixense module\n" );
 		return false;
 	}
 
@@ -464,7 +464,7 @@ bool SixenseInput::LoadModules()
 
 	if(g_pSixenseUtilsModule)
 	{
-		Msg("Successfully found sixense_utils module.\n");
+		Msg( "Successfully found sixense_utils module.\n" );
 		CreateInterfaceFn factory = Sys_GetFactory( g_pSixenseUtilsModule );
 
 		if( factory ) 
@@ -495,7 +495,7 @@ bool SixenseInput::LoadModules()
 
 	if( !found_objects ) 
 	{
-		Msg("Failed to find factory in sixense_utils module\n");
+		Msg( "Failed to find factory in sixense_utils module\n" );
 		return false;
 	}
 
@@ -505,7 +505,7 @@ bool SixenseInput::LoadModules()
 
 	// We can't set the mode until modules are loaded, so do it now
 	SetMode( sixense_mode.GetInt() );
-	Msg("Successfully initialized sixense modules.\n");
+	Msg( "Successfully initialized sixense modules.\n" );
 
 	return true;
 }
@@ -670,7 +670,7 @@ ConCommand sixense_autosave( "sixense_autosave", SixenseAutosave );
 #ifdef INPUT_EVENTS
 static void sendMouseClick( int click, int release )
 {
-#if defined WIN32
+#ifdef WIN32
 	// Set up the input event struct
 	INPUT input_ev[1]; 
 
@@ -723,7 +723,7 @@ static void sendMouseClick( int click, int release )
 
 static void sendKeyState( char key, int press, int release )
 {
-#if defined WIN32
+#ifdef WIN32
 	// Set up the input event struct
 	INPUT input_ev[1];
 
@@ -758,7 +758,7 @@ static void sendKeyState( char key, int press, int release )
 
 static void sendAbsoluteMouseMove( float x, float y ) 
 {
-#if defined WIN32
+#ifdef WIN32
 	// Set up the input event struct
 	INPUT input_ev[1];
 
@@ -873,9 +873,10 @@ SixenseInput::SixenseInput()
 
 	m_bJustSpawned = false;
 
-	// For keeping track of the previous mode when looking down the scope changes it.
+	// For keeping track of the previous mode when looking down the scope or shield charging changes it.
 	m_bScopeSwitchedMode = false;
 	m_nScopeSwitchedPrevSpringViewEnabled = 0;
+	m_nChargingPrevSpringViewEnabled = 0;
 
 	m_pGestureBindings = new SixenseGestureBindings;
 
@@ -1787,7 +1788,6 @@ bool SixenseInput::SixenseFrame( float flFrametime, CUserCmd *pCmd )
 
 
 	CheckWeaponForScope();
-
 	return true;
 }
 
@@ -2542,24 +2542,29 @@ void SixenseInput::SetView( float flInputSampleFrametime, CUserCmd *pCmd )
 
 
 #if defined( TF_CLIENT_DLL )
-	// Dont turn when charging
-	if( !charging )
+    // Identify when the player is/isn't charging. Force view angle to recenter on charge end, then reposition crosshair to where it would be if it were allowed to move during a charge.
+	// Normal Sixense view angle behavior at all other times. 
+    if ( !charging )
+    {
+        engine->SetViewAngles( new_viewangles );
+		m_nChargingPrevSpringViewEnabled = sixense_spring_view_enabled.GetInt();
+    }
+	if( charging )
 	{
+		sixense_spring_view_enabled.SetValue(m_nChargingPrevSpringViewEnabled);
+		m_nChargingPrevSpringViewEnabled = sixense_spring_view_enabled.GetInt();
 		engine->SetViewAngles( new_viewangles );
 	}
-
-	if( charge_stopped )
-	{
-
-		QAngle engine_angles;
-		engine->GetViewAngles( engine_angles );
-
-		ForceViewAngles( engine_angles );
-		Msg("charge stopped\n");
-	}
+    if( charge_stopped )
+    {
+		sixense_spring_view_enabled.SetValue(m_nChargingPrevSpringViewEnabled);
+        QAngle engine_angles;
+        engine->GetViewAngles( engine_angles );
+        ForceViewAngles( engine_angles );
+    }
 #else
-	// Set the engine's aim direction
-	engine->SetViewAngles( new_viewangles );
+    // Set the engine's aim direction
+    engine->SetViewAngles( new_viewangles );
 #endif
 
 	if ( pCmd )
@@ -2914,11 +2919,11 @@ void SixenseInput::SixenseUpdateKeys( float flFrametime, CUserCmd *pCmd )
 		}
 		if( m_pRightButtonStates->stickJustPressed( sixenseUtils::IButtonStates::DIR_DOWN ) )
 		{
-			//engine->ExecuteClientCmd("taunt"); Does not work with taunt menu specifically, so we're doing what the Steam Controller does to close the taunt menu instead. 
+			// "engine->ExecuteClientCmd("lastinv");" Does not work with taunt menu specifically, so we're doing what the Steam Controller does to close the taunt menu instead. 
 			CTFPlayer* pPlayer = C_TFPlayer::GetLocalTFPlayer();
 			if (pPlayer)
 			{
-				pPlayer->SetShowHudMenuTauntSelection(false);
+				pPlayer->SetShowHudMenuTauntSelection( false );
 			}
 		}
 	}

--- a/src/game/client/sixense/in_sixense.h
+++ b/src/game/client/sixense/in_sixense.h
@@ -26,11 +26,11 @@ namespace sixenseUtils {
 	class IFPSPlayerMovement;
 	class IFPSEvents;
 	class IFPSMeleeWeapon;
-
+	class IMousePointer;
 	class IDerivatives;
 	class IButtonStates;
 	class ILaserPointer;
-
+	class IMouseAndKeyboard;
 	class IControllerManager;
 };
 
@@ -197,6 +197,7 @@ private:
 	bool m_bScopeSwitchedMode;
 	sixenseUtils::IFPSViewAngles::fps_mode m_nScopeSwitchedPrevMode;
 	int m_nScopeSwitchedPrevSpringViewEnabled;
+	int m_nChargingPrevSpringViewEnabled;
 
 	float m_fTeleportWaitToBlendTime;
 
@@ -236,11 +237,11 @@ private:
 	class sixenseUtils::IFPSViewAngles *m_pFPSViewAngles;
 	class sixenseUtils::IFPSPlayerMovement *m_pFPSPlayerMovement;
 	class sixenseUtils::IFPSEvents *m_pFPSEvents;
-
+	class sixenseUtils::IMousePointer* m_pMousePointer;
 	class sixenseUtils::IDerivatives *m_pLeftDeriv, *m_pRightDeriv;
 	class sixenseUtils::IButtonStates *m_pLeftButtonStates, *m_pRightButtonStates;
 	class sixenseUtils::ILaserPointer *m_pLaserPointer;
-
+	class sixenseUtils::IMouseAndKeyboard* m_pMouseAndKeyboard;
 	class sixenseUtils::IControllerManager *m_pControllerManager;
 
 	int m_LastViewMode;

--- a/src/game/client/sixense/in_sixense.h
+++ b/src/game/client/sixense/in_sixense.h
@@ -200,7 +200,36 @@ private:
 
 	float m_fTeleportWaitToBlendTime;
 
-	class ISixenseAPI *m_pSixenseAPI;
+	class ISixenseAPI
+	{
+	public:
+		virtual int sixenseInit( void );
+		virtual int sixenseExit( void );
+		virtual int sixenseGetMaxBases();
+		virtual int sixenseSetActiveBase( int i );
+		virtual int sixenseIsBaseConnected( int i );
+		virtual int sixenseGetMaxControllers( void );
+		virtual int sixenseIsControllerEnabled( int which );
+		virtual int sixenseGetNumActiveControllers();
+		virtual int sixenseGetHistorySize();
+		virtual int sixenseGetData( int which, int index_back, sixenseControllerData * );
+		virtual int sixenseGetAllData( int index_back, sixenseAllControllerData * );
+		virtual int sixenseGetNewestData( int which, sixenseControllerData * );
+		virtual int sixenseGetAllNewestData( sixenseAllControllerData * );
+		virtual int sixenseSetHemisphereTrackingMode( int which_controller, int state );
+		virtual int sixenseGetHemisphereTrackingMode( int which_controller, int *state );
+		virtual int sixenseAutoEnableHemisphereTracking( int which_controller );
+		virtual int sixenseSetHighPriorityBindingEnabled( int on_or_off );
+		virtual int sixenseGetHighPriorityBindingEnabled( int *on_or_off );
+		virtual int sixenseTriggerVibration( int controller_id, int duration_100ms, int pattern_id );
+		virtual int sixenseSetFilterEnabled( int on_or_off );
+		virtual int sixenseGetFilterEnabled( int *on_or_off );
+		virtual int sixenseSetFilterParams( float near_range, float near_val, float far_range, float far_val );
+		virtual int sixenseGetFilterParams( float *near_range, float *near_val, float *far_range, float *far_val );
+		virtual int sixenseSetBaseColor( unsigned char red, unsigned char green, unsigned char blue );
+		virtual int sixenseGetBaseColor( unsigned char *red, unsigned char *green, unsigned char *blue );
+	};
+	ISixenseAPI *m_pSixenseAPI;
 
 	struct _sixenseAllControllerData *m_pACD;
 

--- a/src/game/client/sixense/in_sixense_gesture_bindings.cpp
+++ b/src/game/client/sixense/in_sixense_gesture_bindings.cpp
@@ -9,7 +9,7 @@
 #include "tf_gamerules.h"
 #endif
 
-#include <isixense.h>
+#include <sixense.h>
 #include <sixense_math.hpp>
 #include <sixense_utils/interfaces.hpp>
 
@@ -428,9 +428,11 @@ void SixenseGestureBindings::CreateDefaultBindings()
 #elif defined( TF_CLIENT_DLL )
 
 	AddBinding( "left", "tilt_gesture", "ccw", "+reload", "" );
+	AddBinding( "left", "tilt_gesture", "cw", "+use_action_slot_item", "" );
 	AddBinding( "left", "tilt_gesture", "down", "+duck", "" );
 	AddBinding( "left", "tilt_gesture", "up", "+jump", "" );
 	AddBinding( "left", "tilt_gesture", "right", "impulse 201", "" );
+	AddBinding( "left", "tilt_gesture", "left", "player_ready_toggle", "" );
 	AddBinding( "left", "trigger_press", "", "+attack2", "" );
 	AddBinding( "left", "button_press", "start", "cancelselect", "" );
 	AddBinding( "left", "button_press", "bumper", "+duck", "" );
@@ -441,6 +443,8 @@ void SixenseGestureBindings::CreateDefaultBindings()
 	AddBinding( "left", "button_press", "2", "changeteam", "" );
 	AddBinding( "left", "button_press", "4", "lastdisguise", "" );
 	AddBinding( "left", "button_press", "joystick", "voicemenu 0 0", "" );
+	AddBinding( "right", "tilt_gesture", "ccw", "+inspect", "" );
+	AddBinding( "right", "tilt_gesture", "cw", "+attack3", "" );
 	AddBinding( "right", "joystick_move", "up", "+context_action", "" );
 	AddBinding( "right", "joystick_move", "left", "invprev", "" );
 	AddBinding( "right", "joystick_move", "right", "invnext", "" );
@@ -450,7 +454,7 @@ void SixenseGestureBindings::CreateDefaultBindings()
 	AddBinding( "right", "button_press", "3", "+voicerecord", "" );
 	AddBinding( "right", "button_press", "4", "cl_trigger_first_notification", "" );
 	AddBinding( "right", "button_press", "joystick", "dropitem", "" );
-	AddBinding( "right", "button_press", "bumper", "taunt", "" );
+	AddBinding( "right", "button_press", "bumper", "+jump", "" );
 	AddBinding( "right", "trigger_press", "", "+attack", "" );
 	AddBinding( "right", "button_press", "start", "+showscores", "" );
 


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin; and 
2.3	You will include Valve with any third-party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

The changes needed to restore and reinstate Sixense (Razer Hydra) support in the Source engine. When complete, this Pull Request should address Source 1 Issues 1666, 2530, and 5532. Commit is a draft. 


**What's changed:**

in_sixense.cpp
- Updated the library check to look for and initialize the correct library based on OS and system architecture.
- Added more console messages to initialization to identify and aid in troubleshooting.
- Updated includes to look for sixense.h from the Sixense SDK instead of isixense.h which isn't public.
- [TF] Updated includes and added binds for the Eureka Effect and the Taunt menu.
- [TF] Update functions related to Demoknight shield charges to allow for charge turning; charge turning was not possible with any shield when using Sixense input prior.

in_sixense.h
- Updated iSixenseAPI class and pointer to fix "not defined" error.
- Updated includes to look for sixense.h from the Sixense SDK instead of isixense.h which isn't public.
- Added new classes to sixenseUtils namespace.

in_sixense_gesture_bindings.cpp
- Updated TF_CLIENT_DLL default bindings to add missing controls '+attack3', '+use_action_slot_item', 'player_ready_toggle', and '+inspect'. - Rebinds right bumper to '+jump' (was '+taunt', taunt bind is now only active when the taunt menu is open; the default bind for which is up on the Right analog stick). Jump rebind made to have parity with default Steam Controller/Steam Deck grip buttons layout.
- Updated includes to look for sixense.h from the Sixense SDK instead of isixense.h which isn't public.

client_hl2mp.vpc
- Added $PreprocessorDefinition for "$BASE;SIXENSE" to the $Compiler section. Disabled in SOURCESDK by default, just like client_tf.vpc.


**What needs to be done:**

in_sixense.cpp
- Update input event structs to support more platforms than Win32 to allow for emulated mouse/keyboard input in the in-game menus.
- Resolve errors in Linux support (Failed to find factory in sixense module)
- [TF] Add bind and update includes to allow for cancelling looping/moving taunts, currently not possible without reaching over to keyboard.
- [TF] Add dedicated default binds for Halloween bumper car. Currently reuses TF's Sixense binds which maps bumper car turning to the inverse of camera movement and has other oddities.

client_[GAME].vpc
- (VALVE) Update other Source game VPCs to re-enable support for Sixense (Razer Hydra).


**What I'd like to do, but isn't needed:**

- Various changes to enable games to receive simultaneous input from Sixense devices, keyboard and mouse, and the Steam input API, allowing button inputs to be rebound via Steam Input instead of cfg file.
- [TF] Update to allow Contracker panel to be closed from the Sixense device (view of the panel can be closed, but panel remains open in background, locking player input).


**How to set up:**

This commit is reliant on the official Sixense SDK (Steam AppID 42300) to operate. I am not the rights holder to the Sixense SDK; I am explicitly identifying the Sixense SDK as being sourced from a third party, as per section 2.2 of the Contribution guidelines. I legally licensed a copy of the Sixense SDK as I have an instance of the Sixense SDK through my Steam library. The Sixense SDK is subject to terms and conditions which prohibit open redistribution of some files in uncompiled form (such as a public Git repository like this one). 

As Source engine games have previously shipped with Sixense support in their 32-bit versions, Valve is already bound by the same or similar licensing terms as I am. Instead of including the necessary libraries and third party include directories with this commit which would be in violation of Sixense's terms, I will provide written instructions to recreate the setup needed for compiling with Sixense support. The license terms for the Sixense SDK are available [here (Steam).](https://store.steampowered.com/eula/eula_testapp42300)

1. In the original client_tf.vpc and the updated client_hl2mp.vpc I've provided, remove the exclamation mark ("!") from the front of the [!$SOURCESDK] Preprocessor Definition in the Compiler Configuration section of the respective VPC files.

2. In 'source-sdk-2013/src/thirdparty', create a new folder called 'sixensesdk' (case sensitive). Copy and paste the 'include' directory from your copy of the SixenseSDK into the new sixensesdk folder in the thirdparty directory. When complete, the path should be 'source-sdk-2013/src/thirdparty/sixensesdk/include/'.

3.1. For Windows 64-bit, obtain 'sixense_x64.dll' and 'sixense_utils_x64.dll' from the SixenseSDK/bin/x64 directory of the Sixense SDK, and copy them to your mod's 'source-sdk-2013/game/bin/x64' for mod development, or 'steamapps/common/Source SDK Base 2013 Multiplayer/bin/x64' for continuing on this Git Pull request.

3.2. For Linux 64-bit, obtain 'libsixense_x64.so' and 'libsixense_utils_x64.so' from the 'SixenseSDK/lib/linux_x64/release' directory of the Sixense SDK, and copy them to the directory 'steamapps/common/Source SDK Base 2013 Multiplayer/bin/linux64'. Loading the libraries from the mod's 'game/bin' directory doesn't appear to be possible, and setting $LD_ENVIRONMENT_PATH to a directory with the libraries manually provides inconsistent results.

3.3 (VALVE) Obtain the Windows 32-bit 'sixense.dll' and 'sixense_utils.dll' from the Sixense SDK and copy them to the appropriate 32-bit engine directory (Sixense support is currently broken in 32-bit Windows binaries, and this will make sure the library build versions are the same between 32-bit and 64-bit.)

4. Compile source-sdk-2013 as Release.