### PR TITLE
[TF2] Move two of Helltower's Soul Gargoyle locations to in-bounds locations

### DIFF
--- a/src/game/server/tf/halloween/halloween_gift_spawn_locations.cpp
+++ b/src/game/server/tf/halloween/halloween_gift_spawn_locations.cpp
@@ -252,8 +252,8 @@ static valid_item_pos kValidPositions_Hightower[] =
 	{ 5629.083984,  7272.486816, 186.031311f  - g_flPlayerEyeHeight },
 	{ 7569.272461,  7356.835938, 30.543331f   - g_flPlayerEyeHeight },
 	{ 7620.356445,  7806.569824, 43.632362f   - g_flPlayerEyeHeight },
-	{ 10225.334961, 7462.086914, -366.968689f - g_flPlayerEyeHeight },
-	{ 10208.725586, 7768.193848, -366.968689f - g_flPlayerEyeHeight },
+	{ 7160.876953,  8153.071777, -181.631653f - g_flPlayerEyeHeight },
+	{ 7163.816406,  7033.578613, -182.131989f - g_flPlayerEyeHeight },
 };
 
 struct halloween_map_info


### PR DESCRIPTION
As title says. Two Soul Gargoyle locations are out of bounds, both on the cliff side. A similar PR already exists under under #1290, except this one doesn't remove the locations but instead picks two more appropriate locations near the tracks. I considered putting them near the incline, but since that is a place often filled with Sentry Guns it did not seem a fair location, and I considered putting it more near the cliff, but there was not much space to make it look good and putting it on the tracks risks the Payload cart blocking the Soul Gargoyle (not necessarily the hitbox, but definitely visually).

Below are two images showing what the locations look like (they are as centered as I could get them):

<img width="1920" height="1080" alt="Hightower 1" src="https://github.com/user-attachments/assets/62af599b-e570-4768-9e11-f1cece69b38c" />

<img width="1920" height="1080" alt="Hightower 2" src="https://github.com/user-attachments/assets/6ff92a67-88d4-495f-930a-7b7aa8d0ccd0" />

Same location as the second image from a different angle, better showing how centred it is:

<img width="1920" height="1080" alt="Hightower 3" src="https://github.com/user-attachments/assets/bc61693d-ba4f-49d7-ae47-1373fcdfc265" />
