### PR TITLE
[TF2] Fix voice muting causing the user to be kicked for sending too many commands

### DIFF
--- a/src/game/client/tf/vgui/mute_player_dialog.cpp
+++ b/src/game/client/tf/vgui/mute_player_dialog.cpp
@@ -237,7 +237,10 @@ void CMutePlayerDialog::ToggleMuteStateOfSelectedUser()
 	if ( !GetClientVoiceMgr() )
 		return;
 
-	for ( int iSelectedItem = 0; iSelectedItem < m_pPlayerList->GetSelectedItemsCount(); iSelectedItem++ )
+	CUtlVector<VoiceBlockState_t> playerStates;
+
+	const int nSelectedItems = m_pPlayerList->GetSelectedItemsCount();
+	for ( int iSelectedItem = 0; iSelectedItem < nSelectedItems; iSelectedItem++ )
 	{
 		KeyValues *data = m_pPlayerList->GetItem( m_pPlayerList->GetSelectedItem( iSelectedItem ) );
 		if ( !data )
@@ -245,16 +248,14 @@ void CMutePlayerDialog::ToggleMuteStateOfSelectedUser()
 		int playerIndex = data->GetInt( "index" );
 		Assert( playerIndex );
 
-		if ( GetClientVoiceMgr()->IsPlayerBlocked( playerIndex ) )
-		{
-			GetClientVoiceMgr()->SetPlayerBlockedState( playerIndex, false );
-		}
-		else
-		{
-			GetClientVoiceMgr()->SetPlayerBlockedState( playerIndex, true );
-		}
+		VoiceBlockState_t state;
+		state.playerIndex = playerIndex;
+		state.blocked = !GetClientVoiceMgr()->IsPlayerBlocked( playerIndex );
+
+		playerStates.AddToTail( state );
 	}
 
+	GetClientVoiceMgr()->SetPlayersBlockedState( playerStates );
 	RefreshPlayerStatus();
 	OnItemSelected();
 }

--- a/src/game/shared/voice_status.cpp
+++ b/src/game/shared/voice_status.cpp
@@ -546,33 +546,59 @@ bool CVoiceStatus::IsLocalPlayerSpeaking( void )
 
 //-----------------------------------------------------------------------------
 // Purpose: blocks/unblocks the target client from being heard
-// Input  : playerID - 
-// Output : Returns true on success, false on failure.
+// Input  : playerID, block state
 //-----------------------------------------------------------------------------
 void CVoiceStatus::SetPlayerBlockedState(int iPlayer, bool blocked)
 {
-	if (voice_clientdebug.GetInt())
-	{
-		Msg( "CVoiceStatus::SetPlayerBlockedState part 1\n" );
-	}
+	CUtlVector<VoiceBlockState_t> playerState( 1 );
+	VoiceBlockState_t state;
+	state.playerIndex = iPlayer;
+	state.blocked = blocked;
+	playerState.AddToTail( state );
+	SetPlayersBlockedState( playerState );
+}
 
-	player_info_t pi;
-	if ( !engine->GetPlayerInfo( iPlayer, &pi ) )
+//-----------------------------------------------------------------------------
+// Purpose: blocks/unblocks the target client(s) from being heard
+// Input  : vector of playerID, block state
+//-----------------------------------------------------------------------------
+void CVoiceStatus::SetPlayersBlockedState( const CUtlVector<VoiceBlockState_t> &playerStates )
+{
+	if (playerStates.Count() == 0)
 		return;
 
-	if (voice_clientdebug.GetInt())
+	bool shouldUpdateServer = false;
+	for ( int i = 0; i < playerStates.Count(); ++i )
 	{
-		Msg( "CVoiceStatus::SetPlayerBlockedState part 2\n" );
+		if (voice_clientdebug.GetInt())
+		{
+			Msg( "CVoiceStatus::SetPlayerBlockedState part 1\n" );
+		}
+
+		int iPlayer = playerStates[i].playerIndex;
+		player_info_t pi;
+		if ( !engine->GetPlayerInfo( iPlayer, &pi ) )
+			continue;
+
+		if (voice_clientdebug.GetInt())
+		{
+			Msg( "CVoiceStatus::SetPlayerBlockedState part 2\n" );
+		}
+
+		// Squelch or (try to) unsquelch this player.
+		if (voice_clientdebug.GetInt())
+		{
+			Msg("CVoiceStatus::SetPlayerBlockedState: setting player %d ban to %d\n", iPlayer, !m_BanMgr.GetPlayerBan(pi.guid));
+		}
+
+		m_BanMgr.SetPlayerBan(pi.guid, !m_BanMgr.GetPlayerBan(pi.guid));
+		shouldUpdateServer = true;
 	}
 
-	// Squelch or (try to) unsquelch this player.
-	if (voice_clientdebug.GetInt())
+	if ( shouldUpdateServer )
 	{
-		Msg("CVoiceStatus::SetPlayerBlockedState: setting player %d ban to %d\n", iPlayer, !m_BanMgr.GetPlayerBan(pi.guid));
+		UpdateServerState(false);
 	}
-
-	m_BanMgr.SetPlayerBan(pi.guid, !m_BanMgr.GetPlayerBan(pi.guid));
-	UpdateServerState(false);
 }
 
 //-----------------------------------------------------------------------------

--- a/src/game/shared/voice_status.h
+++ b/src/game/shared/voice_status.h
@@ -49,6 +49,12 @@ public:
 	int					m_clientindex;	// Client index of the speaker. -1 if this label isn't being used.
 };
 
+struct VoiceBlockState_t
+{
+    int playerIndex;
+    bool blocked;
+};
+
 // This is provided by each mod to access data that may not be the same across mods.
 abstract_class IVoiceStatusHelper
 {
@@ -128,7 +134,10 @@ public:
 	// returns true if the local player is attempting to speak
 	bool	IsLocalPlayerSpeaking( void );
 
-	// blocks the target client from being heard
+	// blocks the target client(s) from being heard
+	void	SetPlayersBlockedState( const CUtlVector<VoiceBlockState_t> &playerStates );
+
+	// convenience version of SetPlayersBlockedState for a single client
 	void	SetPlayerBlockedState(int iPlayerIndex, bool blocked);
 
 	void	SetHeadLabelMaterial( const char *pszMaterial );


### PR DESCRIPTION
Currently there's an issue with the "Mute Players" UI in TF2 where if you select multiple users, the muting will be done one-by-one by sending individual commands to the server. If you're playing in a large server with e.g. 64 players, this will consistently cause you to get kicked for sending too many commands to the server.

This PR fixes this logic by adding a variant to `SetPlayerBlockedState` that receives a list of users, sending the update only on the last entry rather than for every user. The reason this works is because `UpdateServerState` always sends the info for every user, so there's no need to call it in-between.

How to reproduce the issue:
- Join a large server (or, if testing locally, change mute_player_dialog.cpp to not filter bots)
- Open the Mute Players UI
- Select every user and press "Mute"
- Result: You will get kicked instantly. This PR fixes this.

I was able to validate this fix by temporarily changing the code to allow bots to be muted.

<img width="1181" height="822" alt="Screenshot_20260825_122803" src="https://github.com/user-attachments/assets/f15c7dec-cd63-466a-9ddd-7ce8b5d7f1f6" />

<img width="847" height="369" alt="20260825114822_1" src="https://github.com/user-attachments/assets/327874f3-aba0-408b-ba31-3e6f03b79d44" />

Fixes https://github.com/ValveSoftware/Source-1-Games/issues/8237