### PR TITLE
[TF2] Fix flame manager lingering when changing class

### DIFF
--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -13489,7 +13489,7 @@ void CTFPlayer::RemoveOwnedProjectiles( void )
 		CTFFlameManager *pFlameManager = static_cast< CTFFlameManager* >( ITFFlameManager::AutoList()[i] );
 		if ( pFlameManager->GetAttacker() == this )
 		{
-			pFlameManager->ClearPoints();
+			UTIL_Remove( pFlameManager );
 		}
 	}
 }


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
There's currently an issue where tf_flame_manager will sit around and take up an edict whenever the player changes class while a flame manager is active.

It would _theoretically_ be possible to crash a server if the edict count is already very low, and since the flame manager will linger around for the duration of a round(?) Any round that takes over ~30 minutes could be crashed by a single person.

The reason why the entity linger around is a bit silly, whenever `BaseClass::Update()` (AKA `CTFPointManager::Update()`) gets called every time this entity thinks. There's some server side checks to see if it's time to remove itself.

First the update functions sets `bUpdatePoints` to true if there are any points in the list.
https://github.com/ValveSoftware/source-sdk-2013/blob/88fa198fba3fb85d46d4c95018254693fdc3af0a/src/game/shared/tf/tf_point_manager.cpp#L244
There might be some case (unsure) where we created the manager, but no points have been created yet.

The manager then proceeds to go through every point in the list if any to see if it should be removed. Otherwise it updates to update it's size bounds if applicable.

It then checks against the bool to see if there were actually points to update, if all the points are removed, it'll remove itself. Otherwise it applies the size to itself.
https://github.com/ValveSoftware/source-sdk-2013/blob/88fa198fba3fb85d46d4c95018254693fdc3af0a/src/game/shared/tf/tf_point_manager.cpp#L291-L304

The issue is that, if it's list gets emptied outside of it's think function, the update function will just assume no points have been created yet.

I might try to do a more proper refactor on some of the point manager stuff, but for now this band aid solution will do rather than having this issue living rent free in the back of my head. It simply just uses `UTIL_Remove` like most of everything else in the `RemoveOwnedProjectiles` function. The point manager is already set up to call `ClearPoints` before being removed.

The only regression caused by this, is that flame particles will be immediately removed, these were only visible client side. As the points for flames would only be removed on the server.