### PR TITLE
Don't withhold text say messages if the sender is ignored by the recipient

### DIFF
--- a/src/game/server/client.cpp
+++ b/src/game/server/client.cpp
@@ -308,9 +308,6 @@ void Host_Say( edict_t *pEdict, const CCommand &args, bool teamonly )
 		if ( pPlayer && !client->CanHearAndReadChatFrom( pPlayer ) )
 			continue;
 
-		if ( pPlayer && GetVoiceGameMgr() && GetVoiceGameMgr()->IsPlayerIgnoringPlayer( pPlayer->entindex(), i ) )
-			continue;
-
 		CSingleUserRecipientFilter user( client );
 		user.MakeReliable();
 


### PR DESCRIPTION
# Description
Removes some redundant code from the server which filters text say messages based on voice bans (mutes). Clients already have code to filter say messages based on voicebans, which can be toggled with `cl_mute_all_comms` - notably `1` by default, mirroring the server behavior. Removing this code allows `cl_mute_all_comms` to function as documented, where it was not doing anything before.

Fixes https://github.com/ValveSoftware/Source-1-Games/issues/7926