### PR TITLE
[TF2] Clamp pitch values for extra air dash sounds

### DIFF
--- a/src/game/shared/tf/tf_gamemovement.cpp
+++ b/src/game/shared/tf/tf_gamemovement.cpp
@@ -1075,7 +1075,8 @@ void CTFGameMovement::AirDash( void )
 		CPASFilter filter( m_pTFPlayer->GetAbsOrigin( ) );
 		params.m_flVolume = 0.1f;
 		params.m_SoundLevel = SNDLVL_25dB;
-		params.m_nPitch = RemapVal( iAirDash, 1.0f, 5.0f, 100.f, 120.f );
+		// prevent too many dashes from getting an overflowed pitch
+		params.m_nPitch = RemapValClamped( iAirDash, 1.0f, 32.0f, 100.f, 255.f );
 		params.m_nFlags |= ( SND_CHANGE_PITCH | SND_CHANGE_VOL );
 		m_pTFPlayer->StopSound( "General.banana_slip" );
 		m_pTFPlayer->EmitSound( filter, m_pTFPlayer->entindex( ), params );


### PR DESCRIPTION

<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
Prevents air dash sound pitch values from being set to >255, which overflows int m_nPitch.
Maintains previous scaling (1-5 -> 100-120 is now 1-32 -> 100-255, still scaling by 5 per dash).
