### PR TITLE
[TF2] Add support for MvM-specific Spy Masks + Disguise Portraits (assets linked in post)

### DIFF
--- a/src/game/client/tf/c_tf_player.cpp
+++ b/src/game/client/tf/c_tf_player.cpp
@@ -60,6 +60,7 @@
 #include "tf_proxyentity.h"
 #include "materialsystem/imaterial.h"
 #include "materialsystem/imaterialvar.h"
+#include "materialsystem/MaterialSystemUtil.h"
 #include "materialsystem/itexturecompositor.h"
 #include "c_tf_team.h"
 #include "tf_item_inventory.h"
@@ -1763,6 +1764,72 @@ void CSpyInvisProxy::OnBindNotEntity( void *pRenderable )
 }
 
 EXPOSE_INTERFACE( CSpyInvisProxy, IMaterialProxy, "spy_invis" IMATERIAL_PROXY_INTERFACE_VERSION );
+
+//-----------------------------------------------------------------------------
+// Purpose: Replaces a material's texture while playing Mann vs. Machine.
+//-----------------------------------------------------------------------------
+class CMvMTextureProxy : public CResultProxy
+{
+public:
+	virtual bool Init( IMaterial *pMaterial, KeyValues *pKeyValues ) OVERRIDE;
+	virtual void OnBind( void *pC_BaseEntity ) OVERRIDE;
+
+private:
+	bool CaptureOriginalTexture();
+
+	CTextureReference m_OriginalTexture;
+	CTextureReference m_MvMTexture;
+};
+
+bool CMvMTextureProxy::Init( IMaterial *pMaterial, KeyValues *pKeyValues )
+{
+	if ( !CResultProxy::Init( pMaterial, pKeyValues ) )
+		return false;
+
+	const char *pszMvMTexture = pKeyValues->GetString( "mvmTexture", "" );
+	if ( !pszMvMTexture[0] )
+		return false;
+
+	m_MvMTexture.Init( pszMvMTexture, TEXTURE_GROUP_MODEL );
+
+	// With async material loading, $basetexture may still be a string here.
+	// CaptureOriginalTexture will try again when the material is first bound.
+	CaptureOriginalTexture();
+
+	return m_MvMTexture.IsValid();
+}
+
+bool CMvMTextureProxy::CaptureOriginalTexture()
+{
+	if ( m_OriginalTexture.IsValid() )
+		return true;
+
+	if ( !m_pResult || !m_pResult->IsTexture() )
+		return false;
+
+	ITexture *pOriginalTexture = m_pResult->GetTextureValue();
+	if ( !pOriginalTexture )
+		return false;
+
+	m_OriginalTexture.Init( pOriginalTexture );
+	return true;
+}
+
+void CMvMTextureProxy::OnBind( void *pC_BaseEntity )
+{
+	if ( !CaptureOriginalTexture() )
+		return;
+
+	const bool bUseMvMTexture = TFGameRules() && TFGameRules()->IsMannVsMachineMode();
+	m_pResult->SetTextureValue( bUseMvMTexture ? m_MvMTexture : m_OriginalTexture );
+
+	if ( ToolsEnabled() )
+	{
+		ToolFramework_RecordMaterialParams( GetMaterial() );
+	}
+}
+
+EXPOSE_INTERFACE( CMvMTextureProxy, IMaterialProxy, "MvMTexture" IMATERIAL_PROXY_INTERFACE_VERSION );
 
 //-----------------------------------------------------------------------------
 // Purpose: Used for invulnerability material

--- a/src/game/client/tf/c_tf_player.cpp
+++ b/src/game/client/tf/c_tf_player.cpp
@@ -1842,7 +1842,7 @@ void CMvMTextureProxy::OnBind( void *pC_BaseEntity )
 		bUseMvMTexture = pPlayer &&
 			pPlayer->IsPlayerClass( TF_CLASS_SPY ) &&
 			pPlayer->m_Shared.InCond( TF_COND_DISGUISED ) &&
-			pPlayer->m_Shared.GetDisguiseTeam() != pPlayer->GetTeamNumber();
+			pPlayer->m_Shared.GetDisguiseTeam() == TF_TEAM_PVE_INVADERS;
 	}
 
 	m_pResult->SetTextureValue( bUseMvMTexture ? m_MvMTexture : m_OriginalTexture );

--- a/src/game/client/tf/c_tf_player.cpp
+++ b/src/game/client/tf/c_tf_player.cpp
@@ -1771,6 +1771,8 @@ EXPOSE_INTERFACE( CSpyInvisProxy, IMaterialProxy, "spy_invis" IMATERIAL_PROXY_IN
 class CMvMTextureProxy : public CResultProxy
 {
 public:
+	CMvMTextureProxy() : m_bEnemyDisguiseOnly( false ) {}
+
 	virtual bool Init( IMaterial *pMaterial, KeyValues *pKeyValues ) OVERRIDE;
 	virtual void OnBind( void *pC_BaseEntity ) OVERRIDE;
 
@@ -1779,6 +1781,7 @@ private:
 
 	CTextureReference m_OriginalTexture;
 	CTextureReference m_MvMTexture;
+	bool m_bEnemyDisguiseOnly;
 };
 
 bool CMvMTextureProxy::Init( IMaterial *pMaterial, KeyValues *pKeyValues )
@@ -1791,6 +1794,8 @@ bool CMvMTextureProxy::Init( IMaterial *pMaterial, KeyValues *pKeyValues )
 		return false;
 
 	m_MvMTexture.Init( pszMvMTexture, TEXTURE_GROUP_MODEL );
+	KeyValues *pEnemyDisguiseOnly = pKeyValues->FindKey( "enemyDisguiseOnly", false );
+	m_bEnemyDisguiseOnly = pEnemyDisguiseOnly && pEnemyDisguiseOnly->GetBool();
 
 	// With async material loading, $basetexture may still be a string here.
 	// CaptureOriginalTexture will try again when the material is first bound.
@@ -1820,7 +1825,26 @@ void CMvMTextureProxy::OnBind( void *pC_BaseEntity )
 	if ( !CaptureOriginalTexture() )
 		return;
 
-	const bool bUseMvMTexture = TFGameRules() && TFGameRules()->IsMannVsMachineMode();
+	bool bUseMvMTexture = TFGameRules() && TFGameRules()->IsMannVsMachineMode();
+	if ( bUseMvMTexture && m_bEnemyDisguiseOnly )
+	{
+		C_BaseEntity *pEntity = BindArgToEntity( pC_BaseEntity );
+		C_TFPlayer *pPlayer = ToTFPlayer( pEntity );
+		if ( !pPlayer && pEntity )
+		{
+			IHasOwner *pOwnerInterface = dynamic_cast< IHasOwner* >( pEntity );
+			if ( pOwnerInterface )
+			{
+				pPlayer = ToTFPlayer( pOwnerInterface->GetOwnerViaInterface() );
+			}
+		}
+
+		bUseMvMTexture = pPlayer &&
+			pPlayer->IsPlayerClass( TF_CLASS_SPY ) &&
+			pPlayer->m_Shared.InCond( TF_COND_DISGUISED ) &&
+			pPlayer->m_Shared.GetDisguiseTeam() != pPlayer->GetTeamNumber();
+	}
+
 	m_pResult->SetTextureValue( bUseMvMTexture ? m_MvMTexture : m_OriginalTexture );
 
 	if ( ToolsEnabled() )


### PR DESCRIPTION
This PR adds a new 'MvMTexture' proxy to allow for texture swaps while playing Mann vs Machine.

The 'MvMTexture' proxy supports swapping textures with a specified asset while in MvM:
<img width="550" height="285" alt="image" src="https://github.com/user-attachments/assets/6241e55b-b35e-4648-b3a9-663d66048ff4" />

An optional 'enemyDisguiseOnly' parameter is included to support robot mask textures only drawing when disguised as the enemy team in MvM.

This material proxy is intended to be used for the following features:
### Spy Disguise Masks ###
https://github.com/user-attachments/assets/c59bb2af-aaab-4463-8ee2-fd3672dea7e3

### Spy Disguise Portraits (Disguise UI + 2D Player Class HUD) ###
https://github.com/user-attachments/assets/b84964f6-d39c-4bab-9222-960c5d16b7af

### Assets (Steam Workshop) ### 
Assets can be found here: https://steamcommunity.com/sharedfiles/filedetails/?id=3779034311

Submission includes the following:
- MvM Robot Mask Assets (Robot Engineer Mask VTFs/TGAs + updated VMTs)
- MvM Robot Disguise Portraits (VTFs, TGAs, updated VMTs)
- MvM Robot Class HUD Portraits (VTFs, TGAs, updated VMTs)
- MvM Disguise UI Icon (VTFs, TGAs, updated VMT)

<img width="1658" height="444" alt="image" src="https://github.com/user-attachments/assets/04d41e14-969b-4b5d-9811-f6318ac6f452" />
<img width="256" height="256" alt="image" src="https://github.com/user-attachments/assets/6ab9412d-13d7-425f-86c0-d2ebb474b6ca" />
<img width="256" height="256" alt="image" src="https://github.com/user-attachments/assets/5084d8e8-d838-4187-bf72-886499695819" />


### Credits ###
rabscootle - code + implementation aid
badasscook - assets