### PR TITLE
[TF2] Fix specific weapons not being useable by bots in MvM

### DIFF
--- a/src/game/server/tf/bot/tf_bot.cpp
+++ b/src/game/server/tf/bot/tf_bot.cpp
@@ -4900,7 +4900,8 @@ void CTFBot::AddItem( const char* pszItemName )
 	criteria.SetQuality( AE_USE_SCRIPT_VALUE );
 	criteria.BAddCondition( "name", k_EOperator_String_EQ, pszItemName, true );
 
-	CBaseEntity *pItem = ItemGeneration()->GenerateRandomItem( &criteria, WorldSpaceCenter(), vec3_angle );
+	int classNum = GetPlayerClass()->GetClassIndex();
+	CBaseEntity *pItem = ItemGeneration()->GenerateRandomItem( &criteria, WorldSpaceCenter(), vec3_angle, NULL, classNum);
 	if ( pItem )
 	{
 		CEconItemView *pScriptItem = static_cast< CBaseCombatWeapon * >( pItem )->GetAttributeContainer()->GetItem();

--- a/src/game/shared/econ/econ_entity_creation.cpp
+++ b/src/game/shared/econ/econ_entity_creation.cpp
@@ -38,14 +38,14 @@ CItemGeneration::CItemGeneration( void )
 //-----------------------------------------------------------------------------
 // Purpose: Generate a random item matching the specified criteria
 //-----------------------------------------------------------------------------
-CBaseEntity *CItemGeneration::GenerateRandomItem( CItemSelectionCriteria *pCriteria, const Vector &vecOrigin, const QAngle &vecAngles, const char* pszOverrideClassName )
+CBaseEntity *CItemGeneration::GenerateRandomItem( CItemSelectionCriteria *pCriteria, const Vector &vecOrigin, const QAngle &vecAngles, const char* pszOverrideClassName, int classNum )
 {
 	entityquality_t iQuality;
 	int iChosenItem = ItemSystem()->GenerateRandomItem( pCriteria, &iQuality );
 	if ( iChosenItem == INVALID_ITEM_DEF_INDEX )
 		return NULL;
 
-	return SpawnItem( iChosenItem, vecOrigin, vecAngles, pCriteria->GetItemLevel(), iQuality, pszOverrideClassName );
+	return SpawnItem( iChosenItem, vecOrigin, vecAngles, pCriteria->GetItemLevel(), iQuality, pszOverrideClassName, classNum );
 }
 
 //-----------------------------------------------------------------------------
@@ -79,7 +79,7 @@ CBaseEntity *CItemGeneration::GenerateBaseItem( struct baseitemcriteria_t *pCrit
 //-----------------------------------------------------------------------------
 // Purpose: Create a new instance of the chosen item
 //-----------------------------------------------------------------------------
-CBaseEntity *CItemGeneration::SpawnItem( int iChosenItem, const Vector &vecAbsOrigin, const QAngle &vecAbsAngles, int iItemLevel, entityquality_t entityQuality, const char *pszOverrideClassName )
+CBaseEntity *CItemGeneration::SpawnItem( int iChosenItem, const Vector &vecAbsOrigin, const QAngle &vecAbsAngles, int iItemLevel, entityquality_t entityQuality, const char *pszOverrideClassName, const int classNum )
 {
 	CEconItemDefinition *pData = ItemSystem()->GetStaticDataForItemByDefIndex( iChosenItem );
 	if ( !pData )
@@ -105,6 +105,7 @@ CBaseEntity *CItemGeneration::SpawnItem( int iChosenItem, const Vector &vecAbsOr
 		if ( !pszOverrideClassName )
 			return NULL;
 
+		pszOverrideClassName = TranslateWeaponEntForClass(pszOverrideClassName, classNum);
 		pItem = CreateEntityByName( pszOverrideClassName );
 	}
 

--- a/src/game/shared/econ/econ_entity_creation.h
+++ b/src/game/shared/econ/econ_entity_creation.h
@@ -27,7 +27,7 @@ public:
 	CItemGeneration( void );
 
 	// Generate a random item matching the specified criteria
-	CBaseEntity *GenerateRandomItem( CItemSelectionCriteria *pCriteria, const Vector &vecOrigin, const QAngle &vecAngles, const char* pszOverrideClassName = NULL );
+	CBaseEntity *GenerateRandomItem( CItemSelectionCriteria *pCriteria, const Vector &vecOrigin, const QAngle &vecAngles, const char* pszOverrideClassName = NULL, int classNum = 0 );
 
 	// Generate a random item matching the specified definition index
 	CBaseEntity *GenerateItemFromDefIndex( int iDefIndex, const Vector &vecOrigin, const QAngle &vecAngles );
@@ -40,7 +40,7 @@ public:
 
 private:
 	// Create a new instance of the chosen item
-	CBaseEntity *SpawnItem( int iChosenItem, const Vector &vecAbsOrigin, const QAngle &vecAbsAngles, int iItemLevel, entityquality_t entityQuality, const char *pszOverrideClassName );
+	CBaseEntity *SpawnItem( int iChosenItem, const Vector &vecAbsOrigin, const QAngle &vecAbsAngles, int iItemLevel, entityquality_t entityQuality, const char *pszOverrideClassName, const int classNum = 0 );
 	CBaseEntity *SpawnItem( const CEconItemView *pData, const Vector &vecAbsOrigin, const QAngle &vecAbsAngles, const char *pszOverrideClassName );
 	CBaseEntity *PostSpawnItem( CBaseEntity *pItem, IHasAttributes *pItemInterface, const Vector &vecAbsOrigin, const QAngle &vecAbsAngles );
 };


### PR DESCRIPTION
In MvM when writing pop files, specific weapons cannot be used on bots. These include the reserve shooter, panic attack, all stock melee reskins, and the festive shotgun. This is due to the function `TranslateWeaponEntForClass` not being included in `CTFBot::AddItem` and thus the game tries to create an invalid entity causing the bot to use a stock weapon over the intended weapon.

The fix was found in rafradek's Rafmod here: https://github.com/rafradek/sigsegv-mvm/blob/3ec830cdca755834a0fa69ff187cdde4a2591289/src/mod/pop/ecattr_extensions.cpp#L1588