### PR TITLE
[TF2] building damage feedback fixes

### DIFF
--- a/src/game/client/tf/tf_hud_account.cpp
+++ b/src/game/client/tf/tf_hud_account.cpp
@@ -524,14 +524,11 @@ public:
 	//-----------------------------------------------------------------------------
 	void DisplayDamageFeedback( CTFPlayer *pAttacker, CBaseCombatCharacter *pVictim, int iDamage, int iHealth, bool bIsCrit )
 	{
-		if ( iDamage <= 0 ) // zero value (invuln?)
+		if ( iDamage <= 0 || !pAttacker )
 			return;
 
 		CTFPlayer *pLocalPlayer = C_TFPlayer::GetLocalTFPlayer();
 		if ( !pLocalPlayer || !pLocalPlayer->IsAlive() )
-			return;
-
-		if ( !pAttacker || !pVictim )
 			return;
 
 		// Show the attacker, or when healing the player that is
@@ -617,7 +614,7 @@ public:
 				}
 			}
 
-			if ( hud_combattext.GetBool() )
+			if ( hud_combattext.GetBool() && pVictim )
 			{
 				// Ignore damage events on targets that we can't see, so it's not a cheat
 				trace_t	tr;

--- a/src/game/server/tf/tf_obj.cpp
+++ b/src/game/server/tf/tf_obj.cpp
@@ -2055,7 +2055,7 @@ int CBaseObject::OnTakeDamage( const CTakeDamageInfo &info )
 	if ( event )
 	{
 		event->SetInt( "entindex", entindex() );
-		event->SetInt( "health", Max( 0, (int)GetHealth() ) );
+		event->SetInt( "health", Max( 0, (int)ceil( GetHealth() ) ) );
 		event->SetInt( "damageamount", flDamage );
 		event->SetBool( "crit", ( info.GetDamageType() & DMG_CRITICAL ) ? true : false );
 


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description

fixes an issue where health sent in damage feedback on buildings is rounded down. this would cause damage feedback to incorrectly play the last hitsound on buildings on occasion. this also fixes an issue where the damage feedback sound would not be played if the entity was removed on the client before the event was handled (though the visible damage number still remains unfixed in this regard)

unfixed:

https://github.com/user-attachments/assets/ac73d02a-9fd3-4cb1-bd1a-b5b3fb2a54ba

fixed:

https://github.com/user-attachments/assets/923d6cf8-bab8-4e4f-a2b6-5fabaaba4314

