### PR TITLE
[TF2] Don't resample generated item model panel textures

### DIFF
--- a/src/game/client/econ/item_model_panel.cpp
+++ b/src/game/client/econ/item_model_panel.cpp
@@ -1015,7 +1015,7 @@ void CEmbeddedItemModelPanel::Paint( void )
 			ITexture *pRenderTarget = g_pMaterialSystem->FindTexture( pszCacheRenderTargetName, TEXTURE_GROUP_RENDER_TARGET );
 			if ( pRenderTarget )
 			{
-				pRenderContext->AsyncCreateTextureFromRenderTarget( pRenderTarget, buffer, IMAGE_FORMAT_RGBA8888, false, 0, m_pCachedWeaponIcon, NULL );
+				pRenderContext->AsyncCreateTextureFromRenderTarget( pRenderTarget, buffer, IMAGE_FORMAT_RGBA8888, false, TEXTUREFLAGS_POINTSAMPLE, m_pCachedWeaponIcon, NULL );
 			
 				pCacheRenderTarget->iItemID = m_pItem->GetItemID();
 				pCacheRenderTarget->iItemDefinitionIndex = m_pItem->GetItemDefIndex();


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description

TF2's item model panel will automatically generate icon textures for items without pre-rendered icons (ex. any weapon with a war paint or festivizer). These textures are sized to the exact dimensions of the item model panel that uses them, so they shouldn't need any filtering to look correct wherever they are used. Despite this, these textures are still resampled when they are rendered, causing them to look slightly blurred:

<img width="139" height="106" alt="Before (with filtering)" src="https://github.com/user-attachments/assets/f210d3e0-7e8b-49ce-b8a1-47722a0ab982" />

This PR configures item model panels' auto-generated textures to always use point sampling, allowing them to be rendered pixel-perfectly without any filtering artifacts:

<img width="139" height="106" alt="With this PR (no filtering)" src="https://github.com/user-attachments/assets/82680ce0-50da-4c2b-91ee-8a106759c9fa" />

(Note: I would appreciate if anyone could test this PR on a 4K monitor to ensure this doesn't create any visual regressions on high-res displays.)