### PR TITLE
[TF2] Fix players being stuck in teleporter when being revived in MVM

### DIFF
--- a/src/game/shared/tf/tf_revive.cpp
+++ b/src/game/shared/tf/tf_revive.cpp
@@ -380,7 +380,7 @@ bool CTFReviveMarker::ReviveOwner( void )
 	// See if their marker is clear
 	Vector vecTeleportPos = GetAbsOrigin();			
 	trace_t tr;
-	CTraceFilterIgnoreTeammatesAndTeamObjects filter( m_hOwner, COLLISION_GROUP_NONE, m_hOwner->GetTeamNumber() );
+	CTraceFilterSimple filter( m_hOwner, COLLISION_GROUP_NONE );
 	UTIL_TraceHull( vecTeleportPos, vecTeleportPos, VEC_HULL_MIN_SCALED( m_hOwner ), VEC_HULL_MAX_SCALED( m_hOwner ), ( MASK_SOLID | CONTENTS_PLAYERCLIP ), &filter, &tr );
 		
 	// If not, try the medic's location


### PR DESCRIPTION
If a player's reanimator is dropped inside a friendly teleporter, they will be trapped upon being revived. This occurs because friendly buildings are added to a filter when checking if the respawn location is valid. This PR fixes this by not ignoring friendly buildings when checking respawn location.

Before:

https://github.com/user-attachments/assets/d605d86d-3dad-4eeb-94d0-55a1e6c3ba3c

After:

https://github.com/user-attachments/assets/808a84aa-63e2-4a1c-b6eb-ec862ebd3a57


