### PR TITLE
ALU optimization by approximating weighting functions in Bicubic Lightmaps

### DIFF
--- a/src/materialsystem/stdshaders/common_lightmappedgeneric_fxc.h
+++ b/src/materialsystem/stdshaders/common_lightmappedgeneric_fxc.h
@@ -181,11 +181,11 @@ float g1(float a) {
 
 // h0 and h1 are the two offset functions
 float h0(float a) {
-	return -1.0 + w1(a) / (w0(a) + w1(a));
+	return 0.2 + a * (0.233332 * a + 0.566668) - a;
 }
 
 float h1(float a) {
-	return 1.0 + w3(a) / (w2(a) + w3(a));
+	return 1.0 + a * (0.233332 * a - 1.033332) + a;
 }
 
 #ifndef BICUBIC_LIGHTMAP


### PR DESCRIPTION
We can remove the two divisions from the `h0` and `h1` functions by approximating them, thus optimizing the ALU. This will have no impact on the visual quality.

Reference: [Real-Time Samurai Cinema](https://www.glowybits.com/talks/real-time_samurai_cinema/real-time_samurai_cinema.pdf)

Details are in the Desmos graph (www.desmos.com/calculator/7dcech96ju).

<img width="514" height="455" alt="image" src="https://github.com/user-attachments/assets/daa76d8f-7961-4a94-b9dd-37f2ef4f0b14" />