### PR TITLE
Optimize UTIL_CreateScaledPhysObject

### DIFF
--- a/src/game/server/props.cpp
+++ b/src/game/server/props.cpp
@@ -6044,7 +6044,7 @@ bool UTIL_CreateScaledPhysObject( CBaseAnimating *pInstance, float flScale )
 		physcollision->DestroyQueryModel( pQuery );
 
 		// Create a collision model from all the convexes
-		pNewCollide = physcollision->ConvertPolysoupToCollide( pPolySoups, true );
+		pNewCollide = physcollision->ConvertPolysoupToCollide( pPolySoups, false );
 		if ( pNewCollide == NULL )
 			return false;
 	}

--- a/src/game/server/props.cpp
+++ b/src/game/server/props.cpp
@@ -6016,7 +6016,7 @@ bool UTIL_CreateScaledPhysObject( CBaseAnimating *pInstance, float flScale )
 
 		// Create a container to hold all the convexes we'll create
 		const int nNumConvex = pQuery->ConvexCount();
-		CPhysConvex **pConvexes = (CPhysConvex **) stackalloc( sizeof(CPhysConvex *) * nNumConvex );
+		CPhysPolysoup *pPolySoups = physcollision->PolysoupCreate();
 
 		// For each convex, collect the verts and create a convex from it we'll retain for later
 		for ( int i = 0; i < nNumConvex; i++ )
@@ -6025,7 +6025,6 @@ bool UTIL_CreateScaledPhysObject( CBaseAnimating *pInstance, float flScale )
 			int nNumVerts = nNumTris * 3;
 			// FIXME: Really?  stackalloc?
 			Vector *pVerts = (Vector *) stackalloc( sizeof(Vector) * nNumVerts );
-			Vector **ppVerts = (Vector **) stackalloc( sizeof(Vector *) * nNumVerts );
 			for ( int j = 0; j < nNumTris; j++ )
 			{
 				// Get all the verts for this triangle and scale them up
@@ -6033,25 +6032,19 @@ bool UTIL_CreateScaledPhysObject( CBaseAnimating *pInstance, float flScale )
 				*(pVerts+(j*3)) *= flScale;
 				*(pVerts+(j*3)+1) *= flScale;
 				*(pVerts+(j*3)+2) *= flScale;
-
-				// Setup our pointers (blech!)
-				*(ppVerts+(j*3)) = pVerts+(j*3);
-				*(ppVerts+(j*3)+1) = pVerts+(j*3)+1;
-				*(ppVerts+(j*3)+2) = pVerts+(j*3)+2;
 			}
 
-			// Convert it back to a convex
-			pConvexes[i] = physcollision->ConvexFromVerts( ppVerts, nNumVerts );
-			Assert( pConvexes[i] != NULL );
-			if ( pConvexes[i] == NULL )
-				return false;
+			for ( int j = 0; j < nNumVerts; j += 3 )
+			{
+				physcollision->PolysoupAddTriangle( pPolySoups, pVerts[j], pVerts[j + 1], pVerts[j + 2], 0 );
+			}
 		}
 
 		// Clean up
 		physcollision->DestroyQueryModel( pQuery );
 
 		// Create a collision model from all the convexes
-		pNewCollide = physcollision->ConvertConvexToCollide( pConvexes, nNumConvex );
+		pNewCollide = physcollision->ConvertPolysoupToCollide( pPolySoups, true );
 		if ( pNewCollide == NULL )
 			return false;
 	}


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
I made this back in like 2024, though it should be merged upstream for everyone's benefit :)
This optimizes UTIL_CreateScaledPhysObject by switching it to use CPhysPolysoup which is way faster.
I've suggested this change for GMod around a week ago and has been working great there on the dev branch.

This is an old performance test from when I made it since I **can't** test it with the sdk when the engine keeps crashing :/
Though even in GMod it was confirmed to be significantly faster.
<img width="300" height="98" alt="image" src="https://github.com/user-attachments/assets/3a40402a-615b-4ae1-b0e7-105096d0f49a" />

Test with the same 100 PhysCollide:
Old took ~880ms
New takes ~140ms
