### PR TITLE
[TF2] Fix Half-Zatoichi being invisible when held by disguised Spy

### DIFF
--- a/src/game/shared/tf/tf_weapon_sword.cpp
+++ b/src/game/shared/tf/tf_weapon_sword.cpp
@@ -582,6 +582,14 @@ int CTFKatana::GetActivityWeaponRole() const
 		// demo should use act table item1
 		return TF_WPN_TYPE_ITEM1;
 	}
+	else if ( pPlayer && pPlayer->GetPlayerClass()->GetClassIndex() == TF_CLASS_SPY )
+	{
+		CTFPlayer* pDisguiseTarget = pPlayer->m_Shared.GetDisguiseTarget();
+		if ( pDisguiseTarget && pDisguiseTarget->GetPlayerClass()->GetClassIndex() == TF_CLASS_DEMOMAN ) {
+			// demo should use act table item1
+			return TF_WPN_TYPE_ITEM1;
+		}
+	}
 
 	return BaseClass::GetActivityWeaponRole();
 }

--- a/src/game/shared/tf/tf_weapon_sword.cpp
+++ b/src/game/shared/tf/tf_weapon_sword.cpp
@@ -577,18 +577,10 @@ float CTFKatana::GetMeleeDamage( CBaseEntity *pTarget, int* piDamageType, int* p
 int CTFKatana::GetActivityWeaponRole() const
 {
 	CTFPlayer *pPlayer = GetTFPlayerOwner();
-	if ( pPlayer && pPlayer->GetPlayerClass()->GetClassIndex() == TF_CLASS_DEMOMAN )
+	if ( pPlayer && ( pPlayer->GetPlayerClass()->GetClassIndex() == TF_CLASS_DEMOMAN || ( pPlayer->GetPlayerClass()->GetClassIndex() == TF_CLASS_SPY && pPlayer->m_Shared.GetDisguiseClass() == TF_CLASS_DEMOMAN ) ) )
 	{
 		// demo should use act table item1
 		return TF_WPN_TYPE_ITEM1;
-	}
-	else if ( pPlayer && pPlayer->GetPlayerClass()->GetClassIndex() == TF_CLASS_SPY )
-	{
-		CTFPlayer* pDisguiseTarget = pPlayer->m_Shared.GetDisguiseTarget();
-		if ( pDisguiseTarget && pDisguiseTarget->GetPlayerClass()->GetClassIndex() == TF_CLASS_DEMOMAN ) {
-			// demo should use act table item1
-			return TF_WPN_TYPE_ITEM1;
-		}
 	}
 
 	return BaseClass::GetActivityWeaponRole();

--- a/src/game/shared/tf/tf_weaponbase.cpp
+++ b/src/game/shared/tf/tf_weaponbase.cpp
@@ -693,6 +693,16 @@ const char *CTFWeaponBase::GetWorldModel( void ) const
 		{
 			iClass = pPlayer->GetPlayerClass()->GetClassIndex();
 			iTeam = pPlayer->GetTeamNumber();
+			
+			//if this is a disguise weapon we need the disguise target's team and class
+			if ( m_bDisguiseWeapon )
+			{
+				CTFPlayer *pDisguiseTarget = pPlayer->m_Shared.GetDisguiseTarget();
+				if ( pDisguiseTarget ) {
+					iTeam = pDisguiseTarget->GetTeamNumber();
+					iClass = pDisguiseTarget->GetPlayerClass()->GetClassIndex();
+				}
+			}
 		}
 
 		return pItem->GetPlayerDisplayModel( iClass, iTeam );

--- a/src/game/shared/tf/tf_weaponbase.cpp
+++ b/src/game/shared/tf/tf_weaponbase.cpp
@@ -697,11 +697,8 @@ const char *CTFWeaponBase::GetWorldModel( void ) const
 			//if this is a disguise weapon we need the disguise target's team and class
 			if ( m_bDisguiseWeapon )
 			{
-				CTFPlayer *pDisguiseTarget = pPlayer->m_Shared.GetDisguiseTarget();
-				if ( pDisguiseTarget ) {
-					iTeam = pDisguiseTarget->GetTeamNumber();
-					iClass = pDisguiseTarget->GetPlayerClass()->GetClassIndex();
-				}
+				iClass = ( pPlayer->m_Shared.GetDisguiseClass() ? pPlayer->m_Shared.GetDisguiseClass() : iClass );
+				iTeam = ( pPlayer->m_Shared.GetDisguiseTeam() ? pPlayer->m_Shared.GetDisguiseTeam() : iTeam );
 			}
 		}
 


### PR DESCRIPTION
Currently, if a Spy is disguised as a Soldier or Demoman with the Half-Zatoichi equipped, and has their disguise weapon set to the melee slot, the Half-Zatoichi model will not appear to enemy players, leaving the disguised Spy holding nothing (a major giveaway that they are a Spy).

This is because the Half-Zatoichi is (as far as I'm aware) the only weapon to make use of model_player_per_class in its item definition, and the code to fetch the world model for the weapon just calls for it based on the owner's class (which in this case is Spy, not Soldier or Demoman).

This PR fixes this issue, so that a disguised Spy holding the Half-Zatoichi as the disguise weapon will load the correct katana model for the disguise's class.  It also forces the Demoman disguise to use the correct animation for the Half-Zatoichi.

<img width="1920" height="1080" alt="sollybefore" src="https://github.com/user-attachments/assets/142d8572-c0b8-4355-a6ae-9af32e629251" />
<img width="1913" height="1080" alt="sollyafter" src="https://github.com/user-attachments/assets/1f67381f-cd95-48d9-b739-9b1af975fc25" />
<img width="1920" height="1080" alt="demobefore" src="https://github.com/user-attachments/assets/f9b439ea-095e-41d9-8e3f-e9c69662af2d" />
<img width="1913" height="1080" alt="demoafter" src="https://github.com/user-attachments/assets/2491448a-6966-43ef-8c89-a874ac975170" />

