### PR TITLE
[TF2] Festivizer Support for Throwables, Sappers, and Lunchboxes

### DIFF
--- a/src/game/server/tf/tf_obj_sapper.cpp
+++ b/src/game/server/tf/tf_obj_sapper.cpp
@@ -123,6 +123,10 @@ void CObjectSapper::Precache()
 	Precache( "c_p2rec.mdl" );
 	Precache( "c_sapper_xmas.mdl" );
 	Precache( "c_breadmonster_sapper.mdl" );
+	Precache( "c_sapper_festivized.mdl" );
+	Precache( "c_sd_sapper_festivized.mdl" );
+	Precache( "c_p2rec_festivized.mdl" );
+	Precache( "c_breadmonster_sapper_festivized.mdl" );
 
 	PrecacheScriptSound( "Weapon_Sapper.Plant" );
 	PrecacheScriptSound( "Weapon_Sapper.Timer" );
@@ -366,6 +370,7 @@ const char* CObjectSapper::GetSapperModelName( SapperModel_t nModel, const char 
 	// Check to see if we have model names generated, if not we must generate
 	if ( m_szPlacementModel[0] == '\0' || m_szSapperModel[0] == '\0' )
 	{
+		int iFestivized = 0;
 		if ( !pchModelName )
 		{
 			if ( GetBuilder() )
@@ -374,6 +379,7 @@ const char* CObjectSapper::GetSapperModelName( SapperModel_t nModel, const char 
 				if ( pWeapon )
 				{
 					pchModelName = pWeapon->GetWorldModel();
+					CALL_ATTRIB_HOOK_INT_ON_OTHER(pWeapon, iFestivized, is_festivized);
 				}
 			}
 		}
@@ -392,8 +398,16 @@ const char* CObjectSapper::GetSapperModelName( SapperModel_t nModel, const char 
 		pchModelName = szModelName + 2;
 
 		{
-			V_snprintf(m_szPlacementModel, sizeof(m_szPlacementModel), "models/buildables/%s%s", pchModelName, "_placement.mdl");
-			V_snprintf(m_szSapperModel, sizeof(m_szSapperModel), "models/buildables/%s%s", pchModelName, "_placed.mdl");
+			if (!iFestivized)
+			{
+				V_snprintf(m_szPlacementModel, sizeof(m_szPlacementModel), "models/buildables/%s%s", pchModelName, "_placement.mdl");
+				V_snprintf(m_szSapperModel, sizeof(m_szSapperModel), "models/buildables/%s%s", pchModelName, "_placed.mdl");
+			}
+			else
+			{
+				V_snprintf(m_szPlacementModel, sizeof(m_szPlacementModel), "models/buildables/%s%s", pchModelName, "_festivized_placement.mdl");
+				V_snprintf(m_szSapperModel, sizeof(m_szSapperModel), "models/buildables/%s%s", pchModelName, "_festivized_placed.mdl");
+			}
 		}
 	}
 

--- a/src/game/shared/tf/tf_weapon_jar.cpp
+++ b/src/game/shared/tf/tf_weapon_jar.cpp
@@ -84,9 +84,12 @@ PRECACHE_WEAPON_REGISTER( tf_projectile_cleaver );
 #define TF_JAR_LAUNCH_SPEED		1000.f
 #define TF_CLEAVER_LAUNCH_SPEED		7000.f
 #define TF_WEAPON_PEEJAR_MODEL	"models/weapons/c_models/urinejar.mdl"
+#define TF_WEAPON_PEEJAR_MODEL_FESTIVIZED	"models/weapons/c_models/urinejar_festivizer_projectile.mdl"
 #define TF_WEAPON_FESTIVE_PEEJAR_MODEL	"models/weapons/c_models/c_xms_urinejar.mdl"
 #define TF_WEAPON_MILKJAR_MODEL	"models/workshop/weapons/c_models/c_madmilk/c_madmilk.mdl"
+#define TF_WEAPON_MILKJAR_MODEL_FESTIVIZED	"models/workshop/weapons/c_models/c_madmilk/c_madmilk_festivizer_projectile.mdl"
 #define TF_WEAPON_CLEAVER_MODEL	"models/workshop_partner/weapons/c_models/c_sd_cleaver/c_sd_cleaver.mdl"
+#define TF_WEAPON_CLEAVER_MODEL_FESTIVIZED	"models/workshop_partner/weapons/c_models/c_sd_cleaver/c_sd_cleaver_festivizer_projectile.mdl"
 #define TF_WEAPON_CLEAVER_IMPACT_FLESH_SOUND	"Cleaver.ImpactFlesh"
 #define TF_WEAPON_CLEAVER_IMPACT_WORLD_SOUND	"Cleaver.ImpactWorld"
 
@@ -248,8 +251,10 @@ CTFProjectile_Jar::CTFProjectile_Jar()
 void CTFProjectile_Jar::Precache()
 {
 	PrecacheModel( TF_WEAPON_PEEJAR_MODEL );
+	PrecacheModel( TF_WEAPON_PEEJAR_MODEL_FESTIVIZED);
 	PrecacheModel( TF_WEAPON_FESTIVE_PEEJAR_MODEL );
 	PrecacheModel( "models/weapons/c_models/c_breadmonster/c_breadmonster.mdl" );
+	PrecacheModel( "models/weapons/c_models/c_breadmonster/c_breadmonster_festivizer_projectile.mdl" );
 
 	PrecacheScriptSound( TF_WEAPON_PEEJAR_EXPLODE_SOUND );
 	BaseClass::Precache();
@@ -262,10 +267,12 @@ void CTFProjectile_Jar::SetCustomPipebombModel()
 {
 	// Check for Model Override
 	int iProjectile = 0;
+	int iFestivized = 0;
 	CTFPlayer *pThrower = ToTFPlayer( GetThrower() );
 	if ( pThrower && pThrower->GetActiveWeapon() )
 	{
 		CALL_ATTRIB_HOOK_INT_ON_OTHER( pThrower->GetActiveWeapon(), iProjectile, override_projectile_type );
+		CALL_ATTRIB_HOOK_INT_ON_OTHER( pThrower->GetActiveWeapon(), iFestivized, is_festivized );
 		switch ( iProjectile )
 		{
 		case TF_PROJECTILE_FESTIVE_JAR :
@@ -275,12 +282,12 @@ void CTFProjectile_Jar::SetCustomPipebombModel()
 		case TF_PROJECTILE_BREADMONSTER_JARATE:
 		case TF_PROJECTILE_BREADMONSTER_MADMILK:
 			m_iProjectileType = iProjectile;
-			SetModel( "models/weapons/c_models/c_breadmonster/c_breadmonster.mdl" );
+			SetModel((iFestivized) ? "models/weapons/c_models/c_breadmonster/c_breadmonster_festivizer_projectile.mdl" : "models/weapons/c_models/c_breadmonster/c_breadmonster.mdl");
 			return;
 		}
 	}
 	
-	SetModel( TF_WEAPON_PEEJAR_MODEL );
+	SetModel((iFestivized) ? TF_WEAPON_PEEJAR_MODEL_FESTIVIZED : TF_WEAPON_PEEJAR_MODEL);
 }
 
 //-----------------------------------------------------------------------------
@@ -794,6 +801,9 @@ CTFProjectile_Jar *CTFJarMilk::CreateJarProjectile( const Vector &position, cons
 void CTFProjectile_JarMilk::Precache()
 {
 	PrecacheModel( TF_WEAPON_MILKJAR_MODEL );
+	PrecacheModel( TF_WEAPON_MILKJAR_MODEL_FESTIVIZED);
+	PrecacheModel( "models/weapons/c_models/c_breadmonster/c_breadmonster_milk.mdl" );
+	PrecacheModel( "models/weapons/c_models/c_breadmonster/c_breadmonster_milk_festivizer_projectile.mdl" );
 
 	BaseClass::Precache();
 }
@@ -837,21 +847,23 @@ void CTFProjectile_JarMilk::SetCustomPipebombModel()
 {
 	// Check for Model Override
 	int iProjectile = 0;
+	int iFestivized = 0;
 	CTFPlayer *pThrower = ToTFPlayer( GetThrower() );
 	if ( pThrower && pThrower->GetActiveWeapon() )
 	{
 		CALL_ATTRIB_HOOK_INT_ON_OTHER( pThrower->GetActiveWeapon(), iProjectile, override_projectile_type );
+		CALL_ATTRIB_HOOK_INT_ON_OTHER(pThrower->GetActiveWeapon(), iFestivized, is_festivized);
 		switch ( iProjectile )
 		{
 		case TF_PROJECTILE_BREADMONSTER_JARATE:
 		case TF_PROJECTILE_BREADMONSTER_MADMILK:
 			m_iProjectileType = iProjectile;
-			SetModel( "models/weapons/c_models/c_breadmonster/c_breadmonster_milk.mdl" );
+			SetModel((iFestivized) ? "models/weapons/c_models/c_breadmonster/c_breadmonster_milk_festivizer_projectile.mdl" : "models/weapons/c_models/c_breadmonster/c_breadmonster_milk.mdl");
 			return;
 		}
 	}
 
-	SetModel( TF_WEAPON_MILKJAR_MODEL );
+	SetModel((iFestivized) ? TF_WEAPON_MILKJAR_MODEL_FESTIVIZED : TF_WEAPON_MILKJAR_MODEL);
 }
 #endif
 
@@ -963,6 +975,7 @@ bool CTFCleaver::Holster( CBaseCombatWeapon *pSwitchingTo )
 void CTFProjectile_Cleaver::Precache()
 {
 	PrecacheModel( TF_WEAPON_CLEAVER_MODEL );
+	PrecacheModel( TF_WEAPON_CLEAVER_MODEL_FESTIVIZED );
 	PrecacheScriptSound( TF_WEAPON_CLEAVER_IMPACT_FLESH_SOUND );
 	PrecacheScriptSound( TF_WEAPON_CLEAVER_IMPACT_WORLD_SOUND );
 
@@ -974,7 +987,10 @@ void CTFProjectile_Cleaver::Precache()
 //-----------------------------------------------------------------------------
 void CTFProjectile_Cleaver::SetCustomPipebombModel()
 {
-	SetModel( TF_WEAPON_CLEAVER_MODEL );
+	int iFestivized = 0;
+	CTFPlayer* pThrower = ToTFPlayer(GetThrower());
+	if (pThrower && pThrower->GetActiveWeapon()) { CALL_ATTRIB_HOOK_INT_ON_OTHER(pThrower->GetActiveWeapon(), iFestivized, is_festivized); }
+	SetModel((iFestivized) ? TF_WEAPON_CLEAVER_MODEL_FESTIVIZED : TF_WEAPON_CLEAVER_MODEL);
 }
 
 CTFProjectile_Cleaver::CTFProjectile_Cleaver()

--- a/src/game/shared/tf/tf_weapon_jar_gas.cpp
+++ b/src/game/shared/tf/tf_weapon_jar_gas.cpp
@@ -123,6 +123,7 @@ float CTFJarGas::GetProjectileSpeed( void )
 void CTFProjectile_JarGas::Precache()
 {
 	PrecacheModel( TF_WEAPON_JAR_GAS_JAR_MODEL );
+	PrecacheModel(TF_WEAPON_JAR_GAS_JAR_MODEL_FESTIVIZED);
 	PrecacheParticleSystem( "gas_can_blue" );
 	PrecacheParticleSystem( "gas_can_red" );
 	PrecacheScriptSound( TF_WEAPON_JARGAS_EXPLODE_SOUND );
@@ -158,7 +159,10 @@ CTFProjectile_JarGas* CTFProjectile_JarGas::Create( const Vector &position, cons
 //-----------------------------------------------------------------------------
 void CTFProjectile_JarGas::SetCustomPipebombModel()
 {
-	SetModel( TF_WEAPON_JAR_GAS_JAR_MODEL );
+	int iFestivized = 0;
+	CTFPlayer* pThrower = ToTFPlayer(GetThrower());
+	if (pThrower && pThrower->GetActiveWeapon()){ CALL_ATTRIB_HOOK_INT_ON_OTHER(pThrower->GetActiveWeapon(), iFestivized, is_festivized); }
+	SetModel((iFestivized) ? TF_WEAPON_JAR_GAS_JAR_MODEL_FESTIVIZED : TF_WEAPON_JAR_GAS_JAR_MODEL);
 }
 
 //-----------------------------------------------------------------------------

--- a/src/game/shared/tf/tf_weapon_jar_gas.h
+++ b/src/game/shared/tf/tf_weapon_jar_gas.h
@@ -33,6 +33,7 @@
 #define TF_GAS_MOVE_DISTANCE 10.f
 
 #define TF_WEAPON_JAR_GAS_JAR_MODEL	"models/weapons/c_models/c_gascan/c_gascan.mdl"
+#define TF_WEAPON_JAR_GAS_JAR_MODEL_FESTIVIZED	"models/weapons/c_models/c_gascan/c_gascan_festivizer_projectile.mdl"
 #define TF_WEAPON_JARGAS_EXPLODE_SOUND	"Weapon_GasCan.Explode"
 
 // *************************************************************************************************************************

--- a/src/game/shared/tf/tf_weapon_lunchbox.cpp
+++ b/src/game/shared/tf/tf_weapon_lunchbox.cpp
@@ -70,6 +70,13 @@ END_DATADESC()
 #define LUNCHBOX_BANANA_DROP_MODEL  "models/items/banana/plate_banana.mdl"
 #define LUNCHBOX_FISHCAKE_DROP_MODEL	"models/workshop/weapons/c_models/c_fishcake/plate_fishcake.mdl"
 
+#define LUNCHBOX_DROP_MODEL_FESTIVIZED  "models/items/plate_festivized.mdl"
+#define LUNCHBOX_STEAK_DROP_MODEL_FESTIVIZED  "models/workshop/weapons/c_models/c_buffalo_steak/plate_buffalo_steak_festivized.mdl"
+#define LUNCHBOX_ROBOT_DROP_MODEL_FESTIVIZED  "models/items/plate_robo_sandwich_festivized.mdl"
+#define LUNCHBOX_CHOCOLATE_BAR_DROP_MODEL_FESTIVIZED		"models/workshop/weapons/c_models/c_chocolate/plate_chocolate_festivized.mdl"
+#define LUNCHBOX_BANANA_DROP_MODEL_FESTIVIZED  "models/items/banana/plate_banana_festivized.mdl"
+#define LUNCHBOX_FISHCAKE_DROP_MODEL_FESTIVIZED	"models/workshop/weapons/c_models/c_fishcake/plate_fishcake_festivized.mdl"
+
 #define LUNCHBOX_DROPPED_MINS	Vector( -17, -17, -10 )
 #define LUNCHBOX_DROPPED_MAXS	Vector( 17, 17, 10 )
 
@@ -127,6 +134,12 @@ void CTFLunchBox::Precache( void )
 		PrecacheModel( LUNCHBOX_CHOCOLATE_BAR_DROP_MODEL );
 		PrecacheModel( LUNCHBOX_BANANA_DROP_MODEL );
 		PrecacheModel( LUNCHBOX_FISHCAKE_DROP_MODEL );
+		PrecacheModel( LUNCHBOX_DROP_MODEL_FESTIVIZED );
+		PrecacheModel( LUNCHBOX_STEAK_DROP_MODEL_FESTIVIZED );
+		PrecacheModel( LUNCHBOX_ROBOT_DROP_MODEL_FESTIVIZED );
+		PrecacheModel( LUNCHBOX_CHOCOLATE_BAR_DROP_MODEL_FESTIVIZED );
+		PrecacheModel( LUNCHBOX_BANANA_DROP_MODEL_FESTIVIZED );
+		PrecacheModel( LUNCHBOX_FISHCAKE_DROP_MODEL_FESTIVIZED );
 	}
 
 	BaseClass::Precache();
@@ -242,38 +255,33 @@ void CTFLunchBox::SecondaryAttack( void )
 		AngleVectors( angForward, &vecForward, &vecRight, &vecUp );
 		Vector vecVelocity = vecForward * 500.0;
 		
-		if ( nLunchBoxType == LUNCHBOX_ADDS_MINICRITS )
+		int iFestivized = 0;
+		CALL_ATTRIB_HOOK_INT(iFestivized, is_festivized);
+
+		switch (nLunchBoxType)
 		{
-			pMedKit->SetModel( LUNCHBOX_STEAK_DROP_MODEL );
+		case LUNCHBOX_ADDS_MINICRITS:
+			pMedKit->SetModel((iFestivized) ? LUNCHBOX_STEAK_DROP_MODEL_FESTIVIZED : LUNCHBOX_STEAK_DROP_MODEL);
+			break;
+		case LUNCHBOX_STANDARD_ROBO:
+			pMedKit->SetModel((iFestivized) ? LUNCHBOX_ROBOT_DROP_MODEL_FESTIVIZED : LUNCHBOX_ROBOT_DROP_MODEL);
+			break;
+		case LUNCHBOX_STANDARD_FESTIVE:
+			pMedKit->SetModel(LUNCHBOX_FESTIVE_DROP_MODEL);
+			break;
+		case LUNCHBOX_CHOCOLATE_BAR:
+			pMedKit->SetModel((iFestivized) ? LUNCHBOX_CHOCOLATE_BAR_DROP_MODEL_FESTIVIZED : LUNCHBOX_CHOCOLATE_BAR_DROP_MODEL);
+			break;
+		case LUNCHBOX_BANANA:
+			pMedKit->SetModel((iFestivized) ? LUNCHBOX_BANANA_DROP_MODEL_FESTIVIZED : LUNCHBOX_BANANA_DROP_MODEL);
+			break;
+		case LUNCHBOX_FISHCAKE:
+			pMedKit->SetModel((iFestivized) ? LUNCHBOX_FISHCAKE_DROP_MODEL_FESTIVIZED : LUNCHBOX_FISHCAKE_DROP_MODEL);
+			break;
+		default:
+			pMedKit->SetModel((iFestivized) ? LUNCHBOX_DROP_MODEL_FESTIVIZED : LUNCHBOX_DROP_MODEL);
 		}
-		else if ( nLunchBoxType == LUNCHBOX_STANDARD_ROBO )
-		{
-			pMedKit->SetModel( LUNCHBOX_ROBOT_DROP_MODEL );
-			pMedKit->m_nSkin = ( pPlayer->GetTeamNumber() == TF_TEAM_RED ) ? 0 : 1;
-		}
-		else if ( nLunchBoxType == LUNCHBOX_STANDARD_FESTIVE )
-		{
-			pMedKit->SetModel( LUNCHBOX_FESTIVE_DROP_MODEL );
-			pMedKit->m_nSkin = ( pPlayer->GetTeamNumber() == TF_TEAM_RED ) ? 0 : 1;
-		}
-		else if ( nLunchBoxType == LUNCHBOX_CHOCOLATE_BAR )
-		{
-			pMedKit->SetModel( LUNCHBOX_CHOCOLATE_BAR_DROP_MODEL );
-			pMedKit->m_nSkin = ( pPlayer->GetTeamNumber() == TF_TEAM_RED ) ? 0 : 1;
-		}
-		else if ( nLunchBoxType == LUNCHBOX_BANANA )
-		{
-			pMedKit->SetModel( LUNCHBOX_BANANA_DROP_MODEL );
-		}
-		else if ( nLunchBoxType == LUNCHBOX_FISHCAKE )
-		{
-			pMedKit->SetModel( LUNCHBOX_FISHCAKE_DROP_MODEL );
-			pMedKit->m_nSkin = ( pPlayer->GetTeamNumber() == TF_TEAM_RED ) ? 0 : 1;
-		}
-		else
-		{
-			pMedKit->SetModel( LUNCHBOX_DROP_MODEL );
-		}
+		pMedKit->m_nSkin = (pPlayer->GetTeamNumber() == TF_TEAM_RED) ? 0 : 1;
 
 		// clear out the overrides so the thrown sandvich/steak look correct in either vision mode
 		pMedKit->ClearModelIndexOverrides();


### PR DESCRIPTION
The [Festivizers workshop submission ](https://steamcommunity.com/sharedfiles/filedetails/?id=3364116726) that added Festivizer support to numerous weapons last Smissmas included models for several additional weapons that would have required extra implementation to work correctly.

This PR includes in-code support for Festivized throwable weapons, heavy lunchbox items, and spy sappers, to properly set the hard-coded models generated in-world when the weapons are used.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/b14df4a8-a61f-4c31-a749-61d1c8cc74e4" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/43c85111-95ca-4d92-9cc4-f74f38b88655" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/38ceb4b2-5b83-4f87-bd4b-3b3c92e6c6fd" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/d9f8efe5-17c5-49f1-b4c0-f4ea8b4d4db2" />

The full list of weapons supported with this PR:
-Mad Milk
-Mutated Milk
-Flying Guillotine
-Gas Passer
-Jarate
-Self-Aware Beauty Mark
-Sandvich
-Robo-Sandvich
-Dalokohs Bar
-Fishcake
-Buffalo Steak Sandvich
-Second Banana
-Sapper
-Ap-Sap
-Snack Attack
-Red-Tape Recorder

The model filepaths referenced in these code changes refer to models already included in the original workshop submission (and included for convenience in the tf_festives shared dropbox).

Many of these weapons do require other tweaks (to the weapon base model, item schema, etc) unrelated to the source code -- I'm working on those notes still in the new "2026 Implementation Notes" spreadsheet in the dropbox; the notes for these weapons in particular are still a work-in-progress but I will update that sheet as I go.