### PR TITLE
[TF2] Change "tf_arena_preround_time" convar limits

### DIFF
--- a/src/game/shared/teamplayroundbased_gamerules.cpp
+++ b/src/game/shared/teamplayroundbased_gamerules.cpp
@@ -211,7 +211,7 @@ extern ConVar tf_competitive_preround_countdown_duration;
 #endif // TF_DLL
 
 //Arena Mode
-ConVar tf_arena_preround_time( "tf_arena_preround_time", "10", FCVAR_NOTIFY | FCVAR_REPLICATED, "Length of the Pre-Round time", true, 5.0, true, 15.0 );
+ConVar tf_arena_preround_time( "tf_arena_preround_time", "10", FCVAR_NOTIFY | FCVAR_REPLICATED, "Length of the Pre-Round time", true, 0.0, false, 0.0 );
 ConVar tf_arena_round_time( "tf_arena_round_time", "0", FCVAR_NOTIFY | FCVAR_REPLICATED );
 ConVar tf_arena_max_streak( "tf_arena_max_streak", "3", FCVAR_NOTIFY | FCVAR_REPLICATED, "Teams will be scrambled if one team reaches this streak" );
 ConVar tf_arena_use_queue( "tf_arena_use_queue", "1", FCVAR_REPLICATED | FCVAR_NOTIFY, "Enables the spectator queue system for Arena." );


### PR DESCRIPTION
The `tf_arena_preround_time` convar sets the length of the pre-round timer in the Arena game mode.
Currently, the limits are set to minimum of 5 seconds and maximum of 15 seconds.
While these values work well for classic Arena, they can be unnecessarily restrictive for custom maps/custom gamemodes/community servers.

This PR:
- Lowers the minimum value from 5 to 0
- Removes the maximum value entirely