### PR TITLE
Fix html motd window reloading whenever any other panels are displayed.

### DIFF
--- a/src/game/client/game_controls/vguitextwindow.cpp
+++ b/src/game/client/game_controls/vguitextwindow.cpp
@@ -88,6 +88,7 @@ CTextWindow::CTextWindow(IViewPort *pViewPort) : Frame(NULL, PANEL_INFO	)
 	m_szTitle[0] = '\0';
 	m_szMessage[0] = '\0';
 	m_szMessageFallback[0] = '\0';
+	m_szLastURL[0] = '\0';
 	m_nExitCommand = TEXTWINDOW_CMD_NONE;
 	m_bShownURL = false;
 	m_bUnloadOnDismissal = false;
@@ -151,6 +152,7 @@ void CTextWindow::Reset( void )
 	m_nContentType = TYPE_TEXT;
 	m_bShownURL = false;
 	m_bUnloadOnDismissal = false;
+	m_szLastURL[0] = '\0';
 	Update();
 }
 
@@ -191,7 +193,16 @@ void CTextWindow::ShowURL( const char *URL, bool bAllowUserToDisable )
 	} 
 
 	m_pHTMLMessage->SetVisible( true );
+
+	// Don't reload the page if we're already displaying this exact URL. Re-opening it
+	// would discard any navigation the user has done within the MOTD. This path gets
+	// hit when the viewport calls UpdateAllPanels() -> Update() while the MOTD is still
+	// open (e.g. when other panels show/hide on the local player's death/respawn).
+	if ( m_bShownURL && !Q_strcmp( m_szLastURL, URL ) )
+		return;
+
 	m_pHTMLMessage->OpenURL( URL, NULL );
+	Q_strncpy( m_szLastURL, URL, sizeof( m_szLastURL ) );
 	m_bShownURL = true;
 }
 
@@ -425,6 +436,7 @@ void CTextWindow::ShowPanel( bool bShow )
 		{
 			m_pHTMLMessage->OpenURL( "about:blank", NULL );
 			m_bShownURL = false;
+			m_szLastURL[0] = '\0';
 		}
 	}
 }

--- a/src/game/client/game_controls/vguitextwindow.h
+++ b/src/game/client/game_controls/vguitextwindow.h
@@ -84,6 +84,7 @@ protected:
 	int			m_nContentType;
 	bool		m_bShownURL;
 	bool		m_bUnloadOnDismissal;
+	char		m_szLastURL[2048];	// the URL currently loaded in m_pHTMLMessage, so we don't needlessly reload it
 
 	vgui::TextEntry	*m_pTextMessage;
 	


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description

When you are viewing an HTML motd and if you spawn/die/round end or any situation where new panels are shown, the motd will be forcefully refreshed, causing flashing and anyone that scrolled down or clicked on another link would lose their navigation state.

Why this happens:

When any panel is shown, UpdateAllPanels() is called which then calls Update() on all panels including the motd. 

How this is fixed:

We record if the panel is showing html and the url. If upon calling Update() it is html and the same url, we don't redraw it.