### PR TITLE
[TF2] Fix wrong sorting behavior of the mute UI

### DIFF
--- a/src/game/client/tf/vgui/mute_player_dialog.cpp
+++ b/src/game/client/tf/vgui/mute_player_dialog.cpp
@@ -43,6 +43,20 @@ CMutePlayerDialog::~CMutePlayerDialog()
 }
 
 //-----------------------------------------------------------------------------
+// Purpose: Sort function for the player time column.
+//-----------------------------------------------------------------------------
+static int __cdecl SortPlayersByPlayTime( vgui::ListPanel *pPanel, const ListPanelItem &item1, const ListPanelItem &item2 )
+{
+    int time1 = item1.kv->GetInt( "time_int", 0 );
+    int time2 = item2.kv->GetInt( "time_int", 0 );
+    if ( time1 < time2 )
+        return -1;
+    if ( time1 > time2 )
+        return 1;
+    return 0;
+}
+
+//-----------------------------------------------------------------------------
 // Purpose: 
 //-----------------------------------------------------------------------------
 void CMutePlayerDialog::ApplySchemeSettings( vgui::IScheme *pScheme )
@@ -72,6 +86,7 @@ void CMutePlayerDialog::ApplySchemeSettings( vgui::IScheme *pScheme )
 		m_pPlayerList->AddColumnHeader( 2, "name", "#TF_Scoreboard_Name", m_iNameWidth + m_nExtraSpace );
 		m_pPlayerList->AddColumnHeader( 3, "score", "#TF_Scoreboard_Score", m_iScoreWidth );
 		m_pPlayerList->AddColumnHeader( 4, "time", "#TF_Connected", m_iTimeWidth );
+		m_pPlayerList->SetSortFunc( 4, SortPlayersByPlayTime );
 		m_pPlayerList->AddColumnHeader( 5, "status", "", m_iStatusWidth );
 
 		// doesn't make sense to sort with the images
@@ -155,7 +170,10 @@ void CMutePlayerDialog::Activate()
 
 				// The medal column is just a place holder for the images that are displayed later
 				pKeyValues->SetInt( "medal", 0 );
-				pKeyValues->SetString( "time", FormatSeconds( gpGlobals->curtime - g_TF_PR->GetConnectTime( playerIndex ) ) );
+
+				int nTime = gpGlobals->curtime - g_TF_PR->GetConnectTime( playerIndex );
+				pKeyValues->SetInt( "time_int", nTime );
+				pKeyValues->SetString( "time", FormatSeconds( nTime ) );
 
 				Color clr = g_PR->GetTeamColor( nTeam );
 				pKeyValues->SetColor( "cellcolor", clr );
@@ -185,7 +203,8 @@ void CMutePlayerDialog::RefreshPlayerStatus()
 {
 	for ( int i = 0; i <= m_pPlayerList->GetItemCount(); i++ )
 	{
-		KeyValues *data = m_pPlayerList->GetItem( i );
+		int itemID = m_pPlayerList->GetItemIDFromRow( i );
+		KeyValues *data = m_pPlayerList->GetItem( itemID );
 		if ( !data )
 			continue;
 
@@ -197,6 +216,7 @@ void CMutePlayerDialog::RefreshPlayerStatus()
 		{
 			// disconnected
 			data->SetString( "status", "#TF_Disconnected" );
+			m_pPlayerList->ApplyItemChanges( itemID );
 			continue;
 		}
 
@@ -210,8 +230,9 @@ void CMutePlayerDialog::RefreshPlayerStatus()
 		{
 			data->SetString( "status", "" );
 		}
+
+		m_pPlayerList->ApplyItemChanges( itemID );
 	}
-	m_pPlayerList->RereadAllItems();
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
The voice mute UI has two issues with the column sorting behavior:

- Time sorting is sorting by the formatted string instead of the underlying seconds value, causing e.g. hour-long sessions to be displayed out of order
- The status sorting doesn't work at all. Although the logic is updating the UI text, it never updates the actual underlying data source, so attempting to sort it always retains whatever order you already have.

This PR fixes both issues.

Before:

<img width="1113" height="754" alt="Screenshot_20260825_143025" src="https://github.com/user-attachments/assets/c6a3b952-426f-4eb1-b00f-595d5b14b613" />

After examples:

<img width="1125" height="777" alt="Screenshot_20260825_142830" src="https://github.com/user-attachments/assets/2527c7c1-70f6-4984-87f8-759b57438f2e" />
<img width="1101" height="760" alt="Screenshot_20260825_142805" src="https://github.com/user-attachments/assets/9d72f661-ca34-4445-88a9-cff5bc068211" />

Fixes https://github.com/ValveSoftware/Source-1-Games/issues/8238