### PR TITLE
[TF2] Fix countdown timer skipping from 12 -> 10

### DIFF
--- a/src/game/shared/tf/tf_gamerules.cpp
+++ b/src/game/shared/tf/tf_gamerules.cpp
@@ -2250,7 +2250,7 @@ bool CTFGameRules::BInMatchStartCountdown() const
 	if ( IsCompetitiveMode() )
 	{
 		float flTime = GetRoundRestartTime();
-		if ( ( flTime > 0.f ) && ( (int)( flTime - gpGlobals->curtime ) <= mp_tournament_readymode_countdown.GetInt() ) )
+		if ( ( flTime > 0.f ) && ( (int)ceil( flTime - gpGlobals->curtime ) <= mp_tournament_readymode_countdown.GetInt() ) )
 		{
 			return true;
 		}
@@ -20789,7 +20789,7 @@ void CTFGameRules::BetweenRounds_Think( void )
 	if ( UsePlayerReadyStatusMode() )
 	{
 		// Everyone is ready, or the drop-dead timer naturally ticked down to mp_tournament_readymode_countdown
-		bool bStartFinalCountdown = ( PlayerReadyStatus_ShouldStartCountdown() || ( m_flRestartRoundTime > 0 && (int)( m_flRestartRoundTime - gpGlobals->curtime ) == mp_tournament_readymode_countdown.GetInt() ) );
+		bool bStartFinalCountdown = ( PlayerReadyStatus_ShouldStartCountdown() || ( m_flRestartRoundTime > 0 && (int)ceil( m_flRestartRoundTime - gpGlobals->curtime ) == mp_tournament_readymode_countdown.GetInt() ) );
 
 		// It's the FINAL COUNTDOOOWWWNNnnnnnnnnn
 		float flDropDeadTime = gpGlobals->curtime + mp_tournament_readymode_countdown.GetFloat() + 0.1f;


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description

Fix bug where the countdown timer skips from 14..13..12..10..9.. in casual mode. 

Using `ceil` to make the timer consistent with the `"restart_timer_time"` client event that also uses `ceil`. See [`CTeamplayRoundBasedRules::Update( float frametime )`](https://github.com/ValveSoftware/source-sdk-2013/blob/3300848d8a25ef6403c91f82a4cd97d6daefbc06/src/game/shared/teamplayroundbased_gamerules.cpp#L3530)

Without `ceil` here, the final countdown will start too early. 10.9 seconds gets truncated to 10 seconds, while the ui still is showing 11 seconds (because it's rounding up using ceil). When the final countdown condition is met, it sets the remaining time to 10 seconds, causing the time to jump from 10.9 ->10, causing the ui to jump to 11 to 10 seconds in just a couple frames.

Instead, the final contdown should wait until the remaining seconds drops below 10 seconds remaining. 

Tested locally. See here for fix example [video](https://drive.google.com/file/d/1gvgx4oCgM9kEshMPP8Ya5s9GVBcKMhx7/view)

Broken/Current behavior:
<img width="940" height="626" alt="CountdownBug" src="https://github.com/user-attachments/assets/a86665f8-e4cf-453a-b861-c109322d700d" />

