### PR TITLE
[TF2] Fix Thermal Thruster passives not being removed if it's unequipped during use (or player is a Medic) - [Resubmission]

### DIFF
--- a/src/game/shared/tf/tf_player_shared.cpp
+++ b/src/game/shared/tf/tf_player_shared.cpp
@@ -3160,6 +3160,11 @@ void CTFPlayerShared::ConditionThink( void )
 #endif
 				}
 			}
+			else
+			{
+				// RocketPack not found, may have been unequipped, or we may be a Medic who inherited the cond
+				RemoveCond( TF_COND_ROCKETPACK );
+			}
 		}
 	}
 


### PR DESCRIPTION
First and foremost: unless it is a discussion regarding the code itself, this Pull Request is _not_ the appropriate place for discussions regarding this bug or weapon balance. 

I'm also resubmitting this of my own volition. **Do not harass the original PR author**.

If you wish to view a (now closed) discussion regarding this bug, you can view that here:

https://github.com/ValveSoftware/Source-1-Games/issues/7654

If you wish to add to the discussion, the following thread is still active and open (PLEASE do so constructively!):

https://github.com/ValveSoftware/Source-1-Games/issues/7802

Now that is out of the way, a few thoughts here.

This is a reimplementation of a PR that was previously merged, then later reverted. You can find it [here](https://github.com/ValveSoftware/source-sdk-2013/pull/1490).

From my understanding, it was reverted due to strong feedback from some players who preferred the bugged behavior.

While I personally believe known bugs should be fixed regardless of player preference, I recognize that opinions on this may differ greatly, particularly around whether certain weapons (such as the Detonator) should receive balance adjustments to compensate. However, this is neither here nor there. 

This PR is strictly intended as a bug fix for an issue that has existed for a long time. Any discussion around weapon balance is best handled in their own appropriate threads, not in this PR. Thank you!

### Original PR text:

Fixes https://github.com/ValveSoftware/Source-1-Games/issues/4731

The `TF_COND_ROCKETPACK` cond (stomp, lower fall damage, etc) from the Thermal Thruster is supposed to be removed as soon as the player touches the ground, but the code responsible does not do this if the player does not have a Thermal Thruster equipped.

As a result, players can stop the cond from being removed and keep it until they die by unequipping the Thermal Thruster after using it but before touching the ground (such as by flying into a resupply cabinet after changing their loadout). Additionally, Medics with the Quick Fix will always keep the cond until they die if they heal a Pyro as he uses the Thermal Thruster, because they inherit the cond from the Pyro but don't have the weapon themselves, so the cond is never removed from them.

Fixed by removing `TF_COND_ROCKETPACK` if a player touches the ground without the Thermal Thruster equipped.