### PR TITLE
[TF2] Add tf_player_team_debug command

### DIFF
--- a/src/game/client/tf/c_tf_playerresource.cpp
+++ b/src/game/client/tf/c_tf_playerresource.cpp
@@ -21,6 +21,72 @@ extern ConVar tf_mvm_buybacks_method;
 
 C_TF_PlayerResource *g_TF_PR;
 
+//-----------------------------------------------------------------------------
+// Purpose: Prints connected player identifiers and team assignments.
+//-----------------------------------------------------------------------------
+CON_COMMAND_F( tf_player_team_debug, "Prints player identifiers and team assignments.", FCVAR_CLIENTDLL )
+{
+	if ( !g_TF_PR )
+	{
+		return;
+	}
+
+	Msg( "# userid uniqueid           team_id team\n" );
+
+	for ( int i = 1; i <= MAX_PLAYERS; ++i )
+	{
+		if ( !g_TF_PR->IsConnected( i ) )
+		{
+			continue;
+		}
+
+		const int iUserID = g_TF_PR->GetUserID( i );
+		const uint32 unAccountID = g_TF_PR->GetAccountID( i );
+		const int iTeam = g_TF_PR->GetTeam( i );
+
+		const char *pszTeamName = "Unknown";
+
+		switch ( iTeam )
+		{
+		case TEAM_UNASSIGNED:
+			pszTeamName = "Unassigned";
+			break;
+
+		case TEAM_SPECTATOR:
+			pszTeamName = "Spectator";
+			break;
+
+		case TF_TEAM_RED:
+			pszTeamName = "RED";
+			break;
+
+		case TF_TEAM_BLUE:
+			pszTeamName = "BLU";
+			break;
+
+		default:
+			break;
+		}
+
+		if ( g_TF_PR->IsFakePlayer( i ) )
+		{
+			Msg( "# %6d %-18s %7d %s\n",
+				iUserID, "BOT", iTeam, pszTeamName );
+		}
+		else
+		{
+			const CSteamID steamID(
+				unAccountID,
+				GetUniverse(),
+				k_EAccountTypeIndividual
+			);
+
+			Msg( "# %6d %-18s %7d %s\n",
+				iUserID, steamID.Render(), iTeam, pszTeamName );
+		}
+	}
+}
+
 IMPLEMENT_CLIENTCLASS_DT( C_TF_PlayerResource, DT_TFPlayerResource, CTFPlayerResource )
 	RecvPropArray3( RECVINFO_ARRAY( m_iTotalScore ), RecvPropInt( RECVINFO( m_iTotalScore[0] ) ) ),
 	RecvPropArray3( RECVINFO_ARRAY( m_iMaxHealth ), RecvPropInt( RECVINFO( m_iMaxHealth[0] ) ) ),


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description

Adds the client console command `tf_player_team_debug`, which prints identifiers and current team assignments for connected players.

The output includes:

- Session user ID
- Steam3 ID, or `BOT`
- Native team ID
- Human-readable team name

Example Output:

```
# userid uniqueid           team_id team
#      2 [U:1:1511176553]         2 RED
#      3 BOT                      3 BLU
```

The command reads replicated `C_TF_PlayerResource` data and does not depend on a Game Coordinator lobby. It produces no output when no player resource is available.

Team values follow TF2's existing definitions:

- `0` = Unassigned
- `1` = Spectator
- `2` = RED
- `3` = BLU

This provides a small diagnostic command for inspecting player team assignments, which benefits countless community projects that rely on console inference to function.

Video: https://www.youtube.com/watch?v=q7uGnH_7HKo

Related: ValveSoftware/Source-1-Games#8182