### PR TITLE
[TF2] Fix Robot Destruction heap corruption in source sdk 2013

### DIFF
--- a/src/game/shared/tf/entity_bonuspack.cpp
+++ b/src/game/shared/tf/entity_bonuspack.cpp
@@ -25,6 +25,11 @@ ConVar tf_bonuspack_score( "tf_bonuspack_score", "1", FCVAR_REPLICATED | FCVAR_D
 IMPLEMENT_NETWORKCLASS_ALIASED( BonusPack, DT_CBonusPack )
 
 BEGIN_NETWORK_TABLE( CBonusPack, DT_CBonusPack  )
+#ifdef CLIENT_DLL
+	RecvPropBool( RECVINFO( m_bCoreState ) ),
+#else
+	SendPropBool( SENDINFO( m_bCoreState ) ),
+#endif
 END_NETWORK_TABLE()
 
 BEGIN_DATADESC( CBonusPack )
@@ -39,6 +44,7 @@ IMPLEMENT_AUTO_LIST( IBonusPackAutoList );
 //-----------------------------------------------------------------------------
 CBonusPack::CBonusPack()
 {
+	m_bCoreState = false;
 #ifdef GAME_DLL
 	m_bAutoMaterialize = false;
 #else

--- a/src/game/shared/tf/entity_bonuspack.h
+++ b/src/game/shared/tf/entity_bonuspack.h
@@ -44,7 +44,15 @@ public:
 
 	virtual void	Spawn( void ) OVERRIDE;
 	virtual void	Precache( void ) OVERRIDE;
+private:
+    /*
+	This variable is used to fix a heap corruption for the tf2 sdk.
+    I'm not sure if there is a better way to do this but it solves the issue. -Billy
+	*/
+	CNetworkVar( bool, m_bCoreState );
+
 #ifdef GAME_DLL
+public:
 	virtual bool	AffectedByRadiusCollection() const OVERRIDE { return false; }
 	virtual bool	MyTouch( CBasePlayer *pPlayer ) OVERRIDE;
 	virtual bool	ValidTouch( CBasePlayer *pPlayer ) OVERRIDE;


### PR DESCRIPTION
This pull request adds a boolean network variable to entity_bonuspack that solves the heap corruption caused on robot destruction for the tf2 sdk. This changes makes it function as expected on my end in testing.