### PR TITLE
[TF2] Fix Demoman using the wrong animations for the Half-Zatoichi in the Loadout screen and other UI contexts

### DIFF
--- a/src/game/client/tf/vgui/tf_playermodelpanel.cpp
+++ b/src/game/client/tf/vgui/tf_playermodelpanel.cpp
@@ -999,7 +999,14 @@ void CTFPlayerModelPanel::EquipItem( CEconItemView *pItem )
 
 		if ( iAnimSlot == -1 )
 		{
-			iAnimSlot = pItemDef->GetLoadoutSlot( m_iCurrentClassIndex );
+			if ( strcmp( pItemDef->GetItemClass(), "tf_weapon_katana" ) == 0 && m_iCurrentClassIndex == TF_CLASS_DEMOMAN )
+			{
+				iAnimSlot = TF_WPN_TYPE_ITEM1;
+			}
+			else
+			{
+				iAnimSlot = pItemDef->GetLoadoutSlot(m_iCurrentClassIndex);
+			}
 		}
 
 		const CUtlVector<const char *>& vecWeaponTypeSubstrings = GetItemSchema()->GetWeaponTypeSubstrings();


### PR DESCRIPTION
In-game, the Demoman uses the "ITEM1" animations (the two-handed animations made for the Eyelander) when holding the Half-Zatoichi.  This is distinct from the Soldier, who uses his regular melee animations for it.

However, the Loadout screen and other UI contexts that display the player model (the lower-left HUD, the Scoreboard, the class-select screen) do not use these alternate animations because the code that drives them does not call the code for the katana itself that overrides the animation for Demoman.

This PR adds a check for the katana to the playermodelpanel that drives these UI components, to make the Half-Zatoichi use the correct animations for Demoman.  This does not affect the animations used for the Soldier, nor any other Demoman weapon.

<img width="1913" height="1080" alt="loadoutbefore" src="https://github.com/user-attachments/assets/c4d41fe8-c522-4324-8978-10b23869a756" />
<img width="1913" height="1080" alt="loadoutafter" src="https://github.com/user-attachments/assets/992e7736-4cb1-49a2-9bd1-4e4063e22928" />
<img width="1913" height="1080" alt="hudbefore" src="https://github.com/user-attachments/assets/71bf563b-9a52-4b3b-b38e-eb405241ace7" />
<img width="1913" height="1080" alt="hudafter" src="https://github.com/user-attachments/assets/ef01a094-9595-4244-9978-45092dbc7f07" />
<img width="1913" height="1080" alt="scoreboardbefore" src="https://github.com/user-attachments/assets/3dac8410-56ef-4187-888f-c73e75387c8c" />
<img width="1913" height="1080" alt="scoreboardafter" src="https://github.com/user-attachments/assets/9003cd33-1876-428e-b709-ffd5bf3adb95" />
<img width="1913" height="1080" alt="classbefore" src="https://github.com/user-attachments/assets/73868a1c-5a2e-4288-b13e-91d0597f7831" />
<img width="1913" height="1080" alt="classafter" src="https://github.com/user-attachments/assets/772a0e20-ed87-4264-ab20-25893549347d" />

Fixes https://github.com/ValveSoftware/Source-1-Games/issues/1971