### PR TITLE
Interpolate objects separately from other entities

### DIFF
--- a/src/game/client/c_baseentity.cpp
+++ b/src/game/client/c_baseentity.cpp
@@ -79,6 +79,7 @@ void cc_cl_interp_all_changed( IConVar *pConVar, const char *pOldString, float f
 
 static ConVar  cl_extrapolate( "cl_extrapolate", "1", FCVAR_CHEAT, "Enable/disable extrapolation if interpolation history runs out." );
 static ConVar  cl_interp_npcs( "cl_interp_npcs", "0.0", FCVAR_USERINFO, "Interpolate NPC positions starting this many seconds in past (or cl_interp, if greater)" );  
+static ConVar  cl_interp_objects( "cl_interp_objects", "0.0", FCVAR_USERINFO, "Interpolate objects starting this many seconds in the past (or cl_interp, if greater)" );
 static ConVar  cl_interp_all( "cl_interp_all", "0", 0, "Disable interpolation list optimizations.", 0, 0, 0, 0, cc_cl_interp_all_changed );
 ConVar  r_drawmodeldecals( "r_drawmodeldecals", "1", FCVAR_ALLOWED_IN_COMPETITIVE );
 extern ConVar	cl_showerror;
@@ -5908,6 +5909,23 @@ static float AdjustInterpolationAmount( C_BaseEntity *pEntity, float baseInterpo
 			}
 		}
 	}
+	
+	if ( cl_interp_objects.GetFloat() > 0 )
+	{
+		const float minObjectInterpolationTime = cl_interp_objects.GetFloat();
+		const float minObjectInterpolation = TICK_INTERVAL * ( TIME_TO_TICKS( minObjectInterpolationTime ) + 1 );
+		
+		if ( minObjectInterpolation > baseInterpolation )
+		{
+			while ( pEntity )
+			{
+				if ( pEntity->IsBaseObject() )
+					return minObjectInterpolation;
+				
+				pEntity = pEntity->GetMoveParent();
+			}
+		}
+	}
 
 	return baseInterpolation;
 }
@@ -6448,11 +6466,16 @@ void C_BaseEntity::CheckCLInterpChanged()
 	float flCurValue_InterpNPCs = cl_interp_npcs.GetFloat();
 	static float flLastValue_InterpNPCs = flCurValue_InterpNPCs;
 	
+	float flCurValue_InterpObjects = cl_interp_objects.GetFloat();
+	static float flLastValue_InterpObjects = flCurValue_InterpObjects;
+	
 	if ( flLastValue_Interp != flCurValue_Interp || 
-		 flLastValue_InterpNPCs != flCurValue_InterpNPCs  )
+		 flLastValue_InterpNPCs != flCurValue_InterpNPCs ||
+		 flLastValue_InterpObjects != flCurValue_InterpObjects )
 	{
 		flLastValue_Interp = flCurValue_Interp;
 		flLastValue_InterpNPCs = flCurValue_InterpNPCs;
+		flLastValue_InterpObjects = flCurValue_InterpObjects;
 	
 		// Tell all the existing entities to update their interpolation amounts to account for the change.
 		C_BaseEntityIterator iterator;


### PR DESCRIPTION
Adds a command (`cl_interp_objects`) that acts identically to the `cl_interp_npcs` command except targeting objects.

Will use `cl_interp`'s value if `cl_interp` is higher than `cl_interp_objects`.

---

This PR is mainly intended to fix the choppy animations observed on the Sentry Gun. Note the `cl_interp` settings in the console window.

https://github.com/user-attachments/assets/d1e580dc-178b-43f2-98c3-6249d6d00d5b

This issue is caused by the interpolation not starting far enough in the past (needs to be at least three and a half ticks in the past, 3.5/66ths of a second by default), resulting in the game not knowing where it will be interpolating to when the interpolation starts, giving up and displaying without any interpolation.

Currently, the only way to fix this is by increasing your global interpolation. Many players would prefer not to do this however, as it also comes with a disadvantage in that you are seeing the game world a fraction of a second later than you otherwise would be.

However, given that Engineer buildings are stationary as a rule, many players I've spoken to would be okay with an increased interpolation setting specifically for buildings, which is what this PR provides.

> [!NOTE]
> This PR does not make any changes to the default settings or players' existing configurations. It can only be activated with a new console command which currently does not exist.
>
> `cl_interp_objects` uses `cl_interp`'s value if `cl_interp` is larger, which by default it will be because `cl_interp_objects` is `0.0` by default.

---

This video shows the result of increasing the object interpolation command to be above 3.5/66ths of a second (required for interpolation to work). Note the considerably smoother animations while the Sentry Gun is being built and upgraded.

https://github.com/user-attachments/assets/17bd6fe9-070a-44ac-9411-649ba6cda777

Global interpolation that affects player movement is unaffected, but Sentry Guns look a lot smoother.