### PR TITLE
[All] fix trigger_wind brush rotation

### DIFF
--- a/src/game/server/triggers.cpp
+++ b/src/game/server/triggers.cpp
@@ -3821,6 +3821,7 @@ public:
 	// Input handlers
 	void	InputEnable( inputdata_t &inputdata );
 	void	InputSetSpeed( inputdata_t &inputdata );
+	void	InputSetWindAngle( inputdata_t &inputdata);
 
 private:
 	int 	m_nSpeedBase;	// base line for how hard the wind blows
@@ -3866,6 +3867,7 @@ BEGIN_DATADESC( CTriggerWind )
 	DEFINE_FUNCTION( WindThink ),
 
 	DEFINE_INPUTFUNC( FIELD_INTEGER, "SetSpeed", InputSetSpeed ),
+	DEFINE_INPUTFUNC( FIELD_INTEGER, "SetWindAngle", InputSetWindAngle ),
 
 END_DATADESC()
 
@@ -4074,6 +4076,14 @@ void CTriggerWind::InputSetSpeed( inputdata_t &inputdata )
 	m_bSwitch = true;
 }
 
+//------------------------------------------------------------------------------
+// Purpose: set new wind angle and mark to switch next think
+//------------------------------------------------------------------------------
+void CTriggerWind::InputSetWindAngle( inputdata_t &inputdata )
+{
+	m_nDirBase = (inputdata.value.int() + GetLocalAngles().y);
+	m_bSwitch = true;
+}
 
 //-----------------------------------------------------------------------------
 // Purpose: Draw any debug text overlays

--- a/src/game/server/triggers.cpp
+++ b/src/game/server/triggers.cpp
@@ -4081,7 +4081,7 @@ void CTriggerWind::InputSetSpeed( inputdata_t &inputdata )
 //------------------------------------------------------------------------------
 void CTriggerWind::InputSetWindAngle( inputdata_t &inputdata )
 {
-	m_nDirBase = (inputdata.value.int() + GetLocalAngles().y);
+	m_nDirBase = (inputdata.value.Int() + GetLocalAngles().y);
 	m_bSwitch = true;
 }
 

--- a/src/game/server/triggers.cpp
+++ b/src/game/server/triggers.cpp
@@ -3849,7 +3849,7 @@ BEGIN_DATADESC( CTriggerWind )
 
 	DEFINE_FIELD( m_nSpeedCurrent, FIELD_INTEGER),
 	DEFINE_FIELD( m_nSpeedTarget,	FIELD_INTEGER),
-	DEFINE_FIELD( m_nDirBase,		FIELD_INTEGER),
+	DEFINE_KEYFIELD( m_nDirBase,	FIELD_INTEGER, "WindAngle"),
 	DEFINE_FIELD( m_nDirCurrent,	FIELD_INTEGER),
 	DEFINE_FIELD( m_nDirTarget,	FIELD_INTEGER),
 	DEFINE_FIELD( m_bSwitch,		FIELD_BOOLEAN),
@@ -3869,6 +3869,14 @@ BEGIN_DATADESC( CTriggerWind )
 
 END_DATADESC()
 
+//------------------------------------------------------------------------------
+// Purpose: Constructor for trigger_wind
+//------------------------------------------------------------------------------
+CTriggerWind::CTriggerWind()
+{
+	// assign default values
+	m_nDirBase = -1;
+}
 
 //------------------------------------------------------------------------------
 // Purpose:
@@ -3876,8 +3884,19 @@ END_DATADESC()
 void CTriggerWind::Spawn( void )
 {
 	m_bSwitch = true;
-	m_nDirBase = GetLocalAngles().y;
-
+	if (m_nDirBase >= 0)
+	{
+		// negative "WindAngle" (default) means use the old method and grab
+		// from "angles" instead (has the unintended side effect of rotating
+		// the trigger; not fixing in order to not break existing maps)
+		m_nDirBase = GetLocalAngles().y;
+	}
+	else 
+	{
+		// rotate wind to match brush rotation. fixes rotated instances,
+		// as long as they're only rotated around Z (yaw) axis
+		m_nDirBase += (GetLocalAngles().y);
+	}
 	BaseClass::Spawn();
 
 	m_nSpeedCurrent = m_nSpeedBase;


### PR DESCRIPTION
## Description
Fixes "angles" KV conflict, having been used for both wind direction and brush rotation (as discussed on VDC page). 
* A new "WindAngle" KV has been added, which maps directly to the preexisting `m_nDirBase` variable. Wind direction is modified by brush angles if using the new method (ensures yaw-rotated instances work correctly).
* A new "SetWindAngle" input has been added, which properly updates the wind angle.
* `m_nDirBase` now defaults to `-1` if absent from the entity lump, which reverts to the old method.

## Legalese
All code in this PR was written by me based upon existing Source SDK code. Permission is granted to use it as is laid out in the LICENSE and CONTRIBUTING files.