### PR TITLE
[TF2] Restore sticky detonation while taunting

### DIFF
--- a/src/game/client/tf/c_tf_player.cpp
+++ b/src/game/client/tf/c_tf_player.cpp
@@ -6661,6 +6661,16 @@ bool C_TFPlayer::CreateMove( float flInputSampleTime, CUserCmd *pCmd )
 			VectorCopy( angMoveAngle, pCmd->viewangles );
 		}
 
+		// Re-add IN_ATTACK2 if player is Demoman with sticky launcher. This is done so they can detonate stickies while taunting.
+		if ( (nCurrentButtons & IN_ATTACK2) && IsPlayerClass( TF_CLASS_DEMOMAN ) )
+		{
+			C_TFWeaponBase *pPipebombLauncher = Weapon_OwnsThisID( TF_WEAPON_PIPEBOMBLAUNCHER );
+			if ( pPipebombLauncher )
+			{
+				pCmd->buttons |= IN_ATTACK2;
+			}
+		}
+
 		// allow remap taunt keys to go through
 		CTFTauntInfo *pTaunt = m_TauntEconItemView.GetStaticData()->GetTauntData();
 		if ( pTaunt )

--- a/src/game/shared/tf/tf_player_shared.cpp
+++ b/src/game/shared/tf/tf_player_shared.cpp
@@ -12216,6 +12216,12 @@ bool CTFPlayer::CanAttack( int iCanAttackFlags )
 
 	Assert( pRules );
 
+	CTFPipebombLauncher *pPipebombLauncher = static_cast<CTFPipebombLauncher*>( Weapon_OwnsThisID( TF_WEAPON_PIPEBOMBLAUNCHER ) );
+	if ( pPipebombLauncher )
+	{
+		iCanAttackFlags |= TF_CAN_ATTACK_FLAG_PIPEBOMBLAUNCHER;
+	}
+
 	if ( IsViewingCYOAPDA() )
 		return false;
 
@@ -12246,7 +12252,36 @@ bool CTFPlayer::CanAttack( int iCanAttackFlags )
 	}
 
 	if ( IsTaunting() )
-		return false;
+	{
+		if ( !( iCanAttackFlags & TF_CAN_ATTACK_FLAG_PIPEBOMBLAUNCHER ) )
+			return false;
+
+		if ( m_nButtons & IN_ATTACK )
+			return false;
+
+		if ( m_nButtons & IN_ATTACK2 )
+		{
+			if ( !IsPlayerClass( TF_CLASS_DEMOMAN ) )
+				return false;
+
+			if ( !pPipebombLauncher )
+				return false;
+
+			CTFTauntInfo *pTaunt = m_TauntEconItemView.GetStaticData()->GetTauntData();
+			if ( pTaunt )
+			{
+				for ( int i=0; i<pTaunt->GetTauntInputRemapCount(); ++i )
+				{
+					const CTFTauntInfo::TauntInputRemap_t& tauntRemap = pTaunt->GetTauntInputRemapScene( i );
+					{
+						// disable sticky detonation if the secondary fire key is bound to do something else.
+						if ( m_nButtons & tauntRemap.m_iButton )
+							return false;
+					}
+				}
+			}
+		}
+	}
 
 	if ( m_Shared.InCond( TF_COND_PHASE ) == true )
 		return false;

--- a/src/game/shared/tf/tf_shareddefs.h
+++ b/src/game/shared/tf/tf_shareddefs.h
@@ -2625,6 +2625,7 @@ extern helltower_vo_t g_pszHelltowerAnnouncerLines[];
 // flags to ignore certain check in CanAttack function
 #define TF_CAN_ATTACK_FLAG_NONE				0
 #define TF_CAN_ATTACK_FLAG_GRAPPLINGHOOK	0x01
+#define TF_CAN_ATTACK_FLAG_PIPEBOMBLAUNCHER	0x02
 
 struct PlayerHistoryInfo_t
 {


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
Sticky detonation while taunting was originally an intentional feature added in <a href=https://store.steampowered.com/oldnews/2529>Sniper VS Spy update</a>. Around 2014-2015, in order to accommodate Mannrobic taunt that triggers special animation via primary/secondary fire key, CTFPlayer::CanAttack function blocks the ability to attack while taunting. This in turn removes Demoman's ability to detonate his stickies during a taunt. This removal was never explicitly addressed in any of the patch note.
I have added a special attack flag TF_CAN_ATTACK_FLAG_PIPEBOMBLAUNCHER that restores Demo's ability to use his secondary fire key while taunting.

https://github.com/user-attachments/assets/9a7ee880-d593-4e3c-9a20-5d7daece2d8d

