### PR TITLE
Fix intel carrier glow disappearing when Spy cloaks

### DIFF
--- a/src/game/shared/tf/entity_capture_flag.cpp
+++ b/src/game/shared/tf/entity_capture_flag.cpp
@@ -573,13 +573,6 @@ bool CCaptureFlag::ShouldHideGlowEffect( void )
 			// In non-CTF control the flag changes to the team that's carrying it
 			bIsHiddenTeam = ( pLocalPlayer->GetTeamNumber() != TEAM_SPECTATOR && pLocalPlayer->GetTeamNumber() != GetTeamNumber() );
 		}
-
-		if ( pLocalPlayer->m_Shared.IsFullyInvisible() )
-		{
-			C_TFPlayer *pOwner = ToTFPlayer( m_hPrevOwner );
-			if ( pOwner && pOwner != pLocalPlayer )
-				return true;
-		}
 	}
 
 	bool bHide = IsStolen() && bIsHiddenTeam;
@@ -2600,20 +2593,6 @@ void CCaptureFlag::Simulate( void )
 	BaseClass::Simulate();
 
 	ManageTrailEffects();
-
-	C_TFPlayer *pLocalPlayer = C_TFPlayer::GetLocalTFPlayer();
-	if ( m_hPrevOwner && m_hPrevOwner->IsPlayer() && pLocalPlayer && pLocalPlayer->m_Shared.IsFullyInvisible() && !IsEffectActive( EF_NODRAW ) )
-	{
-		C_TFPlayer *pTFOwner = ToTFPlayer( m_hPrevOwner );
-		if ( pTFOwner && pTFOwner != pLocalPlayer )
-		{
-			AddEffects( EF_NODRAW );
-		}
-	}
-	else if ( IsEffectActive( EF_NODRAW ) && ( IsStolen() || IsDropped() ) )
-	{
-		RemoveEffects( EF_NODRAW );
-	}
 }
 
 void CCaptureFlag::ManageTrailEffects( void )


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description

Fixes ValveSoftware/Source-1-Games#8047

`CCaptureFlag::ShouldHideGlowEffect` and `CCaptureFlag::Simulate` had two conditions related to `LocalPlayer` being fully cloaked, whereas second one was adding `EF_NODRAW` and causing flag to blink even if you stand infront of the player holding it, and first one had two conditions to stop rendering glow effect, if `LocalPlayer` is fully cloaked or `EF_NODRAW` is added.

I removed both checks of "being fully invisible" from the code since they don't seem to have any reason to exist, and more like some old code that was "fixing" something else (since git blame shows they are from first release of TF2 code in Source SDK 2013)

This is how it looks currently in Team Fortress 2 (as of 6/4/2026)

https://github.com/user-attachments/assets/80976222-6b6a-4bf5-aec9-a02ff0f9ae64

This is how it looks after patch applied.

https://github.com/user-attachments/assets/63c9cef5-6dd0-4f28-af16-16b8ad8d5e6d