### PR TITLE
[TF2] Prevent resistance buffs from stopping Half-Zatoichi duel instant kill

### DIFF
--- a/src/game/shared/tf/tf_gamerules.cpp
+++ b/src/game/shared/tf/tf_gamerules.cpp
@@ -6488,9 +6488,7 @@ bool CTFGameRules::ApplyOnDamageModifyRules( CTakeDamageInfo &info, CBaseEntity 
 		}
 
 		// Reduce damage if not resist-piercing weapon or honorbound duel
-		if ( !iAttackIgnoresResists && !( pTFAttacker && pWeapon
-			&& pWeapon == pTFAttacker->GetActiveTFWeapon() && pWeapon->IsHonorBound()
-			&& pVictim->GetActiveTFWeapon() && pVictim->GetActiveTFWeapon()->IsHonorBound() ) )
+		if ( !iAttackIgnoresResists && !( info.GetDamageType() & DMG_IGNORE_RESIST_BUFFS ) )
 		{
 			// If we are defense buffed...
 			if ( pVictim->m_Shared.InCond( TF_COND_DEFENSEBUFF_HIGH ) )
@@ -7284,11 +7282,8 @@ float CTFGameRules::ApplyOnDamageAliveModifyRules( const CTakeDamageInfo &info, 
 		flRealDamage = flDamageBase + flDamageBonus;
 
 		// Some Powerups apply a damage multiplier. Backstabs and honorbound duels are immune to resist protection
-		CTFWeaponBase *pWeapon = dynamic_cast<CTFWeaponBase *>( info.GetWeapon() );
 		if ( pVictim && info.GetDamageCustom() != TF_DMG_CUSTOM_BACKSTAB
-			&& !( pTFAttacker && pWeapon
-			&& pWeapon == pTFAttacker->GetActiveTFWeapon() && pWeapon->IsHonorBound()
-			&& pVictim->GetActiveTFWeapon() && pVictim->GetActiveTFWeapon()->IsHonorBound() ) )
+			&& !( info.GetDamageType() & DMG_IGNORE_RESIST_BUFFS ) )
 		{
 			// Plague bleed damage is immune from resist calculation
 			if ( ( !pVictim->m_Shared.InCond( TF_COND_PLAGUE ) && info.GetDamageCustom() != TF_DMG_CUSTOM_BLEEDING ) )

--- a/src/game/shared/tf/tf_gamerules.cpp
+++ b/src/game/shared/tf/tf_gamerules.cpp
@@ -6467,7 +6467,7 @@ bool CTFGameRules::ApplyOnDamageModifyRules( CTakeDamageInfo &info, CBaseEntity 
 		}
 	}
 
-	// Use defense buffs if it's not a backstab or direct crush damage (telefrage, etc.)
+	// Use defense buffs if it's not a backstab or direct crush damage (telefrag, etc.)
 	if ( pVictim && info.GetDamageCustom() != TF_DMG_CUSTOM_BACKSTAB && ( info.GetDamageType() & DMG_CRUSH ) == 0 )
 	{
 		if ( pVictim->m_Shared.InCond( TF_COND_DEFENSEBUFF ) )
@@ -6487,7 +6487,10 @@ bool CTFGameRules::ApplyOnDamageModifyRules( CTakeDamageInfo &info, CBaseEntity 
 			info.SetCritType( CTakeDamageInfo::CRIT_NONE );
 		}
 
-		if ( !iAttackIgnoresResists )
+		// Reduce damage if not resist-piercing weapon or honorbound duel
+		if ( !iAttackIgnoresResists && !( pTFAttacker && pWeapon
+			&& pWeapon == pTFAttacker->GetActiveTFWeapon() && pWeapon->IsHonorBound()
+			&& pVictim->GetActiveTFWeapon() && pVictim->GetActiveTFWeapon()->IsHonorBound() ) )
 		{
 			// If we are defense buffed...
 			if ( pVictim->m_Shared.InCond( TF_COND_DEFENSEBUFF_HIGH ) )
@@ -7283,8 +7286,12 @@ float CTFGameRules::ApplyOnDamageAliveModifyRules( const CTakeDamageInfo &info, 
 		// Stomp flRealDamage with resist adjusted values
 		flRealDamage = flDamageBase + flDamageBonus;
 
-		// Some Powerups apply a damage multiplier. Backstabs are immune to resist protection
-		if ( ( pVictim && info.GetDamageCustom() != TF_DMG_CUSTOM_BACKSTAB ) )
+		// Some Powerups apply a damage multiplier. Backstabs and honorbound duels are immune to resist protection
+		CTFWeaponBase *pWeapon = dynamic_cast<CTFWeaponBase *>( info.GetWeapon() );
+		if ( pVictim && info.GetDamageCustom() != TF_DMG_CUSTOM_BACKSTAB
+			&& !( pTFAttacker && pWeapon
+			&& pWeapon == pTFAttacker->GetActiveTFWeapon() && pWeapon->IsHonorBound()
+			&& pVictim->GetActiveTFWeapon() && pVictim->GetActiveTFWeapon()->IsHonorBound() ) )
 		{
 			// Plague bleed damage is immune from resist calculation
 			if ( ( !pVictim->m_Shared.InCond( TF_COND_PLAGUE ) && info.GetDamageCustom() != TF_DMG_CUSTOM_BLEEDING ) )

--- a/src/game/shared/tf/tf_gamerules.cpp
+++ b/src/game/shared/tf/tf_gamerules.cpp
@@ -7112,9 +7112,6 @@ float CTFGameRules::ApplyOnDamageAliveModifyRules( const CTakeDamageInfo &info, 
 
 	float flRealDamage = info.GetDamage();
 
-	int iAttackIgnoresResists = 0;
-	CALL_ATTRIB_HOOK_INT_ON_OTHER( info.GetWeapon(), iAttackIgnoresResists, mod_pierce_resists_absorbs );
-
 	if ( pVictimBaseEntity && pVictimBaseEntity->m_takedamage != DAMAGE_EVENTS_ONLY && pVictim )
 	{
 		int iDamageTypeBits = info.GetDamageType() & DMG_IGNITE;
@@ -7200,16 +7197,16 @@ float CTFGameRules::ApplyOnDamageAliveModifyRules( const CTakeDamageInfo &info, 
 			Assert( flDamageBase >= 0.f );
 		}
 
-		int iPierceResists = 0;
-		CALL_ATTRIB_HOOK_INT_ON_OTHER( info.GetWeapon(), iPierceResists, mod_pierce_resists_absorbs );
+		int iAttackIgnoresResists = 0;
+		CALL_ATTRIB_HOOK_INT_ON_OTHER( info.GetWeapon(), iAttackIgnoresResists, mod_pierce_resists_absorbs );
 
 		// This raw damage wont get scaled.  Used for determining how much health to give resist medics.
 		float flRawDamage = flDamageBase;
-		
+
 		// Check if we're immune
 		outParams.bPlayDamageReductionSound = CheckForDamageTypeImmunity( info.GetDamageType(), pVictim, flDamageBase, flDamageBonus );
 
-		if ( !iPierceResists )
+		if ( !iAttackIgnoresResists )
 		{
 			// Reduce only the crit portion of the damage with crit resist
 			bool bCrit = ( info.GetDamageType() & DMG_CRITICAL ) > 0;

--- a/src/game/shared/tf/tf_shareddefs.cpp
+++ b/src/game/shared/tf/tf_shareddefs.cpp
@@ -1462,7 +1462,7 @@ void LoadObjectInfos( IBaseFileSystem *pFileSystem )
 			// Does it make sense to call the below Steam API so it'll force a validation next startup time?
 			// Need to verify it's real corruption and not someone dorking around with their objects.txt file...
 			//
-			// From Martin Otten: If you have a file on disc and you’re 100% sure it’s
+			// From Martin Otten: If you have a file on disc and you're 100% sure it's
 			//  corrupt, call ISteamApps::MarkContentCorrupt( false ), before you shutdown
 			//  the game. This will cause a content validation in Steam.
 

--- a/src/game/shared/tf/tf_shareddefs.h
+++ b/src/game/shared/tf/tf_shareddefs.h
@@ -1169,6 +1169,7 @@ extern const char *g_pszHintMessages[];
 #define DMG_FROM_OTHER_SAPPER					(DMG_IGNITE)		// USED TO DAMAGE SAPPERS ON MATCHED TELEPORTERS
 #define DMG_MELEE								(DMG_BLAST_SURFACE)
 #define DMG_DONT_COUNT_DAMAGE_TOWARDS_CRIT_RATE	(DMG_DISSOLVE)		// DON'T USE THIS FOR EXPLOSION DAMAGE YOU WILL MAKE BRANDON SAD AND KYLE SADDER
+#define DMG_IGNORE_RESIST_BUFFS					(DMG_PHYSGUN)
 
 // This can only ever be used on a TakeHealth call, since it re-uses a dmg flag that means something else
 #define DMG_IGNORE_MAXHEALTH	(DMG_BULLET)

--- a/src/game/shared/tf/tf_weapon_sword.cpp
+++ b/src/game/shared/tf/tf_weapon_sword.cpp
@@ -562,7 +562,7 @@ float CTFKatana::GetMeleeDamage( CBaseEntity *pTarget, int* piDamageType, int* p
 			if ( pTFPlayerTarget->GetActiveTFWeapon() && pTFPlayerTarget->GetActiveTFWeapon()->IsHonorBound() )
 			{
 				fDamage = MAX( fDamage, pTFPlayerTarget->GetHealth() * 3 );
-				*piDamageType |= DMG_DONT_COUNT_DAMAGE_TOWARDS_CRIT_RATE;
+				*piDamageType |= DMG_DONT_COUNT_DAMAGE_TOWARDS_CRIT_RATE | DMG_IGNORE_RESIST_BUFFS;
 			}
 		}
 	}


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
Rework of #1691
This adds checks to prevent damage reduction (from Buff Banner or Powerups) from preventing the Honorbound duel insta-kill.
It does this by creating a new damage type flag `DMG_IGNORE_RESIST_BUFFS` (=`DMG_PHYSGUN`), setting it when the Katana instant kill is handled and reading it where conditions apply their damage resistances.
I used `DMG_PHYSGUN` because it was the least likely to cause side effects (melee damage sets its damage forces on CTakeDamageInfo manually, so Damage_NoPhysicsForce won't take effect even if DMG_PHYSGUN is present in the damage info).
I avoided `DMG_DIRECT` because it is also used by EntityFlame, so using that would cause map-created legacy fire damage (torches on Egypt, as an example) to no longer be affected by resistances, which is technically a regression. I'll leave it to Valve to determine of DMG_DIRECT is a better representation/usage here and if that regression is acceptable, though.
I avoided reusing `DMG_DONT_COUNT_DAMAGE_TOWARDS_CRIT_RATE` as I expected mods to make use of that damage type much more often than other types.

Tested against the case where the victim had Resist powerup + Battalion's Backup buff.

Originally based off changes by @JoriKos

Note that the change in tf_shareddefs is due to Sourcetree very much disliking the special characters in that comment and refusing to commit until they were removed, for some reason.