### PR TITLE
[TF2] Festivizer support for Half-Zatoichi -- "Option 3"

### DIFF
--- a/src/game/client/tf/vgui/tf_playermodelpanel.cpp
+++ b/src/game/client/tf/vgui/tf_playermodelpanel.cpp
@@ -1003,7 +1003,14 @@ void CTFPlayerModelPanel::EquipItem( CEconItemView *pItem )
 
 		if ( iAnimSlot == -1 )
 		{
-			iAnimSlot = pItemDef->GetLoadoutSlot( m_iCurrentClassIndex );
+			if (strcmp(pItemDef->GetItemClass(), "tf_weapon_katana") == 0 && m_iCurrentClassIndex == TF_CLASS_DEMOMAN)
+			{
+				iAnimSlot = TF_WPN_TYPE_ITEM2;
+			}
+			else
+			{
+				iAnimSlot = pItemDef->GetLoadoutSlot(m_iCurrentClassIndex);
+			}
 		}
 
 		const CUtlVector<const char *>& vecWeaponTypeSubstrings = GetItemSchema()->GetWeaponTypeSubstrings();

--- a/src/game/shared/tf/tf_weapon_sword.cpp
+++ b/src/game/shared/tf/tf_weapon_sword.cpp
@@ -99,11 +99,9 @@ Activity CTFDecapitationMeleeWeaponBase::TranslateViewmodelHandActivityInternal(
 			return BaseClass::TranslateViewmodelHandActivityInternal( actBase );
 	}
 
-	// Alright, so we have some decapitation weapons (katana) that can be used
-	// by both the soldier and the demoman, but the classes play totally different
-	// animations using the same weapon.
+	// This logic no longer handles the katana, which is handled in its own override
 	//
-	// This logic is also responsible for playing the correct animations on the
+	// This logic is still responsible for playing the correct animations on the
 	// demo when he's using non-shared weapons like the Eyelanders.
 	if ( pPlayer->GetPlayerClass()->GetClassIndex() == TF_CLASS_DEMOMAN )
 	{
@@ -577,15 +575,80 @@ float CTFKatana::GetMeleeDamage( CBaseEntity *pTarget, int* piDamageType, int* p
 int CTFKatana::GetActivityWeaponRole() const
 {
 	CTFPlayer *pPlayer = GetTFPlayerOwner();
-	if ( pPlayer && pPlayer->GetPlayerClass()->GetClassIndex() == TF_CLASS_DEMOMAN )
+	if (pPlayer && (pPlayer->GetPlayerClass()->GetClassIndex() == TF_CLASS_DEMOMAN || (pPlayer->GetPlayerClass()->GetClassIndex() == TF_CLASS_SPY && pPlayer->m_Shared.GetDisguiseClass() == TF_CLASS_DEMOMAN)))
 	{
-		// demo should use act table item1
-		return TF_WPN_TYPE_ITEM1;
+		// demo should use act table item2
+		return TF_WPN_TYPE_ITEM2;
 	}
 
 	return BaseClass::GetActivityWeaponRole();
 }
 
+//-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
+Activity CTFKatana::TranslateViewmodelHandActivityInternal(Activity actBase)
+{
+	actBase = BaseClass::TranslateViewmodelHandActivityInternal(actBase);
+
+	CTFPlayer* pPlayer = GetTFPlayerOwner();
+	if (!pPlayer)
+		return BaseClass::TranslateViewmodelHandActivityInternal(actBase);
+
+	// katana on demoman needs to use item2 animslot now
+	if (pPlayer->GetPlayerClass()->GetClassIndex() == TF_CLASS_DEMOMAN)
+	{
+		switch (actBase)
+		{
+		case ACT_VM_DRAW_SPECIAL:
+			actBase = ACT_ITEM2_VM_DRAW;
+			break;
+		case ACT_VM_HOLSTER_SPECIAL:
+			actBase = ACT_ITEM2_VM_HOLSTER;
+			break;
+		case ACT_VM_IDLE_SPECIAL:
+			actBase = ACT_ITEM2_VM_IDLE;
+			break;
+		case ACT_VM_PULLBACK_SPECIAL:
+			actBase = ACT_ITEM2_VM_PULLBACK;
+			break;
+		case ACT_VM_PRIMARYATTACK_SPECIAL:
+			actBase = ACT_ITEM2_VM_PRIMARYATTACK;
+			break;
+		case ACT_VM_SECONDARYATTACK_SPECIAL:
+			actBase = ACT_ITEM2_VM_SECONDARYATTACK;
+			break;
+		case ACT_VM_HITCENTER_SPECIAL:
+			actBase = ACT_ITEM2_VM_HITCENTER;
+			break;
+		case ACT_VM_SWINGHARD_SPECIAL:
+			actBase = ACT_ITEM2_VM_SWINGHARD;
+			break;
+		case ACT_VM_IDLE_TO_LOWERED_SPECIAL:
+			actBase = ACT_ITEM2_VM_IDLE_TO_LOWERED;
+			break;
+		case ACT_VM_IDLE_LOWERED_SPECIAL:
+			actBase = ACT_ITEM2_VM_IDLE_LOWERED;
+			break;
+		case ACT_VM_LOWERED_TO_IDLE_SPECIAL:
+			actBase = ACT_ITEM2_VM_LOWERED_TO_IDLE;
+			break;
+		case ACT_SPECIAL_VM_INSPECT_START:
+			actBase = ACT_ITEM2_VM_INSPECT_START;
+			break;
+		case ACT_SPECIAL_VM_INSPECT_IDLE:
+			actBase = ACT_ITEM2_VM_INSPECT_IDLE;
+			break;
+		case ACT_SPECIAL_VM_INSPECT_END:
+			actBase = ACT_ITEM2_VM_INSPECT_END;
+			break;
+		default:
+			break;
+		}
+	}
+
+	return actBase;
+}
 
 //-----------------------------------------------------------------------------
 // Purpose:

--- a/src/game/shared/tf/tf_weapon_sword.h
+++ b/src/game/shared/tf/tf_weapon_sword.h
@@ -131,6 +131,7 @@ public:
 	virtual void	OnDecapitation( CTFPlayer *pDeadPlayer );
 
 	virtual int		GetActivityWeaponRole() const OVERRIDE;
+	virtual Activity	TranslateViewmodelHandActivityInternal(Activity actBase);
 
 protected:
 	virtual int		GetSkinOverride() const;


### PR DESCRIPTION
The Half-Zatoichi is unique in being the only weapon to use different weapon models for different classes -- it uses c_shogun_katana.mdl for demoman and c_shogun_katana_soldier for soldier.  The models themselves have identical meshes, but are positioned differently relative to the bone, offset lengthwise by about 1.5 hammer units directly down weapon_bone's Y axis.  This is done to ensure that the katana's handguard fits snugly against the hand in both class's (re-used existing) animations, despite the animations being otherwise incompatible to do so.

<img width="536" height="332" alt="image" src="https://github.com/user-attachments/assets/3ef35564-b926-411f-9300-03e40a8763b1" />

However, this presents a unique problem for implementing a festivizer -- because the meshes are positioned differently relative to the bone, a festivizer attachment bound to the weapon will present differently on the two models, appearing to be a good inch or so higher up the blade on one class than the other.  Because the blade is curved, a festivizer model designed to do this would also have to be looser-fitting in an awkward way.

<img width="1452" height="534" alt="image" src="https://github.com/user-attachments/assets/a7f50218-6ad5-4827-8f89-c9e139e5cef4" />


In the "2026 Implementation Notes" spreadsheet in the tf_festives shared dropbox outlines four possible options for pursuing implementation of a festivizer on this weapon.  Option 1 is to just use the one-festivizer-model-for-two-weapon-models as seen above (and included in the original workshop submission).  I also included in the adjacent "New Festivizers - Model-Swap" folder in that dropbox two modified versions of the festivizer model, one that fits snug on each and in a consistent location on the mesh. Option 4 is listed for posterity, adding infrastructure to the item schema or otherwise adding a way to hot-swap these two different festivizer models based on class (this is doable but I can't see a way that's not VERY messy)

Option 2 would be to just use the soldier version of the model (and its better-fitting festivizer model) for both classes.  This would mean the festivizer fits snugly, though the side effect is a gap between the handguard and the hand for demoman in both first and third person:
<img width="826" height="707" alt="image" src="https://github.com/user-attachments/assets/eab039d8-66ed-42c0-802b-e1da82a31098" />

This PR's primary purpose is to provide the in-code changes needed for what is in my opinion the best option, Option 3, which builds upon the Option 2 route of just always using the soldier katana model.  It takes the existing carveout code that assigns eyelander animations for the katana on demoman, and adjusts it to instead point to ITEM2 animations (as-of-yet unused on demoman).  It would require new "ITEM2" animations added in 1st and 3rd person for demoman that are identical to those used by the eyelander, but for the exception that weapon_bone is in all frames translated -1.4485525 hammer units along its own Y axis (not the parent bone's Y axis).  I've included also in that folder in the dropbox the new skeletal animation SMDs needed for this (details in the spreadsheet).  The other change required would, as mentioned, be replacing "model_player_per_class" in the item definition ("357") with "model_player"	"models/workshop_partner/weapons/c_models/c_shogun_katana/c_shogun_katana_soldier.mdl" (plus the normal festivizer support lines).

<img width="1913" height="1080" alt="image" src="https://github.com/user-attachments/assets/9c91d459-558b-421e-84fd-ad2f95022e08" />
<img width="1913" height="1080" alt="image" src="https://github.com/user-attachments/assets/02840337-8e61-4053-8318-805ae7e1682d" />


This PR's changes incorporate the fixes in https://github.com/ValveSoftware/source-sdk-2013/pull/2005 and https://github.com/ValveSoftware/source-sdk-2013/pull/2006 since it's touching the same code and the changes were needed for proper testing anyway.