### PR TITLE
[TF2] Add support for Spies to locally emit robot vo while disguised in MvM

### DIFF
--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -463,7 +463,7 @@ public:
 	virtual void			GetStepSoundVelocities( float *velwalk, float *velrun );
 	virtual void			SetStepSoundTime( stepsoundtimes_t iStepSoundTime, bool bWalking );
 	virtual void			DeathSound( const CTakeDamageInfo &info );
-	virtual const char*		GetSceneSoundToken( void ) { return ""; }
+	virtual const char*		GetSceneSoundToken( CBasePlayer * ) { return ""; }
 
 	virtual void			OnEmitFootstepSound( const CSoundParameters& params, const Vector& vecOrigin, float fVolume ) {}
 

--- a/src/game/server/sceneentity.cpp
+++ b/src/game/server/sceneentity.cpp
@@ -1648,7 +1648,7 @@ bool CSceneEntity::GetSoundNameForPlayer( CChoreoEvent *event, CBasePlayer *play
 
 	if ( pActor && pActor->IsPlayer() )
 	{
-		pchToken = dynamic_cast< CBasePlayer* >( pActor )->GetSceneSoundToken();
+		pchToken = dynamic_cast< CBasePlayer* >( pActor )->GetSceneSoundToken( player );
 	}
 
 	// Copy the sound name

--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -15333,7 +15333,7 @@ const char* CTFPlayer::GetSceneSoundToken( CBasePlayer *pListener )
 			  IsPlayerClass( TF_CLASS_SPY ) &&
 			  m_Shared.InCond( TF_COND_DISGUISED ) &&
 			  m_Shared.GetDisguiseTeam() == TF_TEAM_PVE_INVADERS &&
-			  pListener->GetTeamNumber() == TF_TEAM_PVE_INVADERS )
+			  ( pListener == this || ( pListener && pListener->GetTeamNumber() == TF_TEAM_PVE_INVADERS ) ) )
 	{
 		return "MVM_";
 	}

--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -15315,7 +15315,7 @@ void CTFPlayer::DeathSound( const CTakeDamageInfo &info )
 //-----------------------------------------------------------------------------
 // Purpose: 
 //-----------------------------------------------------------------------------
-const char* CTFPlayer::GetSceneSoundToken( void )
+const char* CTFPlayer::GetSceneSoundToken( CBasePlayer *pListener )
 {
 	if ( TFGameRules() && TFGameRules()->IsMannVsMachineMode() && GetTeamNumber() == TF_TEAM_PVE_INVADERS )
 	{
@@ -15327,6 +15327,15 @@ const char* CTFPlayer::GetSceneSoundToken( void )
 		{
 			return "MVM_";
 		}
+	}
+	else if ( TFGameRules() && TFGameRules()->IsMannVsMachineMode() &&
+			  GetTeamNumber() == TF_TEAM_PVE_DEFENDERS &&
+			  IsPlayerClass( TF_CLASS_SPY ) &&
+			  m_Shared.InCond( TF_COND_DISGUISED ) &&
+			  m_Shared.GetDisguiseTeam() == TF_TEAM_PVE_INVADERS &&
+			  pListener->GetTeamNumber() == TF_TEAM_PVE_INVADERS )
+	{
+		return "MVM_";
 	}
 	else
 	{

--- a/src/game/server/tf/tf_player.h
+++ b/src/game/server/tf/tf_player.h
@@ -373,7 +373,7 @@ public:
 	float PlayCritReceivedSound( void );
 	void PainSound( const CTakeDamageInfo &info );
 	void DeathSound( const CTakeDamageInfo &info );
-	virtual const char* GetSceneSoundToken( void );
+	virtual const char* GetSceneSoundToken( CBasePlayer *pListener );
 	void StunSound( CTFPlayer* pAttacker, int iStunFlags, int iOldStunFlags=0 );
 
 	void SetSeeCrit( bool bAllSeeCrit, bool bMiniCrit, bool bShowDisguisedCrit ) { m_bAllSeeCrit = bAllSeeCrit; m_bMiniCrit = bMiniCrit; m_bShowDisguisedCrit = bShowDisguisedCrit;  }


### PR DESCRIPTION
This PR aims to allow Spies to emit robot-filtered vo while disguised as an enemy robot in MvM.

For gameplay purposes, robot vo will only emit for the disguised player (friendly players will keep current behavior). PR has been regression-tested to ensure that enemy robot spies still behave as expected.

https://github.com/user-attachments/assets/1175f77f-5169-4210-b1d1-176a31abace7