### PR TITLE
[TF2] Allow forcing TF2 style hud messages even if cl_hud_minmode is 1

### DIFF
--- a/src/game/client/tf/tf_hud_notification_panel.cpp
+++ b/src/game/client/tf/tf_hud_notification_panel.cpp
@@ -101,7 +101,7 @@ void CHudNotificationPanel::MsgFunc_HudNotify( bf_read &msg )
 	// Ignore notifications in minmode
 	if ( !bForceShow )
 	{
-		ConVarRef cl_hud_minmode( "cl_hud_minmode", true );
+		static ConVarRef cl_hud_minmode( "cl_hud_minmode", true );
 		if ( cl_hud_minmode.IsValid() && cl_hud_minmode.GetBool() )
 			return;
 	}
@@ -139,9 +139,6 @@ void CHudNotificationPanel::MsgFunc_HudNotify( bf_read &msg )
 //-----------------------------------------------------------------------------
 void CHudNotificationPanel::MsgFunc_HudNotifyCustom( bf_read &msg )
 {
-	// Reload the base
-	LoadControlSettings( "resource/UI/notifications/base_notification.res" );
-
 	char szText[256];
 	char szIcon[256];
 
@@ -158,7 +155,7 @@ void CHudNotificationPanel::MsgFunc_HudNotifyCustom( bf_read &msg )
 	// Ignore notifications in minmode
 	if ( !bForceShow )
 	{
-		ConVarRef cl_hud_minmode( "cl_hud_minmode", true );
+		static ConVarRef cl_hud_minmode( "cl_hud_minmode", true );
 		if ( cl_hud_minmode.IsValid() && cl_hud_minmode.GetBool() )
 			return;
 	}

--- a/src/game/client/tf/tf_hud_notification_panel.cpp
+++ b/src/game/client/tf/tf_hud_notification_panel.cpp
@@ -149,6 +149,20 @@ void CHudNotificationPanel::MsgFunc_HudNotifyCustom( bf_read &msg )
 	msg.ReadString( szIcon, sizeof(szIcon) );
 	int iBackgroundTeam = msg.ReadByte();
 
+	bool bForceShow = false;
+	if ( msg.GetNumBytesLeft() > 0 )
+	{
+		bForceShow = msg.ReadByte();
+	}
+
+	// Ignore notifications in minmode
+	if ( !bForceShow )
+	{
+		ConVarRef cl_hud_minmode( "cl_hud_minmode", true );
+		if ( cl_hud_minmode.IsValid() && cl_hud_minmode.GetBool() )
+			return;
+	}
+
 	SetupNotifyCustom( szText, szIcon, iBackgroundTeam );
 }
 

--- a/src/game/client/tf/tf_hud_notification_panel.cpp
+++ b/src/game/client/tf/tf_hud_notification_panel.cpp
@@ -139,11 +139,6 @@ void CHudNotificationPanel::MsgFunc_HudNotify( bf_read &msg )
 //-----------------------------------------------------------------------------
 void CHudNotificationPanel::MsgFunc_HudNotifyCustom( bf_read &msg )
 {
-	// Ignore notifications in minmode
-	ConVarRef cl_hud_minmode( "cl_hud_minmode", true );
-	if ( cl_hud_minmode.IsValid() && cl_hud_minmode.GetBool() )
-		return;
-
 	// Reload the base
 	LoadControlSettings( "resource/UI/notifications/base_notification.res" );
 

--- a/src/game/server/tf/entity_game_text_tf.cpp
+++ b/src/game/server/tf/entity_game_text_tf.cpp
@@ -26,6 +26,7 @@ private:
 	string_t m_iszIcon;
 	int m_iRecipientTeam;
 	int m_iBackgroundTeam;
+	bool m_bForceShow;
 };
 
 LINK_ENTITY_TO_CLASS( game_text_tf, CTFHudNotify );
@@ -36,6 +37,7 @@ DEFINE_KEYFIELD( m_iszMessage, FIELD_STRING, "message" ),
 DEFINE_KEYFIELD( m_iszIcon, FIELD_STRING, "icon" ),
 DEFINE_KEYFIELD( m_iRecipientTeam, FIELD_INTEGER, "display_to_team" ),
 DEFINE_KEYFIELD( m_iBackgroundTeam, FIELD_INTEGER, "background" ),
+DEFINE_KEYFIELD( m_bForceShow, FIELD_BOOLEAN, "force_show" ),
 
 // Inputs
 DEFINE_INPUTFUNC( FIELD_VOID, "Display", InputDisplay ),
@@ -63,5 +65,5 @@ void CTFHudNotify::Display( CBaseEntity *pActivator )
 		break;
 	}
 
-	TFGameRules()->SendHudNotification( filter, STRING(m_iszMessage), STRING(m_iszIcon), m_iBackgroundTeam );
+	TFGameRules()->SendHudNotification( filter, STRING(m_iszMessage), STRING(m_iszIcon), m_iBackgroundTeam, m_bForceShow );
 }

--- a/src/game/shared/tf/tf_gamerules.cpp
+++ b/src/game/shared/tf/tf_gamerules.cpp
@@ -18667,7 +18667,7 @@ void CTFGameRules::SendHudNotification( IRecipientFilter &filter, HudNotificatio
 //-----------------------------------------------------------------------------
 // Purpose: 
 //-----------------------------------------------------------------------------
-void CTFGameRules::SendHudNotification( IRecipientFilter &filter, const char *pszText, const char *pszIcon, int iTeam /*= TEAM_UNASSIGNED*/ )
+void CTFGameRules::SendHudNotification( IRecipientFilter &filter, const char *pszText, const char *pszIcon, int iTeam /*= TEAM_UNASSIGNED*/,  bool bForceShow /*= false*/ )
 {
 	if ( IsInWaitingForPlayers() )
 		return;
@@ -18676,6 +18676,7 @@ void CTFGameRules::SendHudNotification( IRecipientFilter &filter, const char *ps
 		WRITE_STRING( pszText );
 		WRITE_STRING( pszIcon );
 		WRITE_BYTE( iTeam );
+		WRITE_BOOL( bForceShow );
 	MessageEnd();
 }
 

--- a/src/game/shared/tf/tf_gamerules.h
+++ b/src/game/shared/tf/tf_gamerules.h
@@ -920,7 +920,7 @@ bool IsCreepWaveMode( void ) const;
 	int		GetPreviousRoundWinners( void ) { return m_iPreviousRoundWinners; }
 
 	void	SendHudNotification( IRecipientFilter &filter, HudNotification_t iType, bool bForceShow = false  );
-	void	SendHudNotification( IRecipientFilter &filter, const char *pszText, const char *pszIcon, int iTeam = TEAM_UNASSIGNED );
+	void	SendHudNotification( IRecipientFilter &filter, const char *pszText, const char *pszIcon, int iTeam = TEAM_UNASSIGNED, bool bForceShow = false );
 	void	StopWatchModeThink( void );
 
 	virtual		void RestartTournament( void );


### PR DESCRIPTION
# Description

These look nice, but cannot be shown to players in min mode. 

This necessitate a fallback code in SM plugins or repeating the same information with the other options (chat, hudText).

So make it possible to force them visible irrespective of value of `cl_hud_minmode` convar.
