### PR TITLE
fix: Properly Drop disguise botkiller and non-disguise weapons 

### DIFF
--- a/src/game/shared/tf/tf_weaponbase.cpp
+++ b/src/game/shared/tf/tf_weaponbase.cpp
@@ -1129,10 +1129,22 @@ void CTFWeaponBase::Drop( const Vector &vecVelocity )
 	// RemoveDisguiseWearables sweeps it up at full disguise removal which prevents the leak.
 	if ( m_bDisguiseWeapon && m_hExtraWearableViewModel )
 	{
-		m_hExtraWearableViewModel->RemoveFrom( GetOwnerEntity() );
-		m_hExtraWearableViewModel = NULL;
+		// the existance of a viewmodel implies it should go away on weapon switch
+		//for disguised spies.
+		RemoveExtraWearables();
 	}
 #endif
+
+	//Drop is currently only used for disguise weapons,
+	//  but if we ever use it for non-disguise weapons
+	//  we need to make sure to remove the extra wearables here 
+	//  so they don't get orphaned in the world.
+	// Disguise weapons are handled via cap in determineDisguiseWearables
+	if ( !m_bDisguiseWeapon )
+	{
+		RemoveExtraWearables();
+	}
+
 
 	BaseClass::Drop( vecVelocity );
 


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description

CTFWeaponBase::Drop has leaked extra wearables since 2009 due to a bad ordering of RemoveExtraWearables and Drop. CTFWeaponBase::Drop is currently only used for disguise weapons. This was exposed in #1824 due to DetermineDisguiseWeapon actually processing extra wearables, and capped at 5 in #1929 . This fix builds on the fix for the leak in #1929, by fully cleaning up any extra wearables with view models and adds logic to clean up extra wearables for non disguise weapons incase drop is ever used for those in the future. The view model fix handles a visual edge in disguises for botkillers if the spy chose to set up extra wearables multiple times.  The disguise wearable cap is left in place to prevent leaks with  extra wearables without view models. This additionally allows for full disguise functionality from #1824.  ExtraWearables with view models are the ones that should be cleaned up 

A full round of my testing is attached in video form below.  My testing does not hit line 1145 (drop for non disguise weapons), which is not exposed in game, but should be there to prevent future leaks.

https://youtu.be/87DMgfGqxpA


This PR is similar to the closed pr #1939 , but does not share the downsides of that PR.

And yes i hand wrote this pr :p 