### PR TITLE
[TF2] Fix disguising as a player without primary weapon

### DIFF
--- a/src/game/shared/tf/tf_player_shared.cpp
+++ b/src/game/shared/tf/tf_player_shared.cpp
@@ -8316,6 +8316,8 @@ void CTFPlayerShared::CompleteDisguise( void )
 	m_pOuter->UpdateModel();
 	m_pOuter->ClearExpression();
 
+	RemoveDisguiseWeapon();
+
 	FindDisguiseTarget();
 
 	if ( GetDisguiseTarget() )


### PR DESCRIPTION
## Before
<img width="1922" height="1112" alt="before" src="https://github.com/user-attachments/assets/3bb2f752-6962-44f7-aade-abbb962b4657" />

## After
<img width="1922" height="1112" alt="after" src="https://github.com/user-attachments/assets/cd3b5318-f9de-4417-9773-f2afbc2c2171" />

## Reproduction steps
1. Disguise as any class
2. Disguise as a Demoman without a primary weapon (booties)
3. Your disguise is now holding previous disguise's weapon

## Explanation
([this video](https://youtu.be/TJM0AiMhqDg) explains it)

`DetermineDisguiseWeapon` gets called when Spy disguises or changes disguise weapon (the b key).
This function, among other things, checks if there's a "previously held weapon" to fallback to when attempting to switch to an inaccessible weapon slot (primary slot for Demoman with boots, secondary slot for soldier with parachute etc).

This works well when guarding against changing disguise weapon to an invalid slot with the b key. But when changing disguise the `m_hDisguiseWeapon` doesn't get cleared, so the "previous weapon" travels through different disguises.

That makes it so if the primary slot is not available it tries to pick the previously held valid weapon. Which in the scenario described in the reproduction steps is the previous disguise's weapon.

This change clears the `m_hDisguiseWeapon` field every time a spy changes disguise, fixing the issue.