### PR TITLE
Fix FPS-dependent movement acceleration caused by ExtraMouseSample()

### DIFF
--- a/src/game/client/in_main.cpp
+++ b/src/game/client/in_main.cpp
@@ -1008,6 +1008,17 @@ void CInput::ExtraMouseSample( float frametime, bool active )
 
 	cmd->Reset();
 
+	// Snapshot movement key state to prevent ExtraMouseSample() from
+	// consuming impulse-down bits that should be processed by CreateMove().
+	// This fixes FPS-dependent first-tick acceleration behavior.
+	// Ref: ValveSoftware/Source-1-Games#8045
+	kbutton_t saved_forward = in_forward;
+	kbutton_t saved_back = in_back;
+	kbutton_t saved_moveleft = in_moveleft;
+	kbutton_t saved_moveright = in_moveright;
+	kbutton_t saved_up = in_up;
+	kbutton_t saved_down = in_down;
+
 
 	QAngle viewangles;
 	engine->GetViewAngles( viewangles );
@@ -1106,6 +1117,14 @@ void CInput::ExtraMouseSample( float frametime, bool active )
 		}
 	}
 
+	// Undo side effects on kbutton_t state so that
+	// CreateMove() receives the correct impulse transitions.
+	in_forward = saved_forward;
+	in_back = saved_back;
+	in_moveleft = saved_moveleft;
+	in_moveright = saved_moveright;
+	in_up = saved_up;
+	in_down = saved_down;
 }
 
 void CInput::CreateMove ( int sequence_number, float input_sample_frametime, bool active )


### PR DESCRIPTION
This PR fixes the FPS-dependent movement acceleration bug described in ValveSoftware/Source-1-Games#8045.

The root cause is that `CInput::ExtraMouseSample()` consumes movement key impulse state before it is processed by `CInput::CreateMove()`. Since `CInput::ExtraMouseSample()` may run a different number of times depending on FPS, acceleration becomes both FPS-dependent and nondeterministic.

This patch snapshots movement key state before `CInput::ExtraMouseSample()` and restores it afterwards, preventing movement input from being consumed prematurely.

In addition to fixing ordinary movement input, this also fixes the issue where tick taps (pressing and releasing a movement key within the same tick) randomly fail depending on FPS.

This is intentionally a minimal fix. A more complete solution would likely require redesigning parts of the Source 1 input system, which would be significantly more invasive and carry a greater risk of regressions.

The patch has been tested in TF2. Since the issue exists in shared Source 1 input code, it should also apply to other Source 1 games.

One consequence of this fix is that first-tick acceleration will consistently follow the original Source behavior of applying half acceleration on the first movement tick. Players who are accustomed to playing at high FPS may perceive this as a reduction in responsiveness, since the bug often caused full acceleration to be applied instead.

A second PR (ValveSoftware/source-sdk-2013#1950) builds on top of this one and changes the first-tick acceleration from half acceleration to full acceleration. The first PR can be merged independently. The follow-up PR cannot.