### PR TITLE
Fix vgui_screen not changing overlay material

### DIFF
--- a/src/game/client/c_vguiscreen.cpp
+++ b/src/game/client/c_vguiscreen.cpp
@@ -95,7 +95,7 @@ void C_VGuiScreen::OnDataChanged( DataUpdateType_t type )
 	}
 
 	// Set up the overlay material
-	if (m_nOldOverlayMaterial != m_nOverlayMaterial)
+	if ((type == DATA_UPDATE_CREATED) || (m_nOldOverlayMaterial != m_nOverlayMaterial))
 	{
 		m_OverlayMaterial.Shutdown();
 


### PR DESCRIPTION
Sometimes the vgui_screen entity does not change the overlay material during it's spawn, resulting in it using the default "engine/writez" material. This PR fixes that.
(Only tested in TF2)

### Before:
<img width="256" height="256" alt="before" src="https://github.com/user-attachments/assets/b5468e86-f953-43b8-b575-149d6f340835" />

### After:
<img width="256" height="256" alt="after" src="https://github.com/user-attachments/assets/043ba903-6d6a-44c5-a1b3-f2f89c81781c" />
