### PR TITLE
[TF2] Re-add stun effects for The Sandman (BONK! icon, conc stars, voicelines)

### DIFF
--- a/src/game/shared/tf/tf_player_shared.cpp
+++ b/src/game/shared/tf/tf_player_shared.cpp
@@ -7340,41 +7340,42 @@ void CTFPlayerShared::OnAddOverhealed( void )
 //-----------------------------------------------------------------------------
 void CTFPlayerShared::OnAddStunned( void )
 {
-	if ( IsControlStunned() || IsLoserStateStunned() )
+	if ( GetActiveStunInfo() )
 	{
+		int iStunFlags = GetStunFlags();
 #ifdef CLIENT_DLL
-		if ( GetActiveStunInfo() )
+		if ( !m_pOuter->m_pStunnedEffect && !( iStunFlags & TF_STUN_NO_EFFECTS ) &&
+			 ( iStunFlags & ( TF_STUN_CONTROLS | TF_STUN_LOSER_STATE | TF_STUN_EFFECTS ) ) )
 		{
-			if ( !m_pOuter->m_pStunnedEffect && !( GetActiveStunInfo()->iStunFlags & TF_STUN_NO_EFFECTS ) )
+			if ( ( iStunFlags & TF_STUN_BY_TRIGGER ) || InCond( TF_COND_HALLOWEEN_BOMB_HEAD ) )
 			{
-				if ( ( GetActiveStunInfo()->iStunFlags & TF_STUN_BY_TRIGGER ) || InCond( TF_COND_HALLOWEEN_BOMB_HEAD ) )
-				{
-					const char* pEffectName = "yikes_fx";
-					m_pOuter->m_pStunnedEffect = m_pOuter->ParticleProp()->Create( pEffectName, PATTACH_POINT_FOLLOW, "head" );
-				}
-				else
-				{
-					const char* pEffectName = "conc_stars";
-					m_pOuter->m_pStunnedEffect = m_pOuter->ParticleProp()->Create( pEffectName, PATTACH_POINT_FOLLOW, "head" );
-				}
+				const char* pEffectName = "yikes_fx";
+				m_pOuter->m_pStunnedEffect = m_pOuter->ParticleProp()->Create( pEffectName, PATTACH_POINT_FOLLOW, "head" );
+			}
+			else
+			{
+				const char* pEffectName = "conc_stars";
+				m_pOuter->m_pStunnedEffect = m_pOuter->ParticleProp()->Create( pEffectName, PATTACH_POINT_FOLLOW, "head" );
 			}
 		}
 #endif
-
-		// Notify our weapon that we have been stunned.
-		CTFWeaponBase* pWpn = m_pOuter->GetActiveTFWeapon();
-		if ( pWpn )
+		if ( iStunFlags & ( TF_STUN_CONTROLS | TF_STUN_LOSER_STATE ) )
 		{
-			pWpn->OnControlStunned();
-		}
+			// Notify our weapon that we have been stunned.
+			CTFWeaponBase* pWpn = m_pOuter->GetActiveTFWeapon();
+			if ( pWpn )
+			{
+				pWpn->OnControlStunned();
+			}
 
-		if ( InCond( TF_COND_SHIELD_CHARGE ) )
-		{
-			SetDemomanChargeMeter( 0 );
-			RemoveCond( TF_COND_SHIELD_CHARGE );
-		}
+			if ( InCond( TF_COND_SHIELD_CHARGE ) )
+			{
+				SetDemomanChargeMeter( 0 );
+				RemoveCond( TF_COND_SHIELD_CHARGE );
+			}
 
-		m_pOuter->TeamFortress_SetSpeed();
+			m_pOuter->TeamFortress_SetSpeed();
+		}
 	}
 }
 
@@ -9876,8 +9877,10 @@ void CTFPlayerShared::StunPlayer( float flTime, float flReductionAmount, int iSt
 	}
 
 #ifdef GAME_DLL
+	int iActiveStunFlags = GetActiveStunInfo()->iStunFlags;
+
 	// Add in extra time when TF_STUN_CONTROLS
-	if ( GetActiveStunInfo()->iStunFlags & TF_STUN_CONTROLS )
+	if ( iActiveStunFlags & TF_STUN_CONTROLS )
 	{
 		if ( !InCond( TF_COND_HALLOWEEN_KART ) )
 		{
@@ -9890,9 +9893,13 @@ void CTFPlayerShared::StunPlayer( float flTime, float flReductionAmount, int iSt
 	// Update old system for networking
 	UpdateLegacyStunSystem();
 	
-	if ( GetActiveStunInfo()->iStunFlags & TF_STUN_CONTROLS || GetActiveStunInfo()->iStunFlags & TF_STUN_LOSER_STATE )
+	if ( iActiveStunFlags & ( TF_STUN_CONTROLS | TF_STUN_LOSER_STATE ) )
 	{
 		m_pOuter->m_angTauntCamera = m_pOuter->EyeAngles();
+	}
+
+	if ( iActiveStunFlags & ( TF_STUN_CONTROLS | TF_STUN_LOSER_STATE | TF_STUN_EFFECTS ) )
+	{
 		m_pOuter->SpeakConceptIfAllowed( MP_CONCEPT_STUNNED );
 		if ( pAttacker )
 		{
@@ -9900,12 +9907,9 @@ void CTFPlayerShared::StunPlayer( float flTime, float flReductionAmount, int iSt
 		}
 	}
 
-	if ( ( GetActiveStunInfo()->iStunFlags & TF_STUN_SOUND ) ||
-		 ( GetActiveStunInfo()->iStunFlags & TF_STUN_SPECIAL_SOUND ) ||
-		 ( GetActiveStunInfo()->iStunFlags & TF_STUN_CONTROLS ) ||
-		 ( GetActiveStunInfo()->iStunFlags & TF_STUN_LOSER_STATE ) )
+	if ( iActiveStunFlags & ( TF_STUN_CONTROLS | TF_STUN_SPECIAL_SOUND | TF_STUN_LOSER_STATE | TF_STUN_SOUND | TF_STUN_EFFECTS ) )
 	{
-		m_pOuter->StunSound( pAttacker, GetActiveStunInfo()->iStunFlags, iOldStunFlags );
+		m_pOuter->StunSound( pAttacker, iActiveStunFlags, iOldStunFlags );
 	}
 
 	// Event for achievements.
@@ -9918,12 +9922,12 @@ void CTFPlayerShared::StunPlayer( float flTime, float flReductionAmount, int iSt
 		}
 		event->SetInt( "victim", m_pOuter->GetUserID() );
 		event->SetBool( "victim_capping", m_pOuter->IsCapturingPoint() );
-		event->SetBool( "big_stun", ( GetActiveStunInfo()->iStunFlags & TF_STUN_SPECIAL_SOUND ) != 0 );
+		event->SetBool( "big_stun", ( iActiveStunFlags & TF_STUN_SPECIAL_SOUND ) != 0 );
 		gameeventmanager->FireEvent( event );
 	}
 
 	// Clear off all taunts, expressions, and scenes.
-	if ( ( GetActiveStunInfo()->iStunFlags & TF_STUN_CONTROLS) == TF_STUN_CONTROLS || ( GetActiveStunInfo()->iStunFlags & TF_STUN_LOSER_STATE) == TF_STUN_LOSER_STATE )
+	if ( iActiveStunFlags & ( TF_STUN_CONTROLS | TF_STUN_LOSER_STATE ) )
 	{
 		m_pOuter->StopTaunt();
 		m_pOuter->ClearExpression();

--- a/src/game/shared/tf/tf_shareddefs.h
+++ b/src/game/shared/tf/tf_shareddefs.h
@@ -1340,7 +1340,7 @@ enum
 #define TF_STUN_BY_TRIGGER					(1<<7)
 #define TF_STUN_BOTH						TF_STUN_MOVEMENT | TF_STUN_CONTROLS
 #define TF_STUN_SOUND						(1<<8)
-
+#define TF_STUN_EFFECTS						TF_STUN_DODGE_COOLDOWN
 
 //-----------------
 // TF Objects Info

--- a/src/game/shared/tf/tf_weapon_bat.cpp
+++ b/src/game/shared/tf/tf_weapon_bat.cpp
@@ -732,12 +732,13 @@ void CTFStunBall::ApplyBallImpactEffectOnVictim( CBaseEntity *pOther )
 	if ( flLifeTimeRatio > 0.1f )
 	{
 		bool bMax = flLifeTimeRatio >= 1.f;
-		int iStunFlags = ( bMax ) ? TF_STUN_SPECIAL_SOUND | TF_STUN_MOVEMENT : TF_STUN_SOUND | TF_STUN_MOVEMENT;
+		int iStunFlags = TF_STUN_MOVEMENT | TF_STUN_EFFECTS;
 		float flStunAmount = 0.5f;
 		float flStunDuration = Max( 2.f, tf_scout_stunball_base_duration.GetFloat() * flLifeTimeRatio );
 		if ( bMax )
 		{
 			flStunDuration += 1.0;
+			iStunFlags |= TF_STUN_SPECIAL_SOUND;
 		}
 
 		// MvM bots


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
Restores the effects (BONK! icon, conc stars, voicelines) of the Sandman that made it iconic without changing the weapon's functionality otherwise.

Adds a new define `TF_STUN_EFFECTS` for the unused stun flag `TF_STUN_DODGE_COOLDOWN` (once used for the original Bonk's post-effect slowdown), which now makes the effects appear

Supersedes #984, fixes https://github.com/ValveSoftware/Source-1-Games/issues/4467

Vanilla:

https://github.com/user-attachments/assets/0a6c0d9d-4898-4442-b840-756fe93e85bc

This PR (attacker):

https://github.com/user-attachments/assets/11bc39f0-ffa2-4477-a819-6249bc08b3f1

Victim:

https://github.com/user-attachments/assets/db97405b-288e-4b20-85be-fca679523fb2