### PR TITLE
[TF2] Festivizer Support for weapons that change their models

### DIFF
--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -17986,6 +17986,11 @@ void CTFPlayer::Taunt( taunts_t iTauntIndex, int iTauntConcept )
 		}
 		else if ( !V_stricmp( szResponse, "scenes/player/pyro/low/taunt_bubbles.vcd" ) )
 		{
+			CTFWeaponBase* pWeapon = GetActiveTFWeapon();
+			if (pWeapon)
+			{
+				pWeapon->SetIsBeingRepurposedForTaunt(true);
+			}
 			m_flTauntAttackTime = gpGlobals->curtime + 3.0f;
 			m_iTauntAttack = TAUNTATK_PYRO_ARMAGEDDON;
 
@@ -18102,6 +18107,11 @@ void CTFPlayer::Taunt( taunts_t iTauntIndex, int iTauntConcept )
 	{
 		if ( !V_stricmp( szResponse, "scenes/player/engineer/low/taunt07.vcd" ) )
 		{
+			CTFWeaponBase* pWeapon = GetActiveTFWeapon();
+			if (pWeapon)
+			{
+				pWeapon->SetIsBeingRepurposedForTaunt(true);
+			}
 			m_flTauntAttackTime = gpGlobals->curtime + 3.695f;
 			m_iTauntAttack = TAUNTATK_ENGINEER_GUITAR_SMASH;
 		}

--- a/src/game/shared/econ/econ_entity.cpp
+++ b/src/game/shared/econ/econ_entity.cpp
@@ -1115,9 +1115,11 @@ void CEconEntity::UpdateAttachmentModels( void )
 				{
 					for ( int i = 0; i < iAttachedModels; i++ )
 					{
-						attachedmodel_t	*pModel = pItemDef->GetAttachedModelDataFestivized( iTeamNumber, i );
+						attachedmodel_t *pModel = pItemDef->GetAttachedModelDataFestivized( iTeamNumber, i );
+						//check for vision filter of attachment, but NOT if showing the viewmodel since viewmodel won't filter the base weapon model
+						CBasePlayer* pOwner = ToBasePlayer( GetOwnerEntity() );
+						int iModelIndex = modelinfo->GetModelIndex( ( ( !pOwner || pOwner->ShouldDrawThisPlayer() ) && GameRules() ) ? GameRules()->TranslateEffectForVisionFilter( "weapons", pModel->m_pszModelName ) : pModel->m_pszModelName );
 
-						int iModelIndex = modelinfo->GetModelIndex( pModel->m_pszModelName );
 						if ( iModelIndex >= 0 )
 						{
 							AttachedModelData_t attachedModelData;

--- a/src/game/shared/tf/tf_gamerules.cpp
+++ b/src/game/shared/tf/tf_gamerules.cpp
@@ -17410,13 +17410,17 @@ void CTFGameRules::SetUpVisionFilterKeyValues( void )
 	// No special vision
 	pKVFlag = new KeyValues( "0" );
 	pKVFlag->SetString( "models/weapons/c_models/c_rainblower/c_rainblower.mdl", "models/weapons/c_models/c_flamethrower/c_flamethrower.mdl" );
-	pKVFlag->SetString( "models/weapons/c_models/c_lollichop/c_lollichop.mdl", "models/weapons/w_models/w_fireaxe.mdl" );
+	pKVFlag->SetString( "models/weapons/c_models/c_lollichop/c_lollichop.mdl", "models/weapons/c_models/c_fireaxe_pyro/c_fireaxe_pyro.mdl" );
+	pKVFlag->SetString( "models/weapons/c_models/c_rainblower/c_rainblower_festivizer.mdl", "models/weapons/c_models/c_flamethrower/c_flamethrower_festivizer.mdl" );
+	pKVFlag->SetString( "models/weapons/c_models/c_lollichop/c_lollichop_festivizer.mdl", "models/weapons/c_models/c_fireaxe_pyro/c_fireaxe_pyro_festivizer.mdl" );
 	pKVBlock->AddSubKey( pKVFlag );
 
 	// Pyrovision
 	pKVFlag = new KeyValues( "1" );
 	pKVFlag->SetString( "models/weapons/c_models/c_rainblower/c_rainblower.mdl", "models/weapons/c_models/c_rainblower/c_rainblower.mdl" );		//explicit set for pyrovision
 	pKVFlag->SetString( "models/weapons/c_models/c_lollichop/c_lollichop.mdl", "models/weapons/c_models/c_lollichop/c_lollichop.mdl" );
+	pKVFlag->SetString( "models/weapons/c_models/c_rainblower/c_rainblower_festivizer.mdl", "models/weapons/c_models/c_rainblower/c_rainblower_festivizer.mdl" );
+	pKVFlag->SetString( "models/weapons/c_models/c_lollichop/c_lollichop_festivizer.mdl", "models/weapons/c_models/c_lollichop/c_lollichop_festivizer.mdl" );
 
 	pKVFlag->SetString( "models/player/items/demo/demo_bombs.mdl", "models/player/items/all_class/mtp_bottle_demo.mdl" );
 	pKVFlag->SetString( "models/player/items/pyro/xms_pyro_bells.mdl", "models/player/items/all_class/mtp_bottle_pyro.mdl" );

--- a/src/game/shared/tf/tf_weaponbase.cpp
+++ b/src/game/shared/tf/tf_weaponbase.cpp
@@ -3374,7 +3374,7 @@ void CTFWeaponBase::UpdateAttachmentModels( void )
 						{
 							attachedmodel_t	*pModel = pItemDef->GetAttachedModelDataFestivized( iTeamNumber, i );
 
-							int iModelIndex = modelinfo->GetModelIndex( pModel->m_pszModelName );
+							int iModelIndex = modelinfo->GetModelIndex(GameRules() ? GameRules()->TranslateEffectForVisionFilter("weapons", pModel->m_pszModelName) : pModel->m_pszModelName);
 							if ( iModelIndex >= 0 )
 							{
 								AttachedModelData_t attachedModelData;


### PR DESCRIPTION
The [Festivizers workshop submission ](https://steamcommunity.com/sharedfiles/filedetails/?id=3364116726) that added Festivizer support to numerous weapons last Smissmas included models for several additional weapons that would have required extra implementation to work correctly.

This PR includes in-code support for three weapons that circumstantially change their base weapon models, to add support for implementing festivizers without causing issues under these circumstances.

The Frontier Justice and Rainblower both swap their visible models out for taunt props during their default weapon taunts (a guitar and a bubble wand, respectively).  Currently, the code does not account for what should happen for attachments on the current weapon if it is repurposed for these taunts, as it does for the equippable store-bought taunts.  This causes the attachment models to appear floating near the props.  This PR fixes this issue, so that weapon attachments (such as festivizers) on these weapons get properly hidden during these taunts.
<img width="1913" height="1080" alt="beforetauntfj" src="https://github.com/user-attachments/assets/1a594147-6f8d-421b-bffe-cc4ef65b0a9a" />
<img width="1913" height="1080" alt="aftertauntfj" src="https://github.com/user-attachments/assets/b58c897e-6cca-419a-bb50-9a758ee17e71" />
<img width="1913" height="1080" alt="beforetauntrb" src="https://github.com/user-attachments/assets/2a3fef0c-c3e9-43d4-8fbf-32c432894b6e" />
<img width="1913" height="1080" alt="aftertauntrb" src="https://github.com/user-attachments/assets/f9232e33-0f33-4e46-8263-fb822cd317e5" />

Additionally, the Rainblower and the Lollichop both appear as though they were their stock counterparts (the Flamethrower and the Fireaxe) under certain conditions (when viewed in-game, in the hands of another player in 3rd person, and the player is not in Pyroland).  This currently does not account for weapon attachments, causing festivizer attachments for these two weapons to appear broken on these two weapons under these conditions -- on the Lollichop it draws the ill-fitting and mismatched Lollichop festivizer over the stock Fireaxe, and on the Rainblower it draws nothing over the Flamethrower and spits errors into the console due to a bones mismatch.  This PR fixes this issue, using the stock weapons' festivizer models when appropriate.

<img width="1913" height="1080" alt="beforefilterlc" src="https://github.com/user-attachments/assets/03ea509e-8ec4-4cb0-8fa2-50e764145cd0" />
<img width="1913" height="1080" alt="afterfilterlc" src="https://github.com/user-attachments/assets/aca9b3cd-f369-4793-bcac-6c37237bd0d2" />
<img width="1913" height="1080" alt="beforefilterrb" src="https://github.com/user-attachments/assets/fda4b3b2-2581-4066-bceb-d352e432ba38" />
<img width="1913" height="1080" alt="afterfilterrb" src="https://github.com/user-attachments/assets/b561d798-9723-40fa-b35a-f21f75b69f34" />

This also incorporates the [fix for the invisible lollichop fireaxe](https://github.com/ValveSoftware/source-sdk-2013/pull/2002) since it was necessary for testing the changes and part of the same code being edited.

The model filepaths referenced in these code changes refer to models already included in the original workshop submission (and included for convenience in the tf_festives shared dropbox).

Other notes on these weapons (to the weapon base model, item schema, etc) unrelated to the source code are being added to the "2026 Implementation Notes" spreadsheet in the dropbox; the notes for these weapons in particular are still a work-in-progress but I will update that sheet as I go.