### PR TITLE
[TF2] Fix botkiller related disguise issue

### DIFF
--- a/src/game/shared/tf/tf_player_shared.cpp
+++ b/src/game/shared/tf/tf_player_shared.cpp
@@ -8490,6 +8490,12 @@ void CTFPlayerShared::DetermineDisguiseWeapon( bool bForcePrimary )
 
 	if ( strDisguiseWeapon )
 	{
+		// Remove botkiller related wearables
+		if ( m_hDisguiseWeapon && m_hDisguiseWeapon->GetAttributeContainer()->GetItem()->GetStaticData()->GetExtraWearableViewModel() )
+		{
+			m_hDisguiseWeapon->RemoveExtraWearables();
+		}
+
 		// Remove the old disguise weapon, if any.
 		RemoveDisguiseWeapon();
 
@@ -8524,25 +8530,7 @@ void CTFPlayerShared::DetermineDisguiseWeapon( bool bForcePrimary )
 			m_hDisguiseWeapon->m_iState = WEAPON_IS_ACTIVE;
 			m_hDisguiseWeapon->m_bDisguiseWeapon = true;
 			m_hDisguiseWeapon->SetContextThink( &CTFWeaponBase::DisguiseWeaponThink, gpGlobals->curtime + 0.5, "DisguiseWeaponThink" );
-			m_hDisguiseWeapon->RemoveExtraWearables();
-
-			// Cap accumulated disguise wearables. Each disguise-weapon swap
-			// intentionally orphans the prior weapon's world extras (so banners
-			// etc. stay visible across swaps); skip recreation once we're at
-			// the cap so they can't grow unbounded under rapid cycling.
-			// fully cleaned up after disguise removal.
-			const int kMaxDisguiseWearables = 5;
-			int nDisguiseWearableCount = 0;
-			for ( int i = 0; i < m_pOuter->GetNumWearables(); ++i )
-			{
-				CTFWearable *pWearable = dynamic_cast< CTFWearable * >( m_pOuter->GetWearable( i ) );
-				if ( pWearable && pWearable->IsDisguiseWearable() )
-					nDisguiseWearableCount++;
-			}
-			if ( nDisguiseWearableCount < kMaxDisguiseWearables )
-			{
-				m_hDisguiseWeapon->UpdateExtraWearables();
-			}
+			m_hDisguiseWeapon->UpdateExtraWearables();
 
 			// Ammo/clip state is displayed to attached medics
 			m_iDisguiseAmmo = 0;


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
Botkiller disguise has two issues. The spy could clone up to 5 botkiller models when switching to botkiller weapon, and the botkiller model staying after the spy switches to other disguise weapon.
This PR fixes this by looking up items that have item definition "extra_wearable_vm" which is currently exclusively used by botkiller weapons, and then remove the botkiller model.

Before:

https://github.com/user-attachments/assets/fc468719-139d-4de9-8563-867726d0814e

After:

https://github.com/user-attachments/assets/eed68c31-a1f2-4c0a-a202-2e52f6cce275

Edit:
Currently this PR will cause edict leak, I will evaluate a better solution later.