### PR TITLE
[TF2] Fix collection lootlist rarity colors leaking into descriptions on several UI

### DIFF
--- a/src/game/client/econ/item_model_panel.cpp
+++ b/src/game/client/econ/item_model_panel.cpp
@@ -2754,11 +2754,17 @@ void CItemModelPanel::UpdateDescription( bool bIsToolTip /* = false */ )
 
 			// collection
 			int fontHeight = surface()->GetFontTall( m_pFontAttribSmall );
-			if ( ( line.unMetaType & (kDescLineFlag_Collection | kDescLineFlag_CollectionName | kDescLineFlag_CollectionCurrentItem ) ) != 0 && pCollectionNameTextImage && pCollectionListTextImage )
+			if ( ( line.unMetaType & (kDescLineFlag_Collection | kDescLineFlag_CollectionName | kDescLineFlag_CollectionCurrentItem ) ) != 0 )
 			{
 				bool bIsCollectionName = ( line.unMetaType & kDescLineFlag_CollectionName ) != 0;
 				vgui::TextImage *pTextImage = bIsCollectionName ? pCollectionNameTextImage : pCollectionListTextImage;
 				unsigned int &unCurrentCollectionTextStreamIndex = bIsCollectionName ? unCurrentCollectionNameTextStreamIndex : unCurrentCollectionListTextStreamIndex;
+
+				// If the UI does not display collection lootlist, skip the lines so color controls do not leak
+				if ( !pTextImage )
+				{
+					continue;
+				}
 
 				bool bIsCurrentItem = ( line.unMetaType & kDescLineFlag_CollectionCurrentItem ) != 0;
 				// use bg color as text color for current item for a better highlight


### PR DESCRIPTION
Resolves https://github.com/ValveSoftware/Source-1-Games/issues/4031

This PR fixes collection lootlist rarity colors leaking into descriptions on the following UI:
### Inspect Panel ###
<img width="882" height="428" alt="image" src="https://github.com/user-attachments/assets/2abb2432-1552-40db-9648-097a5330ee9a" />

### Mann Co Catalog ###
<img width="953" height="508" alt="image" src="https://github.com/user-attachments/assets/f3572ce5-c8c1-4c68-8332-4c2c3f9a1c66" />

Live TF code doesn't account for instances where the description skips displaying an item's collection lootlist, resulting in rarity color characters leaking into other text:
<img width="1333" height="1000" alt="image" src="https://github.com/user-attachments/assets/58964a69-e3dd-44fd-9b14-f5064ee62600" />