### PR TITLE
[ALL] Add deletion of downloaded manifest files from Servers

### DIFF
--- a/src/game/client/clientmode_shared.cpp
+++ b/src/game/client/clientmode_shared.cpp
@@ -409,6 +409,8 @@ void ClientModeShared::VGui_Shutdown()
 //-----------------------------------------------------------------------------
 void ClientModeShared::Shutdown()
 {
+	RemoveDownloadedMapManifests( "particles" );
+	RemoveDownloadedMapManifests( "level_sounds" );
 }
 
 //-----------------------------------------------------------------------------
@@ -1574,5 +1576,30 @@ void ClientModeShared::DeactivateInGameVGuiContext()
 	vgui::ivgui()->ActivateContext( DEFAULT_VGUI_CONTEXT );
 }
 
+//-----------------------------------------------------------------------------
+// Purpose: Purge downloaded map manifest files matching <mapname>_<suffix>.txt
+//-----------------------------------------------------------------------------
+void ClientModeShared::RemoveDownloadedMapManifests( const char *pszSuffix ) const
+{
+	FileFindHandle_t hFind = NULL;
 
+	CFmtStr fmtSearchPath( "download/maps/*_%s.txt", pszSuffix );
+	const char *pszFileName = g_pFullFileSystem->FindFirstEx( fmtSearchPath, "MOD", &hFind );
+	while ( pszFileName )
+	{
+		if ( pszFileName[0] != '.' )
+		{
+			CFmtStr fmtFilename( "download/maps/%s", pszFileName );
+
+			if ( !g_pFullFileSystem->IsDirectory( fmtFilename, "MOD" ) )
+			{
+				g_pFullFileSystem->RemoveFile( fmtFilename, "MOD" );
+			}
+		}
+
+		pszFileName = g_pFullFileSystem->FindNext( hFind );
+	}
+
+	g_pFullFileSystem->FindClose( hFind );
+}
 

--- a/src/game/client/clientmode_shared.h
+++ b/src/game/client/clientmode_shared.h
@@ -140,6 +140,8 @@ public:
 	virtual void			OnDemoRecordStart( char const* pDemoBaseName ) OVERRIDE {}
 	virtual void			OnDemoRecordStop() OVERRIDE {}
 
+	virtual void			RemoveDownloadedMapManifests( const char *pszSuffix ) const;
+
 protected:
 	CBaseViewport			*m_pViewport;
 

--- a/src/game/client/tf/clientmode_tf.cpp
+++ b/src/game/client/tf/clientmode_tf.cpp
@@ -272,29 +272,6 @@ static void EnableSteamScreenshots( bool bEnable )
 #endif
 }
 
-static void RemoveDownloadedParticlesManifest()
-{
-	FileFindHandle_t hFind = NULL;
-	const char *pszFileName = g_pFullFileSystem->FindFirstEx( "download/maps/*_particles.txt", "MOD", &hFind );
-
-	while ( pszFileName )
-	{
-		if ( pszFileName[0] != '.' )
-		{
-			CFmtStr fmtFilename( "download/maps/%s", pszFileName );
-
-			if ( !g_pFullFileSystem->IsDirectory( fmtFilename, "MOD" ) )
-			{
-				g_pFullFileSystem->RemoveFile( fmtFilename, "MOD" );
-			}
-		}
-
-		pszFileName = g_pFullFileSystem->FindNext( hFind );
-	}
-
-	g_pFullFileSystem->FindClose( hFind );
-}
-
 #if !defined(NO_STEAM)
 void SteamScreenshotsCallBack( IConVar *var, const char *pOldString, float flOldValue )
 {
@@ -374,8 +351,6 @@ void CTFModeManager::LevelShutdown( void )
 	CL_Coaching_LevelShutdown();
 	CL_Consumables_LevelShutdown();
 	CL_Halloween_LevelShutdown();
-
-	RemoveDownloadedParticlesManifest();
 }
 
 //-----------------------------------------------------------------------------
@@ -560,6 +535,8 @@ void ClientModeTFNormal::Shutdown()
 	}
 
 	DestroyStatsSummaryPanel();
+
+	BaseClass::Shutdown();
 }
 
 void ClientModeTFNormal::InitViewport()
@@ -742,8 +719,6 @@ void ClientModeTFNormal::FireGameEvent( IGameEvent *event )
 		m_eConnectState = k_eConnectState_Disconnected;
 		m_szMapBaseName[0] = '\0';
 		m_bPendingRichPresenceUpdate = true;
-
-		RemoveDownloadedParticlesManifest();
 #if !defined( _X360 ) && !defined( NO_STEAM )
 		if ( SteamTimeline() )
 			SteamTimeline()->ClearTimelineStateDescription( 0 );
@@ -1440,8 +1415,6 @@ void ClientModeTFNormal::FireGameEvent( IGameEvent *event )
 		m_bRestrictInfoPanel = pchSource && ( FStrEq( "matchmaking", pchSource ) || !Q_strncmp( pchSource, "quickplay_", 10 ) );
 
 		m_bInfoPanelShown = false;
-
-		RemoveDownloadedParticlesManifest();
 	}
 	else if ( FStrEq( "player_teleported", eventname ) )
 	{

--- a/src/game/client/tf/clientmode_tf.cpp
+++ b/src/game/client/tf/clientmode_tf.cpp
@@ -272,6 +272,29 @@ static void EnableSteamScreenshots( bool bEnable )
 #endif
 }
 
+static void RemoveDownloadedParticlesManifest()
+{
+	FileFindHandle_t hFind = NULL;
+	const char *pszFileName = g_pFullFileSystem->FindFirstEx( "download/maps/*_particles.txt", "MOD", &hFind );
+
+	while ( pszFileName )
+	{
+		if ( pszFileName[0] != '.' )
+		{
+			CFmtStr fmtFilename( "download/maps/%s", pszFileName );
+
+			if ( !g_pFullFileSystem->IsDirectory( fmtFilename, "MOD" ) )
+			{
+				g_pFullFileSystem->RemoveFile( fmtFilename, "MOD" );
+			}
+		}
+
+		pszFileName = g_pFullFileSystem->FindNext( hFind );
+	}
+
+	g_pFullFileSystem->FindClose( hFind );
+}
+
 #if !defined(NO_STEAM)
 void SteamScreenshotsCallBack( IConVar *var, const char *pOldString, float flOldValue )
 {
@@ -351,6 +374,8 @@ void CTFModeManager::LevelShutdown( void )
 	CL_Coaching_LevelShutdown();
 	CL_Consumables_LevelShutdown();
 	CL_Halloween_LevelShutdown();
+
+	RemoveDownloadedParticlesManifest();
 }
 
 //-----------------------------------------------------------------------------
@@ -717,6 +742,8 @@ void ClientModeTFNormal::FireGameEvent( IGameEvent *event )
 		m_eConnectState = k_eConnectState_Disconnected;
 		m_szMapBaseName[0] = '\0';
 		m_bPendingRichPresenceUpdate = true;
+
+		RemoveDownloadedParticlesManifest();
 #if !defined( _X360 ) && !defined( NO_STEAM )
 		if ( SteamTimeline() )
 			SteamTimeline()->ClearTimelineStateDescription( 0 );
@@ -1413,6 +1440,8 @@ void ClientModeTFNormal::FireGameEvent( IGameEvent *event )
 		m_bRestrictInfoPanel = pchSource && ( FStrEq( "matchmaking", pchSource ) || !Q_strncmp( pchSource, "quickplay_", 10 ) );
 
 		m_bInfoPanelShown = false;
+
+		RemoveDownloadedParticlesManifest();
 	}
 	else if ( FStrEq( "player_teleported", eventname ) )
 	{


### PR DESCRIPTION
When connecting to a Community Server, this one can provide downloads of any type (in this case, .pcf files for particles and a txt inside maps that contains a manifest for particles or level sounds in a specific map).
While this is not an issue in custom maps that already packs it's own manifest file inside because it takes priority over the downloaded one, a server could maliciously send lots of particles manifest files for all the base game maps with a pcf that floods the "ParticleEffectNames" string table on precache (making some of the default particles from the base game not being precached and display the default error particle), mute/replace certain sounds, or crash the client when creating a Local Server.

The PR checks for files ending in particles.txt or level_sounds.txt inside download/maps and deletes them on game exit (like tf_delete_temp_files).
Tested both in TF2 & HL2:DM.