### PR TITLE
[TF2] Updated Spy's cigarette to extinguish on milk/gas

### DIFF
--- a/src/game/client/tf/c_tf_player.cpp
+++ b/src/game/client/tf/c_tf_player.cpp
@@ -5816,8 +5816,10 @@ bool C_TFPlayer::CanLightCigarette( void )
 	if ( (pLocalPlayer->GetObserverMode() == OBS_MODE_IN_EYE) && (pLocalPlayer->GetObserverTarget() == this) )
 		return false;
 
-	// Don't light if we're covered in urine.
-	if ( m_Shared.InCond( TF_COND_URINE ) )
+	// Don't light if we're covered in urine, milk, or gas.
+	if ( m_Shared.InCond( TF_COND_URINE ) 
+		|| m_Shared.InCond( TF_COND_MAD_MILK ) 
+		|| m_Shared.InCond( TF_COND_GAS ) )
 		return false;
 
 	return true;


### PR DESCRIPTION
As title says, the Spy's cigarette is 'extinguished' (no smoke particle) when covered in milk or gas. This behaviour already exists when covered in Jarate, and also when dripping with water, but not when covered in milk (would extinguish a cigarette) or gas (safety hazard).