### PR TITLE
[TF2] Fix Demoman Charge Meter

### DIFF
--- a/src/game/client/tf/tf_hud_demomanpipes.cpp
+++ b/src/game/client/tf/tf_hud_demomanpipes.cpp
@@ -66,7 +66,7 @@ CHudDemomanPipes::CHudDemomanPipes( const char *pElementName ) : CHudElement( pE
 
 	SetHiddenBits( HIDEHUD_MISCSTATUS | HIDEHUD_PIPES_AND_CHARGE );
 
-	vgui::ivgui()->AddTickSignal( GetVPanel(), 100 );
+	vgui::ivgui()->AddTickSignal( GetVPanel(), 50 );
 
 	m_bChargeMode = false;
 	m_flOldProgress = 1.f;
@@ -186,9 +186,6 @@ void CHudDemomanPipes::OnTick( void )
 				{
 					m_pChargeMeter->SetFgColor( Color( 153, 255, 153, 255 ) );
 				}
-				
-				// We halve the update ticks so that the meter is mostly reliably synced for the colors
-				vgui::ivgui()->AddTickSignal( GetVPanel(), 50 );
 			}
 			else
 			{
@@ -207,8 +204,6 @@ void CHudDemomanPipes::OnTick( void )
 				{
 					m_flOldProgress = flProgress;
 				}
-
-				vgui::ivgui()->AddTickSignal(GetVPanel(), 100);
 			}
 		}
 	}

--- a/src/game/client/tf/tf_hud_demomanpipes.cpp
+++ b/src/game/client/tf/tf_hud_demomanpipes.cpp
@@ -167,11 +167,14 @@ void CHudDemomanPipes::OnTick( void )
 			m_pPipesPresent->SetVisible( false );
 			m_pNoPipesPresent->SetVisible( false );
 
+			int iDemoChargeDamagePenalty = 0;
+			CALL_ATTRIB_HOOK_INT_ON_OTHER( pPlayer, iDemoChargeDamagePenalty, lose_demo_charge_on_damage_when_charging );
+
 			float flProgress = pPlayer->m_Shared.GetDemomanChargeMeter() / 100.f;
 			m_pChargeMeter->SetProgress( flProgress );
 			if ( pPlayer->m_Shared.InCond( TF_COND_SHIELD_CHARGE ) )
 			{
-				if ( flProgress <= 0.33f )
+				if ( !iDemoChargeDamagePenalty && flProgress <= 0.4f )
 				{
 					m_pChargeMeter->SetFgColor( Color( 255, 0, 0, 255 ) );
 				}
@@ -183,9 +186,13 @@ void CHudDemomanPipes::OnTick( void )
 				{
 					m_pChargeMeter->SetFgColor( Color( 153, 255, 153, 255 ) );
 				}
+				
+				// We halve the update ticks so that the meter is mostly reliably synced for the colors
+				vgui::ivgui()->AddTickSignal( GetVPanel(), 50 );
 			}
 			else
 			{
+				vgui::ivgui()->AddTickSignal( GetVPanel(), 100 );
 				m_pChargeMeter->SetFgColor( Color( 255, 255, 255, 255 ) );
 
 				// Play a sound if we are newly ready.

--- a/src/game/client/tf/tf_hud_demomanpipes.cpp
+++ b/src/game/client/tf/tf_hud_demomanpipes.cpp
@@ -192,7 +192,6 @@ void CHudDemomanPipes::OnTick( void )
 			}
 			else
 			{
-				vgui::ivgui()->AddTickSignal( GetVPanel(), 100 );
 				m_pChargeMeter->SetFgColor( Color( 255, 255, 255, 255 ) );
 
 				// Play a sound if we are newly ready.
@@ -208,6 +207,8 @@ void CHudDemomanPipes::OnTick( void )
 				{
 					m_flOldProgress = flProgress;
 				}
+
+				vgui::ivgui()->AddTickSignal(GetVPanel(), 100);
 			}
 		}
 	}


### PR DESCRIPTION
Currently, in live TF2, the charge meter for Demoman does not factor in the stat that makes it only mini crit (for the Tide Turner).
Alongside this it does not properly reflect the color range properly. 

This pull request tries to fix this so that it is a lot more reliable to use.
Changing it so that the charge meter does not display the crit colors for the Tide Turner, while also fixing the percentage to line up with what is actually used.

<img width="1280" height="720" alt="shield fix" src="https://github.com/user-attachments/assets/093fbc08-f63e-447a-ad48-967ebe5c7cef" />
