### PR TITLE
[TF2] Fix MvM infinite credit exploit

### DIFF
--- a/src/game/shared/tf/tf_upgrades_shared.cpp
+++ b/src/game/shared/tf/tf_upgrades_shared.cpp
@@ -263,7 +263,7 @@ int GetUpgradeStepData( CTFPlayer *pPlayer, int nWeaponSlot, int nUpgradeIndex, 
 		// Early out here -- we know we're over the cap already, so just fill out and return values
 		// that show that.
 		bOverCap = true;
-		nCurrentStep = RoundFloatToInt( fabsf( ( flCurrentAttribValue - flBase ) / flIncrement ) );
+		nCurrentStep = ceilf( fabsf( ( flCurrentAttribValue - flBase ) / flIncrement ) );
 
 		return nCurrentStep;			// Include the 0th step
 	}


### PR DESCRIPTION
There is a hidden infinite credit exploit that can only be triggered with a custom upgrade file, famously used on the Vaccinator's ubercharge rate upgrade and the Wrap Assassin recharge rate upgrade. To simplify what happened, due to rounding issues the game forgets about these "ghost" upgrades and doesn't remove them properly. This fix works well in conjunction with PR #1892 due to that also fixing ghost upgrades and allowing them to be shown and used but that's optional to add. Both PRs are separated in case the ghost upgrade thing is intentional. This fix was found in https://github.com/ValveSoftware/Source-1-Games/issues/4232?issue=ValveSoftware%7CSource-1-Games%7C3467