### PR TITLE
[TF2] Fix a server crash when a player damages someone without an active weapon while carrying the vampire rune

### DIFF
--- a/src/game/shared/tf/tf_gamerules.cpp
+++ b/src/game/shared/tf/tf_gamerules.cpp
@@ -7494,7 +7494,7 @@ float CTFGameRules::ApplyOnDamageAliveModifyRules( const CTakeDamageInfo &info, 
 			{
 				if ( flRealDamage > 0 )
 				{
-					if ( pTFAttacker->GetActiveTFWeapon()->GetWeaponID() == TF_WEAPON_MINIGUN || pTFAttacker->GetActiveTFWeapon()->GetWeaponID() == TF_WEAPON_FLAMETHROWER )
+					if ( pTFAttacker->GetActiveTFWeapon() && ( pTFAttacker->GetActiveTFWeapon()->GetWeaponID() == TF_WEAPON_MINIGUN || pTFAttacker->GetActiveTFWeapon()->GetWeaponID() == TF_WEAPON_FLAMETHROWER ) )
 					{
 						pTFAttacker->TakeHealth( ( flRealDamage * 0.6f ), DMG_GENERIC );
 					}


### PR DESCRIPTION
# Description
The vampire rune checks for the attacker's active weapon ID when calculating the amount of health to return, but it doesn't check if the active weapon actually exists before doing so, causing a crash if it doesn't.