### PR TITLE
dt_utlvector_recv: log diagnostic before RCE-prevention crash (fixes #1511)

### DIFF
--- a/src/public/dt_utlvector_recv.cpp
+++ b/src/public/dt_utlvector_recv.cpp
@@ -36,6 +36,10 @@ void RecvProxy_UtlVectorLength( const CRecvProxyData *pData, void *pStruct, void
 		// to write arbitrary data to out of bounds memory.
 		// There isn't much we can do at this point - we're deep in the networking stack, it's hard to recover
 		// gracefully and we shouldn't be talking to this server anymore.
+		// Log the diagnostic before crashing so the user knows why their client died.
+		Warning( "RecvProxy_UtlVectorLength: server sent lengthprop %d outside allowed range [0, %d]. "
+			"Crashing client to prevent possible remote code execution.\n",
+			pData->m_Value.m_Int, pExtra->m_nMaxElements );
 		// So we crash.
 		*(int *) 1 = 2;
 	}


### PR DESCRIPTION
Fixes #1511.

`RecvProxy_UtlVectorLength` in `src/public/dt_utlvector_recv.cpp` deliberately crashes the client when a server sends an out-of-range `lengthprop`, on the grounds that we're deep in the networking stack and any non-crash recovery would risk arbitrary memory writes (the existing comment block explains the RCE vector). The deliberate crash is correct.

The problem #1511 raises is that the crash is *silent* — the user gets a hard `*(int *) 1 = 2;` segfault with no message, no log line, no clue what happened. From an end-user / support perspective this looks indistinguishable from a random crash, and there's nothing for them to report.

This PR adds a single `Warning()` line immediately before the crash, describing the offending lengthprop value and the allowed range. The deliberate crash is unchanged.

```diff
+		// Log the diagnostic before crashing so the user knows why their client died.
+		Warning( "RecvProxy_UtlVectorLength: server sent lengthprop %d outside allowed range [0, %d]. "
+			"Crashing client to prevent possible remote code execution.\n",
+			pData->m_Value.m_Int, pExtra->m_nMaxElements );
 		// So we crash.
 		*(int *) 1 = 2;
```

**Why `Warning()` instead of `Error()`:** The reporter suggested `Error()`. I chose `Warning()` because the existing comment is emphatic that we want to crash *immediately* without doing anything else ("we're deep in the networking stack, it's hard to recover gracefully"). `Error()` on Source can route through assert handlers, dialogs, and spew sinks, which is more pre-crash work than we want here. `Warning()` is the lightest log call (printf-equivalent with a "Warning: " prefix) and matches the "log and crash" pattern used elsewhere in the engine. Open to swapping if reviewers prefer `Error()` or `Msg()`.

**On testing:** Did not stand up a local SDK build — the change is a strictly additive log line in a code path whose existing crash behavior is preserved bit-for-bit. The new `Warning()` call uses the standard `tier0/dbg.h` printf-style signature and the format specifiers match the int types being logged. Happy to add a build verification if a reviewer wants one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)