### PR TITLE
[TF2] Restore Huntsman Taunt Loop Bug

### DIFF
--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -18081,6 +18081,7 @@ void CTFPlayer::Taunt( taunts_t iTauntIndex, int iTauntConcept )
 		if ( !V_stricmp( szResponse, "scenes/player/sniper/low/taunt04.vcd" ) )
 		{
 			m_flTauntAttackTime = gpGlobals->curtime + 0.85f;
+			m_flTauntNextStartTime = gpGlobals->curtime;
 			m_iTauntAttack = TAUNTATK_SNIPER_ARROW_STAB_IMPALE;
 		}
 	}

--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -297,6 +297,8 @@ extern ConVar mp_developer;
 extern ConVar bot_mimic;
 #endif // _DEBUG || STAGING_ONLY 
 
+ConVar tf_compound_bow_taunt_loop_bug("tf_compound_bow_taunt_loop_bug", "1", FCVAR_NOTIFY, "Restore the compound bow's old taunt attack loop bug behavior when enabled");
+
 extern CBaseEntity *FindPickerEntity( CBasePlayer *pPlayer );
 extern bool CanScatterGunKnockBack( CTFWeaponBase *pWeapon, float flDamage, float flDistanceSq );
 extern bool IsCustomGameMode();
@@ -18081,7 +18083,6 @@ void CTFPlayer::Taunt( taunts_t iTauntIndex, int iTauntConcept )
 		if ( !V_stricmp( szResponse, "scenes/player/sniper/low/taunt04.vcd" ) )
 		{
 			m_flTauntAttackTime = gpGlobals->curtime + 0.85f;
-			m_flTauntNextStartTime = gpGlobals->curtime;
 			m_iTauntAttack = TAUNTATK_SNIPER_ARROW_STAB_IMPALE;
 		}
 	}
@@ -18506,6 +18507,14 @@ void CTFPlayer::DoTauntAttack( void )
 				switch ( iTauntAttack )
 				{
 				case TAUNTATK_SNIPER_ARROW_STAB_IMPALE:
+					if ( tf_compound_bow_taunt_loop_bug.GetBool() && pVictim )
+					{
+						// restore the Huntsman/Fortified Compound taunt attack loop bug staring contest duels
+						pVictim->m_flTauntNextStartTime = gpGlobals->curtime;
+					}
+					
+					// intentional fallthrough
+
 				case TAUNTATK_ENGINEER_ARM_IMPALE:
 					if ( pVictim )
 					{


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
This PR restores the ["Staring Contest"](https://wiki.teamfortress.com/wiki/Arrow_Stab#cite_note-1) infinite stun loop bug with the Huntsman or the Fortified Compound as mentioned by the TF2 Wiki: 
> Because of this, two Snipers wielding the Huntsman or Fortified Compound can create an infinite stun loop without killing each other, commonly known as a "Staring Contest".[[1]](https://wiki.teamfortress.com/wiki/Arrow_Stab#cite_note-1)

The TF2 Wiki page for the Arrow Stab taunt kill does not mention that this bug has been fixed, and was a beloved part of the community back in the day as shown by the number of videos about it such as this: https://www.youtube.com/watch?v=b7XDbzxpGJM

To perform the Staring Contest bug, two players each from opposing teams equipped with the Huntsman/Fortified Compound must be present. Next, both players taunt at around the same time with the bow. After both players are stunned, the taunt key is immediately and repeatedly pressed quickly over and over until one player eventually tires out from repeatedly pressing the taunt button and loses the Staring Contest.

If you try to do the Staring Contest bug in live TF2, both Snipers do get stunned by each other but the loop does not happen. You can test this with a puppet bot with zero ping and no matter how much you try to mash the taunt key, you are not able to do the Staring Contest bug.

I believe this bug was inadvertently fixed sometime around 2013 (or 2017?) based on patch notes, video comments, and historical videos related to the taunt. I still have yet to confirm when exactly was the bug fixed. What I am sure of is an unrelated change fixed it.

This PR tries to recreate the Staring Contest taunt loop bug by setting m_flTauntNextStartTime to the current time, so that the player is able to do the taunt and stun another player again even if stunned by another player doing the same thing.

Video demonstration of the taunt bug restoration: https://youtu.be/9UMqfykEsP4
Before:

https://github.com/user-attachments/assets/418354c6-e82f-4611-9f76-c028aeb4771e


After:

https://github.com/user-attachments/assets/7476b89d-48d1-4a52-aa45-bcfa4c4bac3c


Credits to VerdiusArcana for the bug restoration via the SourceMod weapon reverts plugin


