### PR TITLE
[TF2] Fix being unable to change into an already desired class

### DIFF
--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -6925,19 +6925,6 @@ void CTFPlayer::HandleCommand_JoinClass( const char *pClassName, bool bAllowSpaw
 	}
 #endif // _DEBUG || STAGING_ONLY
 
-	// joining the same class?
-	if ( iClass != TF_CLASS_RANDOM && iClass == GetDesiredPlayerClassIndex() )
-	{
-		// If we're dead, and we have instant spawn, respawn us immediately. Catches the case
-		// where a player misses respawn wave because they're at the class menu, and then changes
-		// their mind and reselects their current class.
-		if ( m_bAllowInstantSpawn && !IsAlive() )
-		{
-			ForceRespawn();
-		}
-		return;
-	}
-
 	if ( TFGameRules()->IsInArenaMode() && tf_arena_use_queue.GetBool() == true && GetTeamNumber() <= LAST_SHARED_TEAM )
 	{
 		TFGameRules()->AddPlayerToQueue( this );


### PR DESCRIPTION
With `hud_classautokill "0"`, you can choose to pick a class outside of a respawn room without being killed, which you will be changed into, the next time you respawn.
If you return to a respawn room however, you will be unable to pick that class, until you swap to another first.

This PR removes block that checks if picked class is the same as already desired class (aka a class that's queued). Code that follows after, already checks if picked class is the same as current class, and prevents respawn. Therefore this code only messes in situation described at the beginning.

Before:

[before.webm](https://github.com/user-attachments/assets/887a2695-c8f2-4b83-9bcd-95a0489c518a)

After:

[after.webm](https://github.com/user-attachments/assets/77dd15a1-41d9-4b68-afc8-f942de5f45b4)
