### PR TITLE
vbsp: snap edge bevel normals before calculating dist

### DIFF
--- a/src/utils/vbsp/map.cpp
+++ b/src/utils/vbsp/map.cpp
@@ -567,6 +567,11 @@ void CMapFile::AddBrushBevels (mapbrush_t *b)
 					CrossProduct (vec, vec2, normal);
 					if (VectorNormalize (normal) < 0.5)
 						continue;
+
+					// snap before calculating dist, otherwise FindFloatPlane() snaps the
+					// normal to an axis but keeps the dist calculated from the unsnapped
+					// normal, resulting in a bogus axial side that cuts into the brush
+					SnapVector( normal );
 					dist = DotProduct (w->p[j], normal);
 
 					// if all the points on all the sides are


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description



Fixes the main issue from #1903 
There is another issue mentioned that this PR does not fix, and should be a different PR / issue.