### PR TITLE
Fix vscript variant EHANDLE conversions

### DIFF
--- a/src/public/vscript/variant.h
+++ b/src/public/vscript/variant.h
@@ -129,8 +129,8 @@ public:
 	operator char() const					{ Assert( m_type == FIELD_CHARACTER );	return m_char; }
 	operator bool() const					{ Assert( m_type == FIELD_BOOLEAN );	return m_bool; }
 	operator HSCRIPT() const				{ Assert( m_type == FIELD_HSCRIPT );	return m_hScript; }
-	operator CBaseHandle() const			{ Assert( m_type == FIELD_EHANDLE );	return CBaseHandle( m_hEntity ); }
-        operator CBaseEntity*() const				{ Assert( m_type == FIELD_EHANDLE );    return CHandle<CBaseEntity>(CBaseHandle( m_hEntity )); }
+	operator CBaseHandle() const			{ Assert( m_type == FIELD_EHANDLE );	return CBaseHandle::UnsafeFromIndex( m_hEntity ); }
+        operator CBaseEntity*() const				{ Assert( m_type == FIELD_EHANDLE );    return CHandle<CBaseEntity>::UnsafeFromIndex( m_hEntity ); }
 	operator const Quaternion &() const		{ Assert( m_type == FIELD_QUATERNION );	return m_pData ? *(Quaternion*)m_pData : quat_identity; }
 //	operator CUtlStringToken() const		{ Assert( m_type == FIELD_UTLSTRINGTOKEN );	CUtlStringToken t; t.m_nHashCode = m_utlStringToken; return t; }
 
@@ -614,7 +614,7 @@ inline bool CVariantBase<CValueAllocator>::AssignTo( CBaseHandle *pDest ) const
 {
 	switch( m_type )
 	{
-	case FIELD_EHANDLE:	*pDest = CHandle< CBaseEntity >(m_hEntity); return true;
+	case FIELD_EHANDLE:	*pDest = CHandle< CBaseEntity >::UnsafeFromIndex( m_hEntity ); return true;
 	default:
 		Warning( "No free conversion of %s variant to EHANDLE right now\n", VariantFieldTypeName( m_type ) );
 		break;
@@ -627,7 +627,7 @@ inline bool CVariantBase<CValueAllocator>::AssignTo( CBaseEntity **pDest ) const
 {
 	switch( m_type )
 	{
-	case FIELD_EHANDLE:	*pDest = CHandle< CBaseEntity >(m_hEntity); return true;
+	case FIELD_EHANDLE:	*pDest = CHandle< CBaseEntity >::UnsafeFromIndex( m_hEntity ); return true;
 	default:
 		Warning( "No free conversion of %s variant to CBaseEntity * right now\n", VariantFieldTypeName( m_type ) );
 		break;


### PR DESCRIPTION
CVariantBase FIELD_EHANDLE conversions build a handle from the raw m_hEntity index by calling `CBaseHandle( m_hEntity )` and `CHandle<CBaseEntity>( m_hEntity )`, but neither type has a constructor that takes a raw index. This means anything using these will fail to compile, which is not a problem in the SDK as-is but could be problematic for users of the public headers.

Use the UnsafeFromIndex factory, which is provided for exactly this (rebuilding from a `ToInt()` value).