### PR TITLE
[TF2] Fix HUD player model not immediately reflecting loadout changes

### DIFF
--- a/src/game/client/tf/tf_hud_playerstatus.cpp
+++ b/src/game/client/tf/tf_hud_playerstatus.cpp
@@ -108,6 +108,7 @@ CTFHudPlayerClass::CTFHudPlayerClass( Panel *parent, const char *name ) : Editab
 	m_nKillStreak = 0;
 
 	m_bUsePlayerModel = cl_hud_playerclass_use_playermodel.GetBool();
+	m_bModelPanelDirty = false;
 
 	ListenForGameEvent( "localplayer_changedisguise" );
 	ListenForGameEvent( "post_inventory_application" );
@@ -233,10 +234,9 @@ void CTFHudPlayerClass::OnThink()
 		bPlayerClassModeChange = true;
 	}
 
-
 	bool bForceEyeUpdate = false;
 	// set our class image
-	if (	m_nClass != pPlayer->GetPlayerClass()->GetClassIndex() || bTeamChange || bCloakChange || bLoadoutPositionChange || bPlayerClassModeChange ||
+	if (	m_bModelPanelDirty || m_nClass != pPlayer->GetPlayerClass()->GetClassIndex() || bTeamChange || bCloakChange || bLoadoutPositionChange || bPlayerClassModeChange ||
 			(
 				m_nClass == TF_CLASS_SPY &&
 				(
@@ -411,6 +411,8 @@ static void HudPlayerClassUsePlayerModelDialogCallback( bool bConfirmed, void *p
 //-----------------------------------------------------------------------------
 void CTFHudPlayerClass::UpdateModelPanel()
 {
+	m_bModelPanelDirty = false;
+
 	if ( !m_bUsePlayerModel )
 	{
 		return;
@@ -547,12 +549,13 @@ void CTFHudPlayerClass::FireGameEvent( IGameEvent * event )
 	}
 	else if ( FStrEq( "post_inventory_application", pszEventName ) )
 	{
-		// Force a refresh. if this is for the local player
+		// Force a refresh if this is for the local player.
 		int iUserID = event->GetInt( "userid" );
 		C_TFPlayer* pPlayer = ToTFPlayer( C_TFPlayer::GetLocalPlayer() );
 		if ( pPlayer && pPlayer->GetUserID() == iUserID )
 		{
-			UpdateModelPanel();
+			// Prediction won't have reconciled our loadout changes yet - defer our refresh to the next time we think.
+			m_bModelPanelDirty = true;
 		}
 	}
 	else if ( FStrEq( "localplayer_pickup_weapon", pszEventName ) )

--- a/src/game/client/tf/tf_hud_playerstatus.h
+++ b/src/game/client/tf/tf_hud_playerstatus.h
@@ -84,8 +84,8 @@ private:
 	int					m_nLoadoutPosition;
 	int					m_nKillStreak;
 
-	
 	bool				m_bUsePlayerModel;
+	bool				m_bModelPanelDirty;
 };
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description

TF2 currently has a bug where the player model in the HUD may not update in response to loadout changes. Observe the model on the lower left below:

<details>
<summary><b>Current behavior</b></summary>

[!](https://github.com/user-attachments/assets/b213d845-dc44-41a4-a33f-963d6072b8d3)

</details>

This occurs because the HUD player model refreshes its appearance as soon as it receives notice of a loadout change by receiving the `post_inventory_application` game event. At this point in time, the model's code can't observe the player's updated loadout because it hasn't been reconciled by prediction yet.

This PR fixes this issue by deferring HUD model refreshes caused by loadout changes to the model's next think cycle, which will only occur after prediction finishes reconciling the player's loadout changes. This ensures that the model is only refreshed when it can access the player's latest loadout data, keeping the model's appearance up to date. See below:

<details>
<summary><b>With this PR</b></summary>

[!](https://github.com/user-attachments/assets/c02a5976-b285-4df7-bd9e-ef45c2d72354)

</details>