### PR TITLE
fix [tf2]: Prevent wearables from leaking when weapon is dropped

### DIFF
--- a/src/game/shared/tf/tf_player_shared.cpp
+++ b/src/game/shared/tf/tf_player_shared.cpp
@@ -8524,8 +8524,25 @@ void CTFPlayerShared::DetermineDisguiseWeapon( bool bForcePrimary )
 			m_hDisguiseWeapon->m_iState = WEAPON_IS_ACTIVE;
 			m_hDisguiseWeapon->m_bDisguiseWeapon = true;
 			m_hDisguiseWeapon->SetContextThink( &CTFWeaponBase::DisguiseWeaponThink, gpGlobals->curtime + 0.5, "DisguiseWeaponThink" );
+			m_hDisguiseWeapon->RemoveExtraWearables();
 
-			m_hDisguiseWeapon->UpdateExtraWearables();
+			// Cap accumulated disguise wearables. Each disguise-weapon swap
+			// intentionally orphans the prior weapon's world extras (so banners
+			// etc. stay visible across swaps); skip recreation once we're at
+			// the cap so they can't grow unbounded under rapid cycling.
+			// fully cleaned up after disguise removal.
+			const int kMaxDisguiseWearables = 5;
+			int nDisguiseWearableCount = 0;
+			for ( int i = 0; i < m_pOuter->GetNumWearables(); ++i )
+			{
+				CTFWearable *pWearable = dynamic_cast< CTFWearable * >( m_pOuter->GetWearable( i ) );
+				if ( pWearable && pWearable->IsDisguiseWearable() )
+					nDisguiseWearableCount++;
+			}
+			if ( nDisguiseWearableCount < kMaxDisguiseWearables )
+			{
+				m_hDisguiseWeapon->UpdateExtraWearables();
+			}
 
 			// Ammo/clip state is displayed to attached medics
 			m_iDisguiseAmmo = 0;

--- a/src/game/shared/tf/tf_weaponbase.cpp
+++ b/src/game/shared/tf/tf_weaponbase.cpp
@@ -1118,6 +1118,22 @@ void CTFWeaponBase::Drop( const Vector &vecVelocity )
 	}
 #endif
 
+#ifndef CLIENT_DLL
+	// For disguise weapons specifically, the viewmodel-only extra wearable
+	// (e.g. botkiller medigun head) must be removed before BaseClass::Drop
+	// clears OwnerEntity — otherwise on disguise-weapon swap it orphans on
+	// the spy's viewmodel and accumulates one per swap. The world-model
+	// extra (e.g. soldier banner) is intentionally NOT removed here so
+	// it remains visible across disguise-weapon swaps within the same
+	// disguise; We cap Wearables during assingment
+	// RemoveDisguiseWearables sweeps it up at full disguise removal which prevents the leak.
+	if ( m_bDisguiseWeapon && m_hExtraWearableViewModel )
+	{
+		m_hExtraWearableViewModel->RemoveFrom( GetOwnerEntity() );
+		m_hExtraWearableViewModel = NULL;
+	}
+#endif
+
 	BaseClass::Drop( vecVelocity );
 
 	ReapplyProvision();


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description

Weapon extra wearables are orphaned during CTFWeaponBase::Drop due to RemoveExtraWearables being called after the drop. This is only exposed due to DetermineDisguiseWeapon actually processing Extra wearables. Viewmodel removal is moved before the drop to correctly clean up view models. World models are capped at 5 (3 for wearables, 1 for action slot + 1 extra wearable) to prevent a leak from accumulating. This enables disguises to correctly keep extrawearables while disguised as the same target. These wearables are correctly cleaned up on disguise removal. 


Tested in itemtest with record_entities and bot_mirror. 

closes https://github.com/ValveSoftware/Source-1-Games/issues/8021 