### PR TITLE
[TF2] Fix the Classic sniper rifle not having crosshair if tf_hud_no_crosshair_on_scope_zoom is set to 1

### DIFF
--- a/src/game/client/tf/clientmode_tf.cpp
+++ b/src/game/client/tf/clientmode_tf.cpp
@@ -609,6 +609,13 @@ bool ClientModeTFNormal::ShouldDrawCrosshair()
 		 pPlayer->m_Shared.InCond( TF_COND_ZOOMED ) &&
 		 tf_hud_no_crosshair_on_scope_zoom.GetBool() )
 	{
+		if ( pPlayer->GetActiveTFWeapon() )
+		{
+			if ( pPlayer->GetActiveTFWeapon()->GetWeaponID() == TF_WEAPON_SNIPERRIFLE_CLASSIC )
+			{
+				return ClientModeShared::ShouldDrawCrosshair();
+			}
+		}
 		return false;
 	}
 


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
The Classic sniper rifle uses a different scope texture that doesn't have crosshair lines. If the player wants to switch to Classic with tf_hud_no_crosshair_on_scope_zoom set to 1, they will have no crosshair to work with. This is a detriment for the player that is trying to do a quick bodyshot.

Before:
<img width="2560" height="1440" alt="20260615231708_1" src="https://github.com/user-attachments/assets/b202fd21-b605-4028-ae7e-5f4f297ec0e8" />

After:
<img width="2560" height="1440" alt="20260615231514_1" src="https://github.com/user-attachments/assets/42db1d96-ee7b-4a5d-a665-2d3faa8a3752" />
