### PR TITLE
[TF2] Fix MvM ghost upgrades

### DIFF
--- a/src/game/shared/tf/tf_upgrades_shared.cpp
+++ b/src/game/shared/tf/tf_upgrades_shared.cpp
@@ -272,8 +272,8 @@ int GetUpgradeStepData( CTFPlayer *pPlayer, int nWeaponSlot, int nUpgradeIndex, 
 	int nNumSteps = 0;
 	
 	// ...
-	nNumSteps = RoundFloatToInt( fabsf( ( flCap - flBase ) / flIncrement ) );
-	nCurrentStep = RoundFloatToInt( fabsf( ( flCurrentAttribValue - flBase ) / flIncrement ) );
+	nNumSteps = ceilf( fabsf( ( flCap - flBase ) / flIncrement ) );
+	nCurrentStep = ceilf( fabsf( ( flCurrentAttribValue - flBase ) / flIncrement ) );
 
 	// Include the 0th step
 	return nNumSteps;


### PR DESCRIPTION
Some weapons in MvM aren't shown their full upgrades (e.g the Scottsman's Skullcutter, the Scottish Resistance, the Force-a-Nature, the Soda Popper) due to rounding issues. If this is added, PR #1893 must also be added due to an infinite credit exploit being omnipresent issue. Both PRs are separated in case this particular limitation is intentional. This fix was found in https://github.com/ValveSoftware/Source-1-Games/issues/4232?issue=ValveSoftware%7CSource-1-Games%7C3467