### PR TITLE
[TF2] Fix team color of attachments and Ubersaw vial in inventory inspect and backpack icons

### DIFF
--- a/src/game/client/econ/item_model_panel.cpp
+++ b/src/game/client/econ/item_model_panel.cpp
@@ -17,6 +17,7 @@
 #include "vgui_controls/Label.h"
 #include "vgui_controls/Button.h"
 #include "econ_item_system.h"
+#include "econ_paintkit.h"
 #include "ienginevgui.h"
 #include "VGuiMatSurface/IMatSystemSurface.h"
 #include "renderparm.h"
@@ -408,6 +409,52 @@ void CEmbeddedItemModelPanel::SetItem( CEconItemView *pItem )
 					}
 				}
 
+				int iTeam = GetLocalPlayerTeam();
+
+				//if we have a team color selector panel, we want to use the color defined by that panel
+				CSchemaAttributeDefHandle pAttrTeamColoredPaintkit("has team color paintkit");
+				uint32 iHasTeamColoredPaintkit = 0;
+				bool bShowTeamButton = m_pItem && FindAttribute_UnsafeBitwiseCast<attrib_value_t>(m_pItem, pAttrTeamColoredPaintkit, &iHasTeamColoredPaintkit) && iHasTeamColoredPaintkit > 0;
+				if (!bShowTeamButton) {
+					uint32 unPaintKitIndex = 0;
+					bool bPaintkit = false;
+					bPaintkit = pItem && GetPaintKitDefIndex(pItem, &unPaintKitIndex);
+					if (bPaintkit)
+					{
+						const CPaintKitDefinition* pPaintKitDef = GetProtoScriptObjDefManager()->GetTypedDefinition< CPaintKitDefinition >(unPaintKitIndex);
+						bShowTeamButton |= pPaintKitDef && pPaintKitDef->BHasTeamTextures();
+					}
+				}
+				if (bShowTeamButton) {
+					iTeam = m_pItem->GetTeamNumber();
+				}
+
+#ifdef TF_CLIENT_DLL
+				// If we aren't in a game we default to previewing the red team skin.
+				if (iTeam == TEAM_UNASSIGNED)
+				{
+					iTeam = TF_TEAM_RED;
+				}
+#endif // TF_CLIENT_DLL
+
+				int iSkin = iTeam;
+
+				if (iSkin != TEAM_UNASSIGNED)
+				{
+					// Use the first skin for the first team, and the second skin for the other (but default to 0)
+					iSkin = (iSkin == (FIRST_GAME_TEAM + 1)) ? 1 : 0;
+				}
+
+				// Handle styles/visuals overriding the skin.
+				int iOverrideSkin = m_pItem->GetSkin(iTeam);
+				if (iOverrideSkin != -1)
+				{
+					iSkin = iOverrideSkin;
+				}
+
+				SetSkin(iSkin);
+				m_ItemModel.m_MDL.m_nSkin = iSkin;
+
 				// Attach Models
 				// Attach the models for the item
 				{
@@ -475,6 +522,7 @@ void CEmbeddedItemModelPanel::SetItem( CEconItemView *pItem )
 							hStatTrackMDL = MDLHANDLE_INVALID;
 						}
 						m_StatTrackModel.m_MDL.SetMDL( hStatTrackMDL );
+						m_StatTrackModel.m_MDL.m_nSkin = m_ItemModel.m_MDL.m_nSkin;
 						mdlcache->Release( hStatTrackMDL ); // counterbalance addref from within FindMDL
 
 						m_StatTrackModel.m_MDL.m_pProxyData = static_cast<IClientRenderable*>(pItem);
@@ -482,37 +530,6 @@ void CEmbeddedItemModelPanel::SetItem( CEconItemView *pItem )
 						m_StatTrackModel.m_MDL.m_nSequence = ACT_IDLE;
 						SetIdentityMatrix( m_StatTrackModel.m_MDLToWorld );
 					}
-				}
-
-				int iTeam = GetLocalPlayerTeam(),
-					iSkin = iTeam;
-
-#ifdef TF_CLIENT_DLL
-				// If we aren't in a game we default to previewing the red team skin.
-				if ( iTeam == TEAM_UNASSIGNED )
-				{
-					iTeam = TF_TEAM_RED;
-				}
-#endif // TF_CLIENT_DLL
-
-				if ( iSkin != TEAM_UNASSIGNED )
-				{
-					// Use the first skin for the first team, and the second skin for the other (but default to 0)
-					iSkin = (iSkin == (FIRST_GAME_TEAM+1)) ? 1 : 0;
-				}
-
-				// Handle styles/visuals overriding the skin.
-				int iOverrideSkin = m_pItem->GetSkin( iTeam );
-				if ( iOverrideSkin != -1 )
-				{
-					iSkin = iOverrideSkin;
-				}
-					
-				SetSkin( iSkin );
-
-				if ( m_bUsePedestal )
-				{
-					m_ItemModel.m_MDL.m_nSkin = iSkin;
 				}
 			}
 		}
@@ -537,6 +554,7 @@ void CEmbeddedItemModelPanel::LoadAttachedModel( attachedmodel_t *pModel )
 		hMDL = MDLHANDLE_INVALID;
 	}
 	m_AttachedModels[iIndex].m_MDL.SetMDL( hMDL );
+	m_AttachedModels[iIndex].m_MDL.m_nSkin = m_ItemModel.m_MDL.m_nSkin;
 	mdlcache->Release( hMDL ); // counterbalance addref from within FindMDL
 
 	m_AttachedModels[iIndex].m_MDL.m_pProxyData = static_cast<IClientRenderable*>( m_pItem );

--- a/src/game/client/tf/vgui/tf_item_inspection_panel.cpp
+++ b/src/game/client/tf/vgui/tf_item_inspection_panel.cpp
@@ -840,6 +840,9 @@ void CTFItemInspectionPanel::OnNavButtonSelected( KeyValues *pData )
 	{
 		pItem->SetTeamNumber( iTeam );
 
+		//set the panel as well to update attachments for team
+		m_pModelInspectPanel->SetItem(pItem);
+
 		RecompositeItem();
 	}
 }


### PR DESCRIPTION
Currently, the behavior of weapon skin team color for generated backpack icons and right click -> inspect in the inventory is as follows:

-If the weapon is a Decorated/War Painted weapon whose paint has different team-colored textures, the preview uses the team color selected via the buttons in the preview screen (and defaults to red team in the backpack icons).
-Otherwise, the preview uses the weapon's skin for the team the player is currently assigned.  If the player is not assigned a team (including if they are not connected to a server), this defaults to red team.

This behavior has a couple small bugs within it.  First of all, attachments such as the stat clock and festivizer do not get properly assigned to the correct team-colored skin, instead always showing as red in these contexts, even if the weapon they're attached to is displaying blue team textures.  Second, the vial of the Ubersaw, unlike the weapon base texture (which gets overwritten by the war paint compositor) retains its per-team coloring for many war paints, which works correctly in-game but can result in either red textures with a blue vial or blue textures with a red vial when previewed or seen in a backpack icon (depending on the player's current team).

The PR retains the team-color-skin prioritization described above (selected paintkit skin (defaulting red for icons), otherwise current team, otherwise red), but fixes these holes in the preview, properly setting the team skin for attachments and the Ubersaw vial.

<img width="1913" height="1080" alt="inventorybefore" src="https://github.com/user-attachments/assets/b3885bf0-9924-46b2-9675-a5b96dd24364" />
<img width="1913" height="1080" alt="inventoryafter" src="https://github.com/user-attachments/assets/99b642da-c163-47d1-8176-7d7b7ea254dd" />
<img width="1913" height="1080" alt="flarebefore" src="https://github.com/user-attachments/assets/47a8bcf9-685a-4e3c-a334-3c0dbf19e7dc" />
<img width="1913" height="1080" alt="flareafter" src="https://github.com/user-attachments/assets/b479b6a1-d14f-4fc3-83dc-5b6fbd648d2b" />
<img width="1913" height="1080" alt="smgbefore" src="https://github.com/user-attachments/assets/07817a65-c893-46f8-b20d-915d93f6bd65" />
<img width="1913" height="1080" alt="smgafter" src="https://github.com/user-attachments/assets/410090f4-a131-4aa4-b41f-272d56909238" />
<img width="1913" height="1080" alt="nutuberbefore" src="https://github.com/user-attachments/assets/3a2fef76-c91d-4d1f-9414-9d61627729f2" />
<img width="1913" height="1080" alt="nutuberafter" src="https://github.com/user-attachments/assets/8e260534-26f4-4629-b38c-2f23a3fe8ff4" />
<img width="1913" height="1080" alt="sniperbefore" src="https://github.com/user-attachments/assets/6387c88f-712f-47d0-8ab6-6f2661674d24" />
<img width="1913" height="1080" alt="sniperafter" src="https://github.com/user-attachments/assets/902875d7-15df-4f9b-8fe4-6d0a21504c57" />
<img width="1913" height="1080" alt="teamuberbefore" src="https://github.com/user-attachments/assets/037a7a3e-9586-4c92-86b6-59b00bcaad35" />
<img width="1913" height="1080" alt="teamuberafter" src="https://github.com/user-attachments/assets/a8a22366-e1f8-4f55-9827-75d261bbd154" />

Please note, the right-click menu in the Inventory is disabled entirely by default in the SDK, via a single return statement at the top of CBackpackPanel::OpenContextMenu() in src\game\client\econ\backpack_panel.cpp -- testing this code change for right click -> inspect within the SDK requires commenting out that line.