### PR TITLE
[TF2] Fix multiple class menu related issues

### DIFF
--- a/src/game/client/tf/vgui/tf_playermodelpanel.cpp
+++ b/src/game/client/tf/vgui/tf_playermodelpanel.cpp
@@ -486,6 +486,7 @@ void CTFPlayerModelPanel::PlayVCD( const char *pszVCD, const char *pszWeaponEnti
 	m_bVCDFileNameOnly = bFileNameOnly;
 }
 
+extern ConVar _cl_classmenuopen;
 //-----------------------------------------------------------------------------
 // Purpose: 
 //-----------------------------------------------------------------------------
@@ -508,6 +509,25 @@ void CTFPlayerModelPanel::FireEvent( const char *pszEventName, const char *pszEv
 		{
 			m_aMergeMDLs[nWeaponIndex].m_bDisabled = false;
 		}
+	}
+	else if ( V_strcmp( pszEventName, "AE_CL_PLAYSOUND" ) == 0 || V_strcmp( pszEventName, "CL_EVENT_SOUND" )
+			|| V_strcmp( pszEventName, "CL_EVENT_FOOTSTEP_LEFT" ) || V_strcmp( pszEventName, "CL_EVENT_FOOTSTEP_RIGHT" ) )
+	{
+		if ( !engine->IsInGame() || !_cl_classmenuopen.GetBool() )
+			return;
+
+		soundlevel_t iSoundlevel = SNDLVL_NONE;
+
+		EmitSound_t es;
+		es.m_nChannel = CHAN_STATIC;
+		es.m_flVolume = 1;
+		es.m_SoundLevel = iSoundlevel;
+		es.m_flSoundTime = gpGlobals->curtime;
+		es.m_bEmitCloseCaption = false;
+		es.m_pSoundName = pszEventOptions;
+
+		C_RecipientFilter filter;
+		C_BaseEntity::EmitSound(filter, SOUND_FROM_UI_PANEL, es);
 	}
 }
 
@@ -2296,10 +2316,22 @@ void CTFPlayerModelPanel::SetupFlexWeights( void )
 
 	LocalFlexController_t i;
 
-	// Decay to neutral
-	for ( i = LocalFlexController_t(0); i < GetNumFlexControllers(); i++)
+	// a bit hackish, but this will let us know if we're entering a new scene.
+	if ( ( m_pScene && m_flLastTickTime < FLT_EPSILON ) || m_RootMDL.m_MDL.m_flTime < FLT_EPSILON )
 	{
-		SetFlexWeight( i, GetFlexWeight( i ) * 0.95 );
+		// reset flex weights
+		for (i = LocalFlexController_t(0); i < GetNumFlexControllers(); i++)
+		{
+			SetFlexWeight(i, 0.0f);
+		}
+	}
+	else
+	{
+		// Decay to neutral
+		for (i = LocalFlexController_t(0); i < GetNumFlexControllers(); i++)
+		{
+			SetFlexWeight(i, GetFlexWeight(i) * 0.95f);
+		}
 	}
 
 	// Run scene
@@ -2332,11 +2364,15 @@ void CTFPlayerModelPanel::SetupFlexWeights( void )
 		// Advance time
 		if ( m_flLastTickTime < FLT_EPSILON )
 		{
-			m_flLastTickTime = m_RootMDL.m_MDL.m_flTime - SCENE_LERP_TIME;
+			m_flLastTickTime = m_RootMDL.m_MDL.m_flTime;
+			// if we have an end time, we can give some time to lerp to idle.
+			if ( m_flSceneEndTime > FLT_EPSILON )
+			{
+				m_flLastTickTime -= SCENE_LERP_TIME;
+			}
 		}
 
 		m_flSceneTime += (m_RootMDL.m_MDL.m_flTime - m_flLastTickTime);
-		m_flSceneTime = Max( m_flSceneTime, -SCENE_LERP_TIME );
 		m_flLastTickTime = m_RootMDL.m_MDL.m_flTime;
 
 		if ( m_flSceneEndTime > FLT_EPSILON && m_flSceneTime > m_flSceneEndTime )

--- a/src/vgui2/matsys_controls/mdlpanel.cpp
+++ b/src/vgui2/matsys_controls/mdlpanel.cpp
@@ -166,6 +166,7 @@ void CMDLPanel::SetMDL( MDLHandle_t handle, void *pProxyData )
 	m_RootMDL.m_MDL.m_bWorldSpaceViewTarget = false;
 	m_RootMDL.m_MDL.m_vecViewTarget.Init( 100.0f, 0.0f, vecMaxs.z );
 
+	m_RootMDL.m_MDL.m_flTime = 0.0f;
 	m_RootMDL.m_flCycleStartTime = 0.f;
 
 	// Set the pose parameters to the default for the mdl


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
Based on mastercoms implementation of class menu fix.
This PR addresses two issues regarding class selection menu. First is missing sound effect, second is facial animation not resetting at the start of the animation.

Before:

https://github.com/user-attachments/assets/0b30393e-a82c-482b-bd44-da4da8679cdb

After:

https://github.com/user-attachments/assets/43b42e43-4771-4c2e-be47-973b57731e08

In addition, Spy has faulty class_select.vcd which causes Spy to have choppy class select animation at the start. The .vcd will also cause Spy to repeatedly huffing his cigarette instead of playing his idle animation. After this PR is applied, the faulty .vcd will cause Spy to play idle animation for 0.1 second at the start of his class select animation.
In order to avoid all the issues listed above, this PR must be accompanied with .vcd fix. Valve will need to place class_select.vcd inside tf/scenes/player/spy/low and then rebuild scenes.image.

Edit: Restore missing facial animation where Spy blows the cigarette smoke.
[class_select.zip](https://github.com/user-attachments/files/30703242/class_select.zip)

Before:

https://github.com/user-attachments/assets/d2d6a904-2aed-4de0-8ff4-4360e3f4f8b5

After without .vcd fix:

https://github.com/user-attachments/assets/deded8fe-6af7-4216-b3a8-f3e743b68a7f

After with .vcd fix:

https://github.com/user-attachments/assets/e49779d0-f0d6-47dd-84fc-d06d112df077

Lastly, the class menu used to have spotlight that was absent since the MVM update. The player model looks much darker compared to how it was before 2012. The method to fix this was mentioned by https://github.com/ValveSoftware/Source-1-Games/issues/4121
Valve needs to put this fixed classselection.res inside tf/resource/ui

[classselection.zip](https://github.com/user-attachments/files/30666918/classselection.zip)

Before:
<img width="2560" height="1440" alt="20260803231849_1" src="https://github.com/user-attachments/assets/b5700da4-c887-429b-af5a-694dd9dfd730" />
After:
<img width="2560" height="1440" alt="Screenshot 2026-08-03 23-28-49" src="https://github.com/user-attachments/assets/48952790-535b-468f-bfea-245717e3ef74" />

If all the suggestions are implemented, this related issue can be closed for good.
https://github.com/ValveSoftware/Source-1-Games/issues/4121