### PR TITLE
[TF2] Fix Lollichop being invisible to players not in pyroland

### DIFF
--- a/src/game/shared/tf/tf_gamerules.cpp
+++ b/src/game/shared/tf/tf_gamerules.cpp
@@ -17410,7 +17410,7 @@ void CTFGameRules::SetUpVisionFilterKeyValues( void )
 	// No special vision
 	pKVFlag = new KeyValues( "0" );
 	pKVFlag->SetString( "models/weapons/c_models/c_rainblower/c_rainblower.mdl", "models/weapons/c_models/c_flamethrower/c_flamethrower.mdl" );
-	pKVFlag->SetString( "models/weapons/c_models/c_lollichop/c_lollichop.mdl", "models/weapons/w_models/w_fireaxe.mdl" );
+	pKVFlag->SetString( "models/weapons/c_models/c_lollichop/c_lollichop.mdl", "models/weapons/c_models/c_fireaxe_pyro/c_fireaxe_pyro.mdl" );
 	pKVBlock->AddSubKey( pKVFlag );
 
 	// Pyrovision


### PR DESCRIPTION
The Rainblower and Lollichop are meant to appear to other players who aren't in Pyroland as the stock Flamethrower and Fireaxe, respectively.

The Rainblower works correctly in this regard, and the Lollichop used to, but currently does not, instead appearing completely invisible to players not in Pyroland, making the Pyro wielding the Lollichop appear completely empty-handed.

This commit fixes this issue, which seems to be the result of the hardcoded vision filter translations table still referencing the old out-of-date w_model for the fireaxe.
<img width="1920" height="1080" alt="before" src="https://github.com/user-attachments/assets/0d9faffc-0b97-437b-bd15-ae354acefaf9" />
<img width="1913" height="1080" alt="after" src="https://github.com/user-attachments/assets/8b5a4e1f-d508-4075-a342-e7f0a8e019e3" />

Fixes https://github.com/ValveSoftware/Source-1-Games/issues/8190