### PR TITLE
[TF2] Fix Pomson 6000 projectile offset

### DIFF
--- a/src/game/shared/tf/tf_weapon_raygun.cpp
+++ b/src/game/shared/tf/tf_weapon_raygun.cpp
@@ -248,8 +248,8 @@ void CTFDRGPomson::Precache()
 //-----------------------------------------------------------------------------
 void CTFDRGPomson::GetProjectileFireSetup( CTFPlayer *pPlayer, Vector vecOffset, Vector *vecSrc, QAngle *angForward, bool bHitTeammates, float flEndDist )
 {
-	BaseClass::GetProjectileFireSetup( pPlayer, vecOffset, vecSrc, angForward, bHitTeammates, flEndDist );
-
 	// adjust to line up with the weapon muzzle
-	vecSrc->z -= 13.0f;
+	vecOffset.z -= 13.0f;
+
+	BaseClass::GetProjectileFireSetup( pPlayer, vecOffset, vecSrc, angForward, bHitTeammates, flEndDist );
 }


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description

The Pomson 6000's projectile offset is defined incorrectly, causing the projectile to be fired below the crosshair. This PR modifies the offset so the projectile works as expected.

### Before

https://github.com/user-attachments/assets/74625163-7920-46f4-882c-0647dcda7534

### After

https://github.com/user-attachments/assets/88daeffc-6422-4039-a27d-c89b5d196c48