### PR TITLE
[TF2] MvM: Fix 3D Player HUD displaying Romevision cosmetics when disguised and Romevision is OFF

### DIFF
--- a/src/game/client/tf/tf_hud_playerstatus.cpp
+++ b/src/game/client/tf/tf_hud_playerstatus.cpp
@@ -106,6 +106,7 @@ CTFHudPlayerClass::CTFHudPlayerClass( Panel *parent, const char *name ) : Editab
 	m_hDisguiseWeapon = NULL;
 	m_flNextThink = 0.0f;
 	m_nKillStreak = 0;
+	m_nVisionFilterFlags = 0;
 
 	m_bUsePlayerModel = cl_hud_playerclass_use_playermodel.GetBool();
 
@@ -158,6 +159,7 @@ void CTFHudPlayerClass::ApplySchemeSettings( IScheme *pScheme )
 	m_flNextThink = 0.0f;
 	m_nCloakLevel = 0;
 	m_nLoadoutPosition = LOADOUT_POSITION_PRIMARY;
+	m_nVisionFilterFlags = GetLocalPlayerVisionFilterFlags( true );
 
 	m_pClassImage = FindControl<CTFClassImage>( "PlayerStatusClassImage", false );
 	m_pClassImageBG = FindControl<CTFImagePanel>( "PlayerStatusClassImageBG", false );
@@ -254,10 +256,17 @@ void CTFHudPlayerClass::OnThink()
 		bPlayerClassModeChange = true;
 	}
 
+	bool bVisionFilterChange = false;
+	int nVisionFilterFlags = GetLocalPlayerVisionFilterFlags( true );
+	if ( m_nVisionFilterFlags != nVisionFilterFlags )
+	{
+		m_nVisionFilterFlags = nVisionFilterFlags;
+		bVisionFilterChange = true;
+	}
 
 	bool bForceEyeUpdate = false;
 	// set our class image
-	if (	m_nClass != pPlayer->GetPlayerClass()->GetClassIndex() || bTeamChange || bCloakChange || bLoadoutPositionChange || bPlayerClassModeChange ||
+	if (	m_nClass != pPlayer->GetPlayerClass()->GetClassIndex() || bTeamChange || bCloakChange || bLoadoutPositionChange || bPlayerClassModeChange || bVisionFilterChange ||
 			(
 				m_nClass == TF_CLASS_SPY &&
 				(
@@ -523,6 +532,9 @@ void CTFHudPlayerClass::UpdateModelPanel()
 		{
 			C_TFWearable *pItem = dynamic_cast<C_TFWearable*>( pPlayer->GetWearable( wbl ) );
 			if ( !pItem )
+				continue;
+
+			if ( pItem->ShouldHideForVisionFilterFlags() )
 				continue;
 
 			if ( pItem->IsViewModelWearable() )

--- a/src/game/client/tf/tf_hud_playerstatus.h
+++ b/src/game/client/tf/tf_hud_playerstatus.h
@@ -83,6 +83,7 @@ private:
 	int					m_nCloakLevel;
 	int					m_nLoadoutPosition;
 	int					m_nKillStreak;
+	int					m_nVisionFilterFlags;
 
 	
 	bool				m_bUsePlayerModel;


### PR DESCRIPTION
This PR is intended to complement the recently merged #1977. Current bug has been present since the introduction of Romevision in 2012.

This PR fixes the 3D Player HUD displaying Romevision cosmetics on Spy Disguises while Romevision is disabled.

PR has been regression tested with Romevision set to ON.

**BEFORE**
<img width="500" height="256" alt="Discord_kySwfLkB0O" src="https://github.com/user-attachments/assets/2deec3f0-a3cb-490e-9889-38c447b7b85a" />

**AFTER**
<img width="490" height="249" alt="Discord_qZOMr34zvQ" src="https://github.com/user-attachments/assets/a1e5974b-c7f7-465c-9bf7-1d3091ced9e5" />
