### PR TITLE
[TF2] MvM: Fix Zombies displaying as robots in 3D playerhud while disguised

### DIFF
--- a/src/game/client/tf/tf_hud_playerstatus.cpp
+++ b/src/game/client/tf/tf_hud_playerstatus.cpp
@@ -184,7 +184,8 @@ static bool IsMvMRobotDisguise( C_TFPlayer *pPlayer )
 		   TFGameRules() && TFGameRules()->IsMannVsMachineMode() &&
 		   pPlayer->GetTeamNumber() == TF_TEAM_PVE_DEFENDERS &&
 		   pPlayer->m_Shared.InCond( TF_COND_DISGUISED ) &&
-		   pPlayer->m_Shared.GetDisguiseTeam() != pPlayer->GetTeamNumber();
+		   pPlayer->m_Shared.GetDisguiseTeam() != pPlayer->GetTeamNumber() &&
+		   pPlayer->m_Shared.GetDisguisedSkinOverride() == 0; // If the target is a zombie, do not display as robot!
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This PR complements the recently added #1977 

This PR fixes the 3D playerhud displaying robot models in missions where invaders are Zombies

Before:
<img width="1360" height="910" alt="image" src="https://github.com/user-attachments/assets/4af81470-0a89-4fe6-b6aa-ca2ac868fcc2" />

After:
<img width="1277" height="798" alt="image" src="https://github.com/user-attachments/assets/0e6d7033-84e1-4488-9593-5b99dc96da96" />

NOTE: Romevision cosmetics displaying in the 3D playerhud when Romevision is OFF is a known issue and has been fixed in PR #2007 
