### PR TITLE
inputsystem: fix IsKeypad lower bound (fixes #1708)

### DIFF
--- a/src/public/inputsystem/ButtonCode.h
+++ b/src/public/inputsystem/ButtonCode.h
@@ -310,7 +310,7 @@ inline bool IsSpace( ButtonCode_t code )
 
 inline bool IsKeypad( ButtonCode_t code )
 {
-	return ( code >= MOUSE_FIRST ) && ( code <= KEY_PAD_DECIMAL );
+	return ( code >= KEY_PAD_0 ) && ( code <= KEY_PAD_DECIMAL );
 }
 
 inline bool IsPunctuation( ButtonCode_t code )


### PR DESCRIPTION
Fixes #1708.

`IsKeypad`'s lower bound is `MOUSE_FIRST`, but `MOUSE_FIRST` is defined as `KEY_LAST + 1` — i.e. larger than every KEY_* value including `KEY_PAD_DECIMAL`. The compound predicate `(code >= MOUSE_FIRST && code <= KEY_PAD_DECIMAL)` is therefore unsatisfiable, and `IsKeypad` returns false for every input.

This PR fixes the lower bound to `KEY_PAD_0` so the range matches the keypad codes the function is named for. Siblings `IsMouseCode` (`MOUSE_FIRST .. MOUSE_LAST`) and `IsKeyCode` (`KEY_FIRST .. KEY_LAST`) already follow the `<RANGE>_FIRST .. <RANGE>_LAST` pattern this fix restores.

**Behavior change worth flagging:** `IsPunctuation` calls `!IsKeypad(code)` as part of its predicate. Under the bug, that term is always true and contributed nothing to the check; with the fix, keypad codes are correctly excluded from the punctuation range. This matches the apparent intent (a numpad key is not punctuation), but is technically a behavioral change for any caller that was relying on the broken `IsKeypad` result.

**On testing:** Did not set up a local SDK build — the change is a one-token correction in a public inline header, the enum ordering is self-evident from the file itself (`MOUSE_FIRST = KEY_LAST + 1` at L170 vs. `KEY_PAD_DECIMAL` declared inside the KEY_* range), and the fix restores the pattern already used by `IsMouseCode`/`IsKeyCode`. Happy to add a local-build verification if a reviewer wants one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)