### PR TITLE
Update tf_weapon_invis.cpp

### DIFF
--- a/src/game/shared/tf/tf_weapon_invis.cpp
+++ b/src/game/shared/tf/tf_weapon_invis.cpp
@@ -223,7 +223,7 @@ bool CTFWeaponInvis::ActivateInvisibilityWatch( void )
 		if ( flDecloakRate <= 0.0f )
 			flDecloakRate = 1.0f;
 
-		pOwner->m_Shared.FadeInvis( 1.0f );
+		pOwner->m_Shared.FadeInvis( flDecloakRate );
 	}
 	else
 	{


### PR DESCRIPTION
Fixes `mult_decloak_rate` attribute being fetched but not used.

I don't know whether this was intentional or not, but it just seemed a little odd, so I wanted to point it out.