### PR TITLE
[TF2] Fix rocket trails being duplicated by reflects

### DIFF
--- a/src/game/client/tf/c_tf_projectile_rocket.cpp
+++ b/src/game/client/tf/c_tf_projectile_rocket.cpp
@@ -20,6 +20,7 @@ END_NETWORK_TABLE()
 //-----------------------------------------------------------------------------
 C_TFProjectile_Rocket::C_TFProjectile_Rocket( void )
 {
+	m_bCreatedTrails = false;
 	pEffect = NULL;
 }
 
@@ -50,7 +51,6 @@ void C_TFProjectile_Rocket::CreateTrails( void )
 	if ( IsDormant() )
 		return;
 
-	bool bUsingCustom = false;
 
 	if ( pEffect )
 	{
@@ -59,70 +59,77 @@ void C_TFProjectile_Rocket::CreateTrails( void )
 	}
 
 	int iAttachment = LookupAttachment( "trail" );
-	if ( iAttachment == INVALID_PARTICLE_ATTACHMENT )
-		return;
-
-	if ( enginetrace->GetPointContents( GetAbsOrigin() ) & MASK_WATER )
+	if ( iAttachment != INVALID_PARTICLE_ATTACHMENT )
 	{
-		ParticleProp()->Create( "rockettrail_underwater", PATTACH_POINT_FOLLOW, "trail" );
-		bUsingCustom = true;
-	}
-	else if ( GetTeamNumber() == TEAM_UNASSIGNED )
-	{
-		ParticleProp()->Create( "rockettrail_underwater", PATTACH_POINT_FOLLOW, "trail" );
-		bUsingCustom = true;
-	}
-	else
-	{
-		// Halloween Spell Effect Check
-		int iHalloweenSpell = 0;
-		// if the owner is a Sentry, Check its owner
-		CBaseObject *pSentry = GetOwnerEntity() && GetOwnerEntity()->IsBaseObject() ? assert_cast<CBaseObject*>( GetOwnerEntity() ) : NULL;
-		if ( TF_IsHolidayActive( kHoliday_HalloweenOrFullMoon ) )
+		if ( !m_bCreatedTrails )
 		{
-			if ( pSentry )
+			bool bUsingCustom = false;
+
+			if ( enginetrace->GetPointContents( GetAbsOrigin() ) & MASK_WATER )
 			{
-				CALL_ATTRIB_HOOK_INT_ON_OTHER( pSentry->GetOwner(), iHalloweenSpell, halloween_pumpkin_explosions );
+				ParticleProp()->Create( "rockettrail_underwater", PATTACH_POINT_FOLLOW, "trail" );
+				bUsingCustom = true;
+			}
+			else if ( GetTeamNumber() == TEAM_UNASSIGNED )
+			{
+				ParticleProp()->Create( "rockettrail_underwater", PATTACH_POINT_FOLLOW, "trail" );
+				bUsingCustom = true;
 			}
 			else
 			{
-				CALL_ATTRIB_HOOK_INT_ON_OTHER( GetOwnerEntity(), iHalloweenSpell, halloween_pumpkin_explosions );
-			}
-		}
-
-		// Mini rockets from airstrike RL
-		if ( iHalloweenSpell > 0 )
-		{
-			ParticleProp()->Create( "halloween_rockettrail", PATTACH_POINT_FOLLOW, iAttachment );
-			bUsingCustom = true;
-		}
-		else if ( !pSentry )
-		{
-			if ( GetLauncher() )
-			{
-				int iMiniRocket = 0;
-				CALL_ATTRIB_HOOK_INT_ON_OTHER( GetLauncher(), iMiniRocket, mini_rockets );
-				if ( iMiniRocket )
+				// Halloween Spell Effect Check
+				int iHalloweenSpell = 0;
+				// if the owner is a Sentry, Check its owner
+				CBaseObject *pSentry = GetOwnerEntity() && GetOwnerEntity()->IsBaseObject() ? assert_cast<CBaseObject*>( GetOwnerEntity() ) : NULL;
+				if ( TF_IsHolidayActive( kHoliday_HalloweenOrFullMoon ) )
 				{
-					ParticleProp()->Create( "rockettrail_airstrike", PATTACH_POINT_FOLLOW, iAttachment );
-					bUsingCustom = true;
-
-					// rockettrail_airstrike_line
-					CTFPlayer *pPlayer = ToTFPlayer( GetOwnerEntity() );
-					if ( pPlayer && pPlayer->m_Shared.InCond( TF_COND_BLASTJUMPING ) )
+					if ( pSentry )
 					{
-						ParticleProp()->Create( "rockettrail_airstrike_line", PATTACH_POINT_FOLLOW, iAttachment );
+						CALL_ATTRIB_HOOK_INT_ON_OTHER( pSentry->GetOwner(), iHalloweenSpell, halloween_pumpkin_explosions );
+					}
+					else
+					{
+						CALL_ATTRIB_HOOK_INT_ON_OTHER( GetOwnerEntity(), iHalloweenSpell, halloween_pumpkin_explosions );
+					}
+				}
+
+				// Mini rockets from airstrike RL
+				if ( iHalloweenSpell > 0 )
+				{
+					ParticleProp()->Create( "halloween_rockettrail", PATTACH_POINT_FOLLOW, iAttachment );
+					bUsingCustom = true;
+				}
+				else if ( !pSentry )
+				{
+					if ( GetLauncher() )
+					{
+						int iMiniRocket = 0;
+						CALL_ATTRIB_HOOK_INT_ON_OTHER( GetLauncher(), iMiniRocket, mini_rockets );
+						if ( iMiniRocket )
+						{
+							ParticleProp()->Create( "rockettrail_airstrike", PATTACH_POINT_FOLLOW, iAttachment );
+							bUsingCustom = true;
+
+							// rockettrail_airstrike_line
+							CTFPlayer *pPlayer = ToTFPlayer( GetOwnerEntity() );
+							if ( pPlayer && pPlayer->m_Shared.InCond( TF_COND_BLASTJUMPING ) )
+							{
+								ParticleProp()->Create( "rockettrail_airstrike_line", PATTACH_POINT_FOLLOW, iAttachment );
+							}
+						}
 					}
 				}
 			}
-		}
-	}
 
-	if ( !bUsingCustom )
-	{
-		if ( GetTrailParticleName() )
-		{
-			ParticleProp()->Create( GetTrailParticleName(), PATTACH_POINT_FOLLOW, iAttachment );
+			if ( !bUsingCustom )
+			{
+				if ( GetTrailParticleName() )
+				{
+					ParticleProp()->Create( GetTrailParticleName(), PATTACH_POINT_FOLLOW, iAttachment );
+				}
+			}
+
+			m_bCreatedTrails = true;
 		}
 	}
 

--- a/src/game/client/tf/c_tf_projectile_rocket.h
+++ b/src/game/client/tf/c_tf_projectile_rocket.h
@@ -34,6 +34,7 @@ public:
 
 private:
 	bool	m_bCritical;
+	bool	m_bCreatedTrails;
 
 	CNewParticleEffect	*pEffect;
 };


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description

In Team Fortress 2, whenever a rocket is created or reflected, clients call `C_TFProjectile_Rocket::CreateTrails`, which removes any team-specific trails from a rocket and attaches a new set of trails to the rocket. `CreateTrails` does not check for or remove any non-team-specific rocket trails before creating new trails, however; because of this, each time a rocket is reflected, it receives a duplicated set of non-team-specific rocket trails.

This PR fixes this issue by having `C_TFProjectile_Rocket::CreateTrails` only create a new set of non-team-specific trails the first time it is run for any given rocket, preventing these duplicate trails from being created.

See the following videos below for how this issue and this PR's fix appear in gameplay. The difference is more visible closer to the rocket itself.

<details>
<summary><b>Before this PR (/w duplicated trails)</b></summary>

[!](https://github.com/user-attachments/assets/80a033f2-c8ce-4e58-986d-2a25efcb41ae)

</details>

<details>
<summary><b>With this PR (w/o duplicated trails)</b></summary>

[!](https://github.com/user-attachments/assets/4bcd08bb-5124-41a7-b893-6283be4ebb02)

</details>

This PR resolves https://github.com/ValveSoftware/Source-1-Games/issues/4171 and https://github.com/ValveSoftware/Source-1-Games/issues/7668.