### PR TITLE
[TF2] Allow "Inspect Item" from Backpack for Sappers, Construction PDA, Disguise Kit

### DIFF
--- a/src/game/client/econ/backpack_panel.cpp
+++ b/src/game/client/econ/backpack_panel.cpp
@@ -265,7 +265,12 @@ bool BCanPreviewPaintKit( const CEconItemView* pItem )
 	if ( IsPaintKitTool( pItem->GetItemDefinition() ) )
 		return true;
 
-	return IsValidPickupWeaponSlot( pItem->GetItemDefinition()->GetDefaultLoadoutSlot() );
+	int iSlot = pItem->GetItemDefinition()->GetDefaultLoadoutSlot();
+	return iSlot == LOADOUT_POSITION_PRIMARY
+		|| iSlot == LOADOUT_POSITION_SECONDARY
+		|| iSlot == LOADOUT_POSITION_MELEE
+		|| iSlot == LOADOUT_POSITION_BUILDING
+		|| iSlot == LOADOUT_POSITION_PDA;
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Currently, the "Inspect Item" option in the Backpack right-click menu only appears for weapons if they are Primary, Secondary, or Melee weapons.  This means the option is NOT available for any of Spy's Sappers, nor the Construction PDA nor Disguise Kit.

This PR addresses this issue, enabling this option for the five Sapper variants and the Construction/Disguise PDAs.

A few notes regarding this PR:

-First, the right-click menu in the Inventory is disabled entirely by default in the SDK, via a single return statement at the top of CBackpackPanel::OpenContextMenu() in src\game\client\econ\backpack_panel.cpp -- testing this code change within the SDK requires commenting out that line.

-Second, this change enables this option for items classed as "building" or "pda" -- it intentionally excludes "pda2" which includes the Spy Watches and the Destruction PDA.  None of the Spy Watches have proper standalone models (they all use ONLY v_models) so including them would be mostly pointless, however if that were to change they could be included as well by appending an additional line to the added block specifying LOADOUT_POSITION_PDA2

-Third, these items need some minor tweaks to appear properly:

    -Add "inspect_panel_dist" "25" to the item schema definition for the Construction PDA ("737")
    -Add "inspect_panel_dist" "13" to the item schema definition for the Disguise Kit ("27")
    
    -Add a "pedestal_0" attachment to the QC script for the Construction PDA base weapon model:
        models/weapons/c_models/c_builder/c_builder.mdl
        |
        $attachment "pedestal_0" "weapon_bone" 0.00 2.37 0.04 rotate -45 -90 0

    -Add "pedestal_0" attachments to the QC scripts for the Disguise Kit and Sappers base weapon models:
        models/weapons/w_models/w_cigarette_case.mdl
        models/weapons/c_models/c_sapper/c_sapper.mdl
        models/weapons/c_models/c_sapper/c_sapper_xmas.mdl
        models/weapons/c_models/c_p2rec/c_p2rec.mdl
        models/weapons/c_models/c_breadmonster_sapper/c_breadmonster_sapper.mdl
        models/workshop_partner/weapons/c_models/c_sd_sapper/c_sd_sapper.mdl
        |
        $attachment "pedestal_0" "weapon_bone" 0.00 0.00 0.00 rotate -90 -90 0
        
        Some of the sapper models already have a "pedestal_0" attachment,
        but they should be replaced with the above across the board for uniformity and better visibility

<img width="1568" height="783" alt="menu" src="https://github.com/user-attachments/assets/5b971dfd-379c-4078-94c2-66bfe4a004f2" />
<img width="1136" height="645" alt="build" src="https://github.com/user-attachments/assets/9c1db9fc-8d82-49eb-845f-09837032b647" />
<img width="1327" height="668" alt="cigcase" src="https://github.com/user-attachments/assets/285bea5e-7c24-48dc-a787-38c055fc8dc0" />
<img width="1054" height="652" alt="sapper" src="https://github.com/user-attachments/assets/a105efd0-1934-416c-8118-3536f8df8654" />
<img width="1029" height="632" alt="festsapper" src="https://github.com/user-attachments/assets/6c14af0b-dcf4-431d-b1a7-982755575d7e" />
<img width="963" height="647" alt="apsap" src="https://github.com/user-attachments/assets/d422732b-704c-40b0-bfac-33faf33f6983" />
<img width="895" height="672" alt="snack" src="https://github.com/user-attachments/assets/3b02973c-864e-4b9c-98d2-b0d305da6129" />
<img width="946" height="679" alt="redtape" src="https://github.com/user-attachments/assets/e2619517-8589-4d8d-860e-6373b04a0d89" />

Fixes https://github.com/ValveSoftware/Source-1-Games/issues/2907 (partially, see comment on that issue)