### PR TITLE
[TF2] Update Default FOV from 75 -> 90 for freshly generated configurations.

### DIFF
--- a/src/game/shared/tf/tf_gamerules.h
+++ b/src/game/shared/tf/tf_gamerules.h
@@ -1036,7 +1036,7 @@ private:
 
 	void ChooseNextMapVoteOptions();
 
-	int DefaultFOV( void ) { return 75; }
+	int DefaultFOV( void ) { return 90; }
 	int GetDuckSkinForClass( int nTeam, int nClass ) const;
 	void MatchSummaryTeleport();
 


### PR DESCRIPTION
This is a resubmission of a [previous PR](https://github.com/ValveSoftware/source-sdk-2013/pull/1000), per request.

Original PR text:

# Description
Self explanatory but most new player guides almost immediately suggest changing the fov from 75 -> 90 as it is a direct benefit to do so.