### PR TITLE
[TF2] Fix tf_parachute_maxspeed_xy to dampen overall horizontal speed instead of individual X/Y speed components

### DIFF
--- a/src/game/shared/tf/tf_gamemovement.cpp
+++ b/src/game/shared/tf/tf_gamemovement.cpp
@@ -51,7 +51,7 @@ ConVar  tf_resolve_stuck_players( "tf_resolve_stuck_players", "1", FCVAR_REPLICA
 ConVar  tf_scout_hype_mod( "tf_scout_hype_mod", "55", FCVAR_REPLICATED | FCVAR_CHEAT | FCVAR_DEVELOPMENTONLY );
 ConVar	tf_max_charge_speed( "tf_max_charge_speed", "750", FCVAR_NOTIFY | FCVAR_REPLICATED | FCVAR_CHEAT  | FCVAR_DEVELOPMENTONLY );
 ConVar  tf_parachute_gravity( "tf_parachute_gravity", "0.2f", FCVAR_DEVELOPMENTONLY | FCVAR_REPLICATED, "Gravity while parachute is deployed" );
-ConVar  tf_parachute_maxspeed_xy( "tf_parachute_maxspeed_xy", "425.0f", FCVAR_DEVELOPMENTONLY | FCVAR_REPLICATED, "Max XY Speed while Parachute is deployed", true, 0.f, false, 0.f );
+ConVar  tf_parachute_maxspeed_xy( "tf_parachute_maxspeed_xy", "350.0f", FCVAR_DEVELOPMENTONLY | FCVAR_REPLICATED, "Max XY Speed while Parachute is deployed", true, 0.f, false, 0.f );
 ConVar  tf_parachute_maxspeed_z( "tf_parachute_maxspeed_z", "-100.0f", FCVAR_DEVELOPMENTONLY | FCVAR_REPLICATED, "Max Z Speed while Parachute is deployed" );
 ConVar  tf_parachute_maxspeed_onfire_z( "tf_parachute_maxspeed_onfire_z", "-100.0f", FCVAR_DEVELOPMENTONLY | FCVAR_REPLICATED, "Max Z Speed when on Fire and Parachute is deployed" );
 ConVar  tf_parachute_aircontrol( "tf_parachute_aircontrol", "2.5f", FCVAR_DEVELOPMENTONLY | FCVAR_REPLICATED, "Multiplier for how much air control players have when Parachute is deployed" );

--- a/src/game/shared/tf/tf_gamemovement.cpp
+++ b/src/game/shared/tf/tf_gamemovement.cpp
@@ -51,7 +51,7 @@ ConVar  tf_resolve_stuck_players( "tf_resolve_stuck_players", "1", FCVAR_REPLICA
 ConVar  tf_scout_hype_mod( "tf_scout_hype_mod", "55", FCVAR_REPLICATED | FCVAR_CHEAT | FCVAR_DEVELOPMENTONLY );
 ConVar	tf_max_charge_speed( "tf_max_charge_speed", "750", FCVAR_NOTIFY | FCVAR_REPLICATED | FCVAR_CHEAT  | FCVAR_DEVELOPMENTONLY );
 ConVar  tf_parachute_gravity( "tf_parachute_gravity", "0.2f", FCVAR_DEVELOPMENTONLY | FCVAR_REPLICATED, "Gravity while parachute is deployed" );
-ConVar  tf_parachute_maxspeed_xy( "tf_parachute_maxspeed_xy", "425.0f", FCVAR_DEVELOPMENTONLY | FCVAR_REPLICATED, "Max XY Speed while Parachute is deployed" );
+ConVar  tf_parachute_maxspeed_xy( "tf_parachute_maxspeed_xy", "425.0f", FCVAR_DEVELOPMENTONLY | FCVAR_REPLICATED, "Max XY Speed while Parachute is deployed", true, 0.f, false, 0.f );
 ConVar  tf_parachute_maxspeed_z( "tf_parachute_maxspeed_z", "-100.0f", FCVAR_DEVELOPMENTONLY | FCVAR_REPLICATED, "Max Z Speed while Parachute is deployed" );
 ConVar  tf_parachute_maxspeed_onfire_z( "tf_parachute_maxspeed_onfire_z", "-100.0f", FCVAR_DEVELOPMENTONLY | FCVAR_REPLICATED, "Max Z Speed when on Fire and Parachute is deployed" );
 ConVar  tf_parachute_aircontrol( "tf_parachute_aircontrol", "2.5f", FCVAR_DEVELOPMENTONLY | FCVAR_REPLICATED, "Multiplier for how much air control players have when Parachute is deployed" );
@@ -2629,12 +2629,12 @@ void CTFGameMovement::FullWalkMove()
 
 			float flDrag = tf_parachute_maxspeed_xy.GetFloat();
 			float flSpeedXY = mv->m_vecVelocity.Length2D();
-			if ( flSpeedXY > flDrag )
+			if ( flSpeedXY > 0.0f && flSpeedXY > flDrag )
 			{
 				// Instead of clamping, we'll dampen
 				float flReduction = ( flSpeedXY - flDrag ) / 3.0f - 10.0f;
 				float flMaxSpeed = flDrag + flReduction;
-				if ( flSpeedXY > flMaxSpeed )
+				if ( flMaxSpeed > 0.0f && flSpeedXY > flMaxSpeed )
 				{
 					float flScale = flMaxSpeed / flSpeedXY;
 					mv->m_vecVelocity[0] *= flScale;

--- a/src/game/shared/tf/tf_gamemovement.cpp
+++ b/src/game/shared/tf/tf_gamemovement.cpp
@@ -51,7 +51,7 @@ ConVar  tf_resolve_stuck_players( "tf_resolve_stuck_players", "1", FCVAR_REPLICA
 ConVar  tf_scout_hype_mod( "tf_scout_hype_mod", "55", FCVAR_REPLICATED | FCVAR_CHEAT | FCVAR_DEVELOPMENTONLY );
 ConVar	tf_max_charge_speed( "tf_max_charge_speed", "750", FCVAR_NOTIFY | FCVAR_REPLICATED | FCVAR_CHEAT  | FCVAR_DEVELOPMENTONLY );
 ConVar  tf_parachute_gravity( "tf_parachute_gravity", "0.2f", FCVAR_DEVELOPMENTONLY | FCVAR_REPLICATED, "Gravity while parachute is deployed" );
-ConVar  tf_parachute_maxspeed_xy( "tf_parachute_maxspeed_xy", "300.0f", FCVAR_DEVELOPMENTONLY | FCVAR_REPLICATED, "Max XY Speed while Parachute is deployed" );
+ConVar  tf_parachute_maxspeed_xy( "tf_parachute_maxspeed_xy", "425.0f", FCVAR_DEVELOPMENTONLY | FCVAR_REPLICATED, "Max XY Speed while Parachute is deployed" );
 ConVar  tf_parachute_maxspeed_z( "tf_parachute_maxspeed_z", "-100.0f", FCVAR_DEVELOPMENTONLY | FCVAR_REPLICATED, "Max Z Speed while Parachute is deployed" );
 ConVar  tf_parachute_maxspeed_onfire_z( "tf_parachute_maxspeed_onfire_z", "-100.0f", FCVAR_DEVELOPMENTONLY | FCVAR_REPLICATED, "Max Z Speed when on Fire and Parachute is deployed" );
 ConVar  tf_parachute_aircontrol( "tf_parachute_aircontrol", "2.5f", FCVAR_DEVELOPMENTONLY | FCVAR_REPLICATED, "Multiplier for how much air control players have when Parachute is deployed" );
@@ -2628,14 +2628,19 @@ void CTFGameMovement::FullWalkMove()
 			mv->m_vecVelocity[2] = Max( mv->m_vecVelocity[2], m_pTFPlayer->m_Shared.InCond( TF_COND_BURNING ) ? tf_parachute_maxspeed_onfire_z.GetFloat() : tf_parachute_maxspeed_z.GetFloat() );
 
 			float flDrag = tf_parachute_maxspeed_xy.GetFloat();
-			// Instead of clamping, we'll dampen
-			float flSpeedX = abs( mv->m_vecVelocity[0] );
-			float flSpeedY = abs( mv->m_vecVelocity[1] );
-			float flReductionX = flSpeedX > flDrag ? ( flSpeedX - flDrag ) / 3.0f - 10.0f : 0;
-			float flReductionY = flSpeedY > flDrag ? ( flSpeedY - flDrag ) / 3.0f - 10.0f : 0;
-
-			mv->m_vecVelocity[0] = Clamp( mv->m_vecVelocity[0], -flDrag - flReductionX, flDrag + flReductionX );
-			mv->m_vecVelocity[1] = Clamp( mv->m_vecVelocity[1], -flDrag - flReductionY, flDrag + flReductionY );
+			float flSpeedXY = mv->m_vecVelocity.Length2D();
+			if ( flSpeedXY > flDrag )
+			{
+				// Instead of clamping, we'll dampen
+				float flReduction = ( flSpeedXY - flDrag ) / 3.0f - 10.0f;
+				float flMaxSpeed = flDrag + flReduction;
+				if ( flSpeedXY > flMaxSpeed )
+				{
+					float flScale = flMaxSpeed / flSpeedXY;
+					mv->m_vecVelocity[0] *= flScale;
+					mv->m_vecVelocity[1] *= flScale;
+				}
+			}
 		}
 
 		StartGravity();

--- a/src/game/shared/tf/tf_gamemovement.cpp
+++ b/src/game/shared/tf/tf_gamemovement.cpp
@@ -2633,7 +2633,7 @@ void CTFGameMovement::FullWalkMove()
 			{
 				// Instead of clamping, we'll dampen
 				float flReduction = ( flSpeedXY - flDrag ) / 3.0f - 10.0f;
-				float flMaxSpeed = flDrag + flReduction;
+				float flMaxSpeed = Max( flDrag, flDrag + flReduction );
 				if ( flMaxSpeed > 0.0f && flSpeedXY > flMaxSpeed )
 				{
 					float flScale = flMaxSpeed / flSpeedXY;

--- a/src/game/shared/tf/tf_gamemovement.cpp
+++ b/src/game/shared/tf/tf_gamemovement.cpp
@@ -2634,7 +2634,7 @@ void CTFGameMovement::FullWalkMove()
 				// Instead of clamping, we'll dampen
 				float flReduction = ( flSpeedXY - flDrag ) / 3.0f - 10.0f;
 				float flMaxSpeed = Max( flDrag, flDrag + flReduction );
-				if ( flMaxSpeed > 0.0f && flSpeedXY > flMaxSpeed )
+				if ( flMaxSpeed >= 0.0f && flSpeedXY > flMaxSpeed )
 				{
 					float flScale = flMaxSpeed / flSpeedXY;
 					mv->m_vecVelocity[0] *= flScale;


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
B.A.S.E. Jumper handling was reducing X and Y speeds individually which could result in unexpected movement when deploying parachutes at high speeds or charging based on how the player was aligned with the map's coordinate grid.
This commit updates the handling to dampen the XY speed correctly regardless of which direction the player is moving.
This also increases the XY speed clamp to ~~425 which was the previous max speed people could reach if traveling along diagonals (sqrt(2*(300^2)), rounded up) to avoid nerfing it~~ 350 per community recommendation as an in-between value of minimum to maximum (300-425) achievable speeds under the old bugged behavior. (As a note: the average speed cap was ~337 based on the average value of 300/cos(angle) between 0 and 45 degrees, so this 350 is a buff on average).
The end result of this is that parachuting charging players will move in the direction they're looking, instead of the current behavior where they move at arbitrary off-angles based on how they align with the map's coordinate grid.

**Demonstration (man):**
**Before** fix, at angles of 0, 3, 40, 45, and trying to turn:

https://github.com/user-attachments/assets/351d2560-0273-422f-9629-db91de5d4003

**After** fix: at angles of 0, 3, 45, 40 (got the order wrong in editing, sorry), and trying to turn:

https://github.com/user-attachments/assets/270daac6-e90f-4779-848d-3f3fb59ed4c8



