### PR TITLE
lightmappedgeneric: add $forcetangentspace material param (fixes #1916)

### DIFF
--- a/src/materialsystem/stdshaders/lightmappedgeneric_dx9.cpp
+++ b/src/materialsystem/stdshaders/lightmappedgeneric_dx9.cpp
@@ -73,6 +73,8 @@ BEGIN_VS_SHADER( LightmappedGeneric,
 		SHADER_PARAM( OUTLINESTART1, SHADER_PARAM_TYPE_FLOAT, "0.0", "inner start value for outline")
 		SHADER_PARAM( OUTLINEEND0, SHADER_PARAM_TYPE_FLOAT, "0.0", "inner end value for outline")
 		SHADER_PARAM( OUTLINEEND1, SHADER_PARAM_TYPE_FLOAT, "0.0", "outer end value for outline")
+
+		SHADER_PARAM( FORCETANGENTSPACE, SHADER_PARAM_TYPE_BOOL, "0", "Force tangent-space vertex stream even without $bumpmap/$envmap" )
 END_SHADER_PARAMS
 
 	void SetupVars( LightmappedGeneric_DX9_Vars_t& info )
@@ -134,6 +136,8 @@ END_SHADER_PARAMS
 		info.m_nOutlineStart1 = OUTLINESTART1;
 		info.m_nOutlineEnd0 = OUTLINEEND0;
 		info.m_nOutlineEnd1 = OUTLINEEND1;
+
+		info.m_nForceTangentSpace = FORCETANGENTSPACE;
 	}
 
 	SHADER_FALLBACK

--- a/src/materialsystem/stdshaders/lightmappedgeneric_dx9_helper.cpp
+++ b/src/materialsystem/stdshaders/lightmappedgeneric_dx9_helper.cpp
@@ -317,7 +317,10 @@ void DrawLightmappedGeneric_DX9_Internal(CBaseVSShader *pShader, IMaterialVar** 
 			(params[info.m_nBlendModulateTexture]->IsTexture() );
 		bool hasNormalMapAlphaEnvmapMask = IS_FLAG_SET( MATERIAL_VAR_NORMALMAPALPHAENVMAPMASK );
 
-		if ( hasFlashlight && !IsX360() )				
+		bool bForceTangentSpace = ( info.m_nForceTangentSpace != -1 ) &&
+			( params[info.m_nForceTangentSpace]->GetIntValue() != 0 );
+
+		if ( hasFlashlight && !IsX360() )
 		{
 			// !!speed!! do this in the caller so we don't build struct every time
 			CBaseVSShader::DrawFlashlight_dx90_Vars_t vars;
@@ -449,7 +452,7 @@ void DrawLightmappedGeneric_DX9_Internal(CBaseVSShader *pShader, IMaterialVar** 
 					pShaderShadow->EnableSRGBRead( SHADER_SAMPLER1, false );
 				}
 
-				if( hasEnvmap || ( IsX360() && hasFlashlight ) )
+				if( hasEnvmap || bForceTangentSpace || ( IsX360() && hasFlashlight ) )
 				{
 					if( hasEnvmap )
 					{
@@ -533,7 +536,7 @@ void DrawLightmappedGeneric_DX9_Internal(CBaseVSShader *pShader, IMaterialVar** 
 
 				DECLARE_STATIC_VERTEX_SHADER( lightmappedgeneric_vs20 );
 				SET_STATIC_VERTEX_SHADER_COMBO( ENVMAP_MASK,  hasEnvmapMask );
-				SET_STATIC_VERTEX_SHADER_COMBO( TANGENTSPACE,  params[info.m_nEnvmap]->IsTexture() );
+				SET_STATIC_VERTEX_SHADER_COMBO( TANGENTSPACE,  params[info.m_nEnvmap]->IsTexture() || bForceTangentSpace );
 				SET_STATIC_VERTEX_SHADER_COMBO( BUMPMAP,  hasBump );
 				SET_STATIC_VERTEX_SHADER_COMBO( DIFFUSEBUMPMAP, hasDiffuseBumpmap );
 				SET_STATIC_VERTEX_SHADER_COMBO( VERTEXCOLOR, IS_FLAG_SET( MATERIAL_VAR_VERTEXCOLOR ) );

--- a/src/materialsystem/stdshaders/lightmappedgeneric_dx9_helper.h
+++ b/src/materialsystem/stdshaders/lightmappedgeneric_dx9_helper.h
@@ -87,6 +87,8 @@ struct LightmappedGeneric_DX9_Vars_t
 	int m_nOutlineEnd0;
 	int m_nOutlineEnd1;
 
+	int m_nForceTangentSpace;
+
 };
 
 void InitParamsLightmappedGeneric_DX9( CBaseVSShader *pShader, IMaterialVar** params, const char *pMaterialName, LightmappedGeneric_DX9_Vars_t &info );


### PR DESCRIPTION
Fixes #1916.

When a `lightmappedgeneric` material has neither `$bumpmap` nor `$envmap`, the vertex shader's `TANGENTSPACE` static combo is forced off and the vertex format omits `VERTEX_TANGENT_S | VERTEX_TANGENT_T`, so tangent and binormal arrive at the vertex shader as zero. This breaks custom shader paths (e.g. interior mapping via cubemaps) that need tangent-space transforms but don't carry a normal map or envmap.

This PR adds an opt-in material parameter `$forcetangentspace` (default `0`). When set, the helper:

1. ORs `bForceTangentSpace` into the gate at `lightmappedgeneric_dx9_helper.cpp:452`, so the vertex format gets `VERTEX_TANGENT_S | VERTEX_TANGENT_T | VERTEX_NORMAL`.
2. ORs it into the `TANGENTSPACE` static combo selector at line 536 so the vertex shader actually consumes the stream.

The new struct field defaults to `-1` via the existing `memset(this, 0xFF, sizeof(...))` in `LightmappedGeneric_DX9_Vars_t`, so any caller (including `worldvertextransition.cpp`, which shares the struct) that doesn't set the new param is bit-for-bit unchanged. Materials that don't declare `$forcetangentspace` are bit-for-bit unchanged.

No shader recompile required — the change only adjusts which inputs feed the existing `TANGENTSPACE` combo.

**On testing:** I did not set up a full SDK build + custom shader to visually confirm tangent/binormal arrival. The reporter of #1916 already demonstrated empirically (screenshots in the issue) that forcing `hasEnvMap=true` in the helper — which flips exactly the same two gates this PR widens — makes tangent and binormal arrive correctly in the vertex shader. This PR exposes that same toggle as an opt-in material parameter without altering the underlying mechanism. Happy to do a build + capture if a reviewer wants extra confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)