### PR TITLE
Typo fixes in interface headers for Steam stuff

### DIFF
--- a/src/public/steam/isteamapps.h
+++ b/src/public/steam/isteamapps.h
@@ -84,7 +84,7 @@ public:
 	// return the buildid of this app, may change at any time based on backend updates to the game
 	virtual int GetAppBuildId() = 0;
 
-	// Request all proof of purchase keys for the calling appid and asociated DLC.
+	// Request all proof of purchase keys for the calling appid and associated DLC.
 	// A series of AppProofOfPurchaseKeyResponse_t callbacks will be sent with
 	// appropriate appid values, ending with a final callback where the m_nAppId
 	// member is k_uAppIdInvalid (zero).

--- a/src/public/steam/isteamnetworkingsockets.h
+++ b/src/public/steam/isteamnetworkingsockets.h
@@ -206,7 +206,7 @@ public:
 	/// WARNING: Be *very careful* when using the value provided in callbacks structs.
 	/// Callbacks are queued, and the value that you will receive in your
 	/// callback is the userdata that was effective at the time the callback
-	/// was queued.  There are subtle race conditions that can hapen if you
+	/// was queued.  There are subtle race conditions that can happen if you
 	/// don't understand this!
 	///
 	/// If any incoming messages for this connection are queued, the userdata


### PR DESCRIPTION
# Description
"associated" (**on line 87 in isteamapps.h**) and "happen" (**on line 209 in isteamnetworkingsockets.h**) were one S and one P too short, respectively.

I should mention that these typos are absent from Fortress Forever's Source 2013 code:
https://github.com/fortressforever-2013/fortressforever-src/blob/dev/mp/src/public/steam/isteamapps.h#L87
https://github.com/fortressforever-2013/fortressforever-src/blob/dev/mp/src/public/steam/isteamnetworkingsockets.h#L209