### PR TITLE
[TF2] Implement unused teleporter activation sound for MvM

### DIFF
--- a/src/game/server/tf/tf_obj_teleporter.cpp
+++ b/src/game/server/tf/tf_obj_teleporter.cpp
@@ -445,7 +445,7 @@ void CObjectTeleporter::OnGoActive( void )
 		}
 	}
 
-	if ( TFGameRules()->IsMannVsMachineMode() )
+	if ( TFGameRules()->IsMannVsMachineMode() && GetTeamNumber() == TF_TEAM_PVE_INVADERS )
 	{
 		EmitSound( "mvm/mvm_tele_activate.wav" );
 	}

--- a/src/game/server/tf/tf_obj_teleporter.cpp
+++ b/src/game/server/tf/tf_obj_teleporter.cpp
@@ -444,6 +444,11 @@ void CObjectTeleporter::OnGoActive( void )
 			UpdateMaxHealth( pMatch->GetMaxHealth() );
 		}
 	}
+
+	if ( TFGameRules()->IsMannVsMachineMode() )
+	{
+		EmitSound( "mvm/mvm_tele_activate.wav" );
+	}
 }
 
 //-----------------------------------------------------------------------------
@@ -482,6 +487,7 @@ void CObjectTeleporter::Precache()
 	PrecacheScriptSound( "Building_Teleporter.SpinLevel1" );
 	PrecacheScriptSound( "Building_Teleporter.SpinLevel2" );
 	PrecacheScriptSound( "Building_Teleporter.SpinLevel3" );
+	PrecacheSound("mvm/mvm_tele_activate.wav");
 
 	PrecacheParticleSystem( "teleporter_red_charged" );
 	PrecacheParticleSystem( "teleporter_blue_charged" );


### PR DESCRIPTION
Implements the unused Teleporter activation sound for MvM into the game: `mvm/mvm_tele_activate.wav`


https://github.com/user-attachments/assets/63f08176-6bce-4e4d-a5c7-6e9470d65174


