### PR TITLE
[TF2] Fix Escape handling in item selection dialogs

### DIFF
--- a/src/game/client/econ/item_style_select_dialog.cpp
+++ b/src/game/client/econ/item_style_select_dialog.cpp
@@ -20,6 +20,36 @@
 #include <tier0/memdbgon.h>
 
 
+
+
+
+class CStyleComboMenu : public vgui::Menu
+{
+	DECLARE_CLASS_SIMPLE(CStyleComboMenu, vgui::Menu);
+
+public:
+	CStyleComboMenu(vgui::Panel* pParent, const char* pszName)
+		: BaseClass(pParent, pszName)
+	{
+	}
+
+	virtual void OnKeyCodeTyped(vgui::KeyCode code)
+	{
+		if (code == KEY_ESCAPE)
+		{
+			SetVisible(false);
+			PostActionSignal(new KeyValues("ComboBoxEscape"));
+			return;
+		}
+
+		BaseClass::OnKeyCodeTyped(code);
+	}
+};
+
+
+
+
+
 //-----------------------------------------------------------------------------
 // Purpose:
 //-----------------------------------------------------------------------------
@@ -35,6 +65,10 @@ CComboBoxBackpackOverlayDialogBase::CComboBoxBackpackOverlayDialogBase( vgui::Pa
 	}
 
 	m_pComboBox = new vgui::ComboBox( this, "ComboBox", 5, false );
+	CStyleComboMenu* pMenu = new CStyleComboMenu(m_pComboBox, "StyleComboMenu");
+
+	pMenu->AddActionSignalTarget(this);
+	m_pComboBox->SetMenu(pMenu);
 }
 
 //-----------------------------------------------------------------------------
@@ -74,6 +108,25 @@ void CComboBoxBackpackOverlayDialogBase::ApplySchemeSettings( vgui::IScheme *pSc
 		pTitleLabel->SetText( GetTitleLabelLocalizationToken() );
 	}
 }
+
+
+void CComboBoxBackpackOverlayDialogBase::OnComboBoxEscape()
+{
+	OnCommand("cancel");
+}
+
+
+void CComboBoxBackpackOverlayDialogBase::OnKeyCodeTyped(vgui::KeyCode code)
+{
+	if (code == KEY_ESCAPE)
+	{
+		OnCommand("cancel");
+		return;
+	}
+
+	BaseClass::OnKeyCodeTyped(code);
+}
+
 
 //-----------------------------------------------------------------------------
 // Purpose:

--- a/src/game/client/econ/item_style_select_dialog.h
+++ b/src/game/client/econ/item_style_select_dialog.h
@@ -43,9 +43,11 @@ private:
 	virtual void PopulateComboBoxOptions() = 0;
 	virtual void OnComboBoxApplication() = 0;
 	virtual void OnComboBoxChanged( int iNewSelection ) { }
+	virtual void OnKeyCodeTyped(vgui::KeyCode code);
 	virtual const char *GetTitleLabelLocalizationToken() const = 0;
 
 	MESSAGE_FUNC_PARAMS( OnTextChanged, "TextChanged", data );
+	MESSAGE_FUNC(OnComboBoxEscape, "ComboBoxEscape");
 
 	CItemModelPanel			*m_pPreviewModelPanel;
 	vgui::ComboBox			*m_pComboBox;


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description

While playing TF2 casual, I noticed an issue with backpack combo overlay dialogs. Here is a video of the issue:

https://github.com/user-attachments/assets/cbb47f0e-f9d0-430a-9d02-f763f67e496e

And if u play around with that it can gets even worse. 

https://github.com/user-attachments/assets/ecc68888-1574-4fb9-aaba-ddfaf1ffd75e

The Select Style window did not have complete Escape handling, especially for the combo box dropdown state. 

I compared this behavior with `CConfirmDialog` in `game/client/econ/confirm_dialog.cpp`. Like `CComboBoxBackpackOverlayDialogBase`, `CConfirmDialog` is also based on `vgui::EditablePanel`. `CConfirmDialog` handles Escape by overriding the `EditablePanel` keyboard input method, `OnKeyCodeTyped`, and routing it through its normal cancel command:

```cpp
void CConfirmDialog::OnKeyCodeTyped( vgui::KeyCode code )
{
	if ( code == KEY_ESCAPE )
	{
		OnCommand( "cancel" );
	}
}
```

`CComboBoxBackpackOverlayDialogBase` did not fully handle the same case. Adding Escape handling to the base overlay fixes the case where the overlay itself has focus. However, `vgui::ComboBox` opens an internal `vgui::Menu` for its dropdown, and that menu takes focus while the dropdown is open. Because of that, Escape never reaches the parent overlay while the dropdown is active.

This fix handles both focus paths:

- `CComboBoxBackpackOverlayDialogBase` now maps Escape to `OnCommand("cancel")`, similar to `CConfirmDialog`.
- The combo box dropdown uses a small custom menu that catches Escape while the dropdown has focus.
- That menu posts a `ComboBoxEscape` action signal back to the parent overlay.
- The parent overlay handles `ComboBoxEscape` by calling the same `OnCommand("cancel")` path.

Here is the result after the fix:

https://github.com/user-attachments/assets/6b02d05c-fc25-4f63-8c07-6dee98e513bf

Now Escape consistently closes the Select Style dialog whether focus is on the overlay itself or inside the opened combo box dropdown. The existing style selection/apply logic is unchanged.


This base combo overlay is not only used by Select Style (`CStyleSelectDialog`). It is also used by the refurbish/restoration dialog (`CRefurbishItemDialog`) and by the strange part restriction selection dialog (`CSelectStrangePartToRestrictDialog`). The refurbish dialog can hit the same issue: for example, try restoring/removing a customization from a Strange weapon that has more than one Strange part, open the dropdown, and press Escape. The dropdown can close while the parent overlay remains open, which can leave the UI in the same awkward state.

Example of issue with restoration

https://github.com/user-attachments/assets/ede6e3f8-e329-4de9-b789-144452c9d615

I did not find an in-game issue with the strange part restriction flow (`CSelectStrangePartToRestrictDialog`) during testing, but it shares the same base dropdown behavior. I do not expect forwarding Escape through the normal cancel path to break it. If a specific derived dialog ever needs different Escape behavior, it can override the relevant handler with an empty or custom implementation.




