### PR TITLE
[TF2] Jiggle bones freezes when Alt-Tab out of the game Fix

### DIFF
--- a/src/public/jigglebones.cpp
+++ b/src/public/jigglebones.cpp
@@ -99,7 +99,7 @@ void CJiggleBones::BuildJiggleTransformations( int boneIndex, float currenttime,
 	bool bMaxDeltaT = deltaT < thousandHZ;
 	bool bUseGoalMatrix = cl_jiggle_bone_framerate_cutoff.GetFloat() <= 0.0f || deltaT > ( 1.0f / cl_jiggle_bone_framerate_cutoff.GetFloat() );
 
-	if ( bUseGoalMatrix )
+	if ( bUseGoalMatrix && data->useGoalMatrixCount <= 0 )
 	{
 		// We hit the jiggle bone framerate cutoff. Reset the useGoalMatrixCount so we
 		//  use the goal matrix at least 32 frames and don't flash back and forth.


### PR DESCRIPTION
### Bug
When you alt-tab out of the game, the jiggle bones freeze because the FPS drops below `cl_jiggle_bone_framerate_cutoff`. However, when you switch back to the game, the jiggle bones remain permanently frozen and never unfreeze. This PR fixes it.

### Media
Video demonstrating the bug (All tests were conducted with the default `cl_jiggle_bone_framerate_cutoff` value set to 20):

https://github.com/user-attachments/assets/e947ce34-0245-4fa3-b9ad-7dbaa8e99053

Video demonstrating the fix:

https://github.com/user-attachments/assets/f45933ec-8cfe-42ab-a602-661496d17834