### PR TITLE
[TF2] Fix Shields Not Restoring Charge With Pickups When Mid Charge

### DIFF
--- a/src/game/server/tf/entity_ammopack.cpp
+++ b/src/game/server/tf/entity_ammopack.cpp
@@ -111,7 +111,7 @@ bool CAmmoPack::MyTouch( CBasePlayer *pPlayer )
 				// Update the shield charge condition to reflect the ammo pack increase
 				if ( pTFPlayer->m_Shared.InCond( TF_COND_SHIELD_CHARGE ) )
 				{
-					float flChargeTime = pTFPlayer->m_Shared.GetConditionDuration( TF_COND_SHIELD_CHARGE ) + flPackRatio;
+					float flChargeTime = ( pTFPlayer->m_Shared.GetDemomanChargeMeter() / 100.0f ) + flPackRatio;
 
 					pTFPlayer->m_Shared.SetConditionDuration( TF_COND_SHIELD_CHARGE, flChargeTime );
 				}

--- a/src/game/server/tf/entity_ammopack.cpp
+++ b/src/game/server/tf/entity_ammopack.cpp
@@ -9,6 +9,7 @@
 #include "tf_shareddefs.h"
 #include "tf_player.h"
 #include "tf_team.h"
+#include "tf_wearable_weapons.h"
 #include "engine/IEngineSound.h"
 #include "entity_ammopack.h"
 #include "tf_gamestats.h"
@@ -104,7 +105,26 @@ bool CAmmoPack::MyTouch( CBasePlayer *pPlayer )
 				{
 					flPackRatio *= 0.2;
 				}
+				
+				CTFWearableDemoShield* pWearableShield = NULL;
+
+				// Loop through our wearables in search of a shield
+				for ( int i = 0; i < pTFPlayer->GetNumWearables(); ++i )
+				{
+					pWearableShield = dynamic_cast<CTFWearableDemoShield*>( pTFPlayer->GetWearable( i ) );
+				}
+
 				pTFPlayer->m_Shared.SetDemomanChargeMeter( flCurrentCharge + flPackRatio * 100.0f );
+
+				// Update the shield charge condition to reflect the ammo pack increase
+				if ( pWearableShield && pTFPlayer->m_Shared.InCond( TF_COND_SHIELD_CHARGE ) )
+				{
+					float flChargeTime = 1.5f;
+					CALL_ATTRIB_HOOK_FLOAT_ON_OTHER( pTFPlayer, flChargeTime, mod_charge_time );
+					flChargeTime = ( flCurrentCharge + flPackRatio ) * flChargeTime;
+
+					pTFPlayer->m_Shared.AddCond( TF_COND_SHIELD_CHARGE, flChargeTime );
+				}
 				bSuccess = true;
 			}
 		}

--- a/src/game/server/tf/entity_ammopack.cpp
+++ b/src/game/server/tf/entity_ammopack.cpp
@@ -105,25 +105,15 @@ bool CAmmoPack::MyTouch( CBasePlayer *pPlayer )
 				{
 					flPackRatio *= 0.2;
 				}
-				
-				CTFWearableDemoShield* pWearableShield = NULL;
-
-				// Loop through our wearables in search of a shield
-				for ( int i = 0; i < pTFPlayer->GetNumWearables(); ++i )
-				{
-					pWearableShield = dynamic_cast<CTFWearableDemoShield*>( pTFPlayer->GetWearable( i ) );
-				}
 
 				pTFPlayer->m_Shared.SetDemomanChargeMeter( flCurrentCharge + flPackRatio * 100.0f );
 
 				// Update the shield charge condition to reflect the ammo pack increase
-				if ( pWearableShield && pTFPlayer->m_Shared.InCond( TF_COND_SHIELD_CHARGE ) )
+				if ( pTFPlayer->m_Shared.InCond( TF_COND_SHIELD_CHARGE ) )
 				{
-					float flChargeTime = 1.5f;
-					CALL_ATTRIB_HOOK_FLOAT_ON_OTHER( pTFPlayer, flChargeTime, mod_charge_time );
-					flChargeTime = ( flCurrentCharge + flPackRatio ) * flChargeTime;
+					float flChargeTime = pTFPlayer->m_Shared.GetConditionDuration( TF_COND_SHIELD_CHARGE ) + flPackRatio;
 
-					pTFPlayer->m_Shared.AddCond( TF_COND_SHIELD_CHARGE, flChargeTime );
+					pTFPlayer->m_Shared.SetConditionDuration( TF_COND_SHIELD_CHARGE, flChargeTime );
 				}
 				bSuccess = true;
 			}

--- a/src/game/server/tf/tf_ammo_pack.cpp
+++ b/src/game/server/tf/tf_ammo_pack.cpp
@@ -392,7 +392,7 @@ void CTFAmmoPack::PackTouch( CBaseEntity *pOther )
 			// Update the shield charge condition to reflect the ammo pack increase
 			if ( pPlayer->m_Shared.InCond( TF_COND_SHIELD_CHARGE ) )
 			{
-				float flChargeTime = pPlayer->m_Shared.GetConditionDuration( TF_COND_SHIELD_CHARGE ) + m_flAmmoRatio;
+				float flChargeTime = (pPlayer->m_Shared.GetDemomanChargeMeter() / 100.0f ) + m_flAmmoRatio;
 
 				pPlayer->m_Shared.SetConditionDuration( TF_COND_SHIELD_CHARGE, flChargeTime );
 			}

--- a/src/game/server/tf/tf_ammo_pack.cpp
+++ b/src/game/server/tf/tf_ammo_pack.cpp
@@ -10,6 +10,7 @@
 #include "ammodef.h"
 #include "tf_gamerules.h"
 #include "explode.h"
+#include "tf_wearable_weapons.h"
 #include "tf_gamestats.h"
 
 // memdbgon must be the last include file in a .cpp file!!!
@@ -385,7 +386,27 @@ void CTFAmmoPack::PackTouch( CBaseEntity *pOther )
 			{
 				m_flAmmoRatio *= 0.2;
 			}
+
+			CTFWearableDemoShield* pWearableShield = NULL;
+
+			// Loop through our wearables in search of a shield
+			for ( int i = 0; i < pPlayer->GetNumWearables(); ++i )
+			{
+				pWearableShield = dynamic_cast<CTFWearableDemoShield*>( pPlayer->GetWearable( i ) );
+			}
+
 			pPlayer->m_Shared.SetDemomanChargeMeter( flCurrentCharge + m_flAmmoRatio * 100.0f );
+
+			// Update the shield charge condition to reflect the ammo pack increase
+			if ( pWearableShield && pPlayer->m_Shared.InCond( TF_COND_SHIELD_CHARGE ) )
+			{
+				float flChargeTime = 1.5f;
+				CALL_ATTRIB_HOOK_FLOAT_ON_OTHER( pPlayer, flChargeTime, mod_charge_time );
+				flChargeTime = ( flCurrentCharge + m_flAmmoRatio ) * flChargeTime;
+
+				pPlayer->m_Shared.AddCond( TF_COND_SHIELD_CHARGE, flChargeTime );
+			}
+
 			iAmmoTaken++;
 		}
 	}

--- a/src/game/server/tf/tf_ammo_pack.cpp
+++ b/src/game/server/tf/tf_ammo_pack.cpp
@@ -387,24 +387,14 @@ void CTFAmmoPack::PackTouch( CBaseEntity *pOther )
 				m_flAmmoRatio *= 0.2;
 			}
 
-			CTFWearableDemoShield* pWearableShield = NULL;
-
-			// Loop through our wearables in search of a shield
-			for ( int i = 0; i < pPlayer->GetNumWearables(); ++i )
-			{
-				pWearableShield = dynamic_cast<CTFWearableDemoShield*>( pPlayer->GetWearable( i ) );
-			}
-
 			pPlayer->m_Shared.SetDemomanChargeMeter( flCurrentCharge + m_flAmmoRatio * 100.0f );
 
 			// Update the shield charge condition to reflect the ammo pack increase
-			if ( pWearableShield && pPlayer->m_Shared.InCond( TF_COND_SHIELD_CHARGE ) )
+			if ( pPlayer->m_Shared.InCond( TF_COND_SHIELD_CHARGE ) )
 			{
-				float flChargeTime = 1.5f;
-				CALL_ATTRIB_HOOK_FLOAT_ON_OTHER( pPlayer, flChargeTime, mod_charge_time );
-				flChargeTime = ( flCurrentCharge + m_flAmmoRatio ) * flChargeTime;
+				float flChargeTime = pPlayer->m_Shared.GetConditionDuration( TF_COND_SHIELD_CHARGE ) + m_flAmmoRatio;
 
-				pPlayer->m_Shared.AddCond( TF_COND_SHIELD_CHARGE, flChargeTime );
+				pPlayer->m_Shared.SetConditionDuration( TF_COND_SHIELD_CHARGE, flChargeTime );
 			}
 
 			iAmmoTaken++;

--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -4097,18 +4097,12 @@ void CTFPlayer::Regenerate( bool bRefillHealthAndAmmo /*= true*/ )
 		m_Shared.SetScoutEnergyDrinkMeter( 100.0f );
 		m_Shared.SetDemomanChargeMeter( 100.0f );
 
-		CTFWearableDemoShield* pWearableShield = NULL;
-
-		// Loop through our wearables in search of a shield
-		for ( int i = 0; i < GetNumWearables(); ++i )
+		// Update the shield charge condition to reflect the reset for charge
+		if ( m_Shared.InCond(TF_COND_SHIELD_CHARGE ) )
 		{
-			pWearableShield = dynamic_cast<CTFWearableDemoShield*>( GetWearable( i ) );
-		}
+			float flChargeTime = m_Shared.GetConditionDuration( TF_COND_SHIELD_CHARGE ) + 1.0f;
 
-		// Update the shield charge condition to reflect the shield refill
-		if ( pWearableShield && m_Shared.InCond( TF_COND_SHIELD_CHARGE ) )
-		{
-			pWearableShield->DoCharge( this );
+			m_Shared.SetConditionDuration( TF_COND_SHIELD_CHARGE, flChargeTime );
 		}
 
 		// Selectively refill the item effect meters if they're allowed
@@ -14784,18 +14778,12 @@ void CTFPlayer::CheatImpulseCommands( int iImpulse )
 				m_Shared.m_flRageMeter = 100.f;
 				m_Shared.SetDemomanChargeMeter( 100.f );
 
-				CTFWearableDemoShield* pWearableShield = NULL;
-
-				// Loop through our wearables in search of a shield
-				for ( int i = 0; i < GetNumWearables(); ++i )
+				// Update the shield charge condition to reflect the reset for charge
+				if ( m_Shared.InCond( TF_COND_SHIELD_CHARGE ) )
 				{
-					pWearableShield = dynamic_cast<CTFWearableDemoShield*>( GetWearable( i ) );
-				}
+					float flChargeTime = m_Shared.GetConditionDuration( TF_COND_SHIELD_CHARGE ) + 1.0f;
 
-				// Update the shield charge condition to reflect the shield refill
-				if ( pWearableShield && m_Shared.InCond( TF_COND_SHIELD_CHARGE ) )
-				{
-					pWearableShield->DoCharge( this );
+					m_Shared.SetConditionDuration( TF_COND_SHIELD_CHARGE, flChargeTime );
 				}
 
 				for( int i = FIRST_LOADOUT_SLOT_WITH_CHARGE_METER; i <= LAST_LOADOUT_SLOT_WITH_CHARGE_METER; ++i )

--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -4097,6 +4097,20 @@ void CTFPlayer::Regenerate( bool bRefillHealthAndAmmo /*= true*/ )
 		m_Shared.SetScoutEnergyDrinkMeter( 100.0f );
 		m_Shared.SetDemomanChargeMeter( 100.0f );
 
+		CTFWearableDemoShield* pWearableShield = NULL;
+
+		// Loop through our wearables in search of a shield
+		for ( int i = 0; i < GetNumWearables(); ++i )
+		{
+			pWearableShield = dynamic_cast<CTFWearableDemoShield*>( GetWearable( i ) );
+		}
+
+		// Update the shield charge condition to reflect the shield refill
+		if ( pWearableShield && m_Shared.InCond( TF_COND_SHIELD_CHARGE ) )
+		{
+			pWearableShield->DoCharge( this );
+		}
+
 		// Selectively refill the item effect meters if they're allowed
 		for( int i = FIRST_LOADOUT_SLOT_WITH_CHARGE_METER; i <= LAST_LOADOUT_SLOT_WITH_CHARGE_METER; ++i )
 		{
@@ -14769,6 +14783,20 @@ void CTFPlayer::CheatImpulseCommands( int iImpulse )
 
 				m_Shared.m_flRageMeter = 100.f;
 				m_Shared.SetDemomanChargeMeter( 100.f );
+
+				CTFWearableDemoShield* pWearableShield = NULL;
+
+				// Loop through our wearables in search of a shield
+				for ( int i = 0; i < GetNumWearables(); ++i )
+				{
+					pWearableShield = dynamic_cast<CTFWearableDemoShield*>( GetWearable( i ) );
+				}
+
+				// Update the shield charge condition to reflect the shield refill
+				if ( pWearableShield && m_Shared.InCond( TF_COND_SHIELD_CHARGE ) )
+				{
+					pWearableShield->DoCharge( this );
+				}
 
 				for( int i = FIRST_LOADOUT_SLOT_WITH_CHARGE_METER; i <= LAST_LOADOUT_SLOT_WITH_CHARGE_METER; ++i )
 				{

--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -4100,7 +4100,10 @@ void CTFPlayer::Regenerate( bool bRefillHealthAndAmmo /*= true*/ )
 		// Update the shield charge condition to reflect the reset for charge
 		if ( m_Shared.InCond(TF_COND_SHIELD_CHARGE ) )
 		{
-			float flChargeTime = m_Shared.GetConditionDuration( TF_COND_SHIELD_CHARGE ) + 1.0f;
+			float flChargeTime = 1.5f;
+			CALL_ATTRIB_HOOK_FLOAT_ON_OTHER( this, flChargeTime, mod_charge_time );
+
+			flChargeTime = m_Shared.GetConditionDuration( TF_COND_SHIELD_CHARGE ) + flChargeTime;
 
 			m_Shared.SetConditionDuration( TF_COND_SHIELD_CHARGE, flChargeTime );
 		}
@@ -14781,7 +14784,10 @@ void CTFPlayer::CheatImpulseCommands( int iImpulse )
 				// Update the shield charge condition to reflect the reset for charge
 				if ( m_Shared.InCond( TF_COND_SHIELD_CHARGE ) )
 				{
-					float flChargeTime = m_Shared.GetConditionDuration( TF_COND_SHIELD_CHARGE ) + 1.0f;
+					float flChargeTime = 1.5f;
+					CALL_ATTRIB_HOOK_FLOAT_ON_OTHER( this, flChargeTime, mod_charge_time );
+
+					flChargeTime = m_Shared.GetConditionDuration( TF_COND_SHIELD_CHARGE ) + flChargeTime;
 
 					m_Shared.SetConditionDuration( TF_COND_SHIELD_CHARGE, flChargeTime );
 				}


### PR DESCRIPTION
The stat that gives shield charge with ammo pickups (_Persian Persuader_) do not accurately restore the charge meter, as it essentially does nothing if you are mid charge when collecting. In the end, causing you to lose the charge you would have gained. This PR fixes this alongside makes it align accurately if you charge into a resupply locker.

This PR basically adjusts the clock on the charge from when you get a pickup or resupply.

Resolves https://github.com/ValveSoftware/Source-1-Games/issues/4722