### PR TITLE
[TF2] Fix redeployed Sentry Guns consuming metal incorrectly

### DIFF
--- a/src/game/server/tf/tf_obj.cpp
+++ b/src/game/server/tf/tf_obj.cpp
@@ -1594,7 +1594,7 @@ void CBaseObject::FinishedBuilding( void )
 //-----------------------------------------------------------------------------
 void CBaseObject::SetHealth( float flHealth )
 {
-	if ( m_bCarryDeploy && (flHealth>m_iHealthOnPickup) )
+	if ( m_bCarryDeploy && (flHealth>m_iHealthOnPickup) && IsBuilding() )
 	{
 		// If we are re-deploying after being carried we shouldn't gain more health than we had
 		// on pickup until the deploy process is finished.
@@ -2962,7 +2962,7 @@ int CBaseObject::Command_Repair( CTFPlayer *pActivator, float flAmount, float fl
 	{
 		iRepairAmount = iRepairCost * flRepairToMetalRatio;
 		float flNewHealth = Min( (float)GetMaxHealth(), m_flHealth + iRepairAmount );
-		if ( m_bCarryDeploy && ( flNewHealth > m_iHealthOnPickup ) )
+		if ( m_bCarryDeploy && ( flNewHealth > m_iHealthOnPickup ) && isBuilding() )
 		{
 			// If we are re-deploying after being carried we shouldn't gain more health than we had
 			// on pickup until the deploy process is finished.

--- a/src/game/server/tf/tf_obj.cpp
+++ b/src/game/server/tf/tf_obj.cpp
@@ -2962,18 +2962,8 @@ int CBaseObject::Command_Repair( CTFPlayer *pActivator, float flAmount, float fl
 	{
 		iRepairAmount = iRepairCost * flRepairToMetalRatio;
 		float flNewHealth = Min( (float)GetMaxHealth(), m_flHealth + iRepairAmount );
-		if ( m_bCarryDeploy && ( flNewHealth > m_iHealthOnPickup ) && isBuilding() )
-		{
-			// If we are re-deploying after being carried we shouldn't gain more health than we had
-			// on pickup until the deploy process is finished.
-			flNewHealth = m_iHealthOnPickup;
-			iRepairAmount = 0;
-		}
-		else
-		{
-			// remove the repair cost
-			pActivator->RemoveBuildResources( iRepairCost );
-		}
+		// remove the repair cost
+		pActivator->RemoveBuildResources( iRepairCost );
 		SetHealth( flNewHealth );
 
 		if ( iRepairAmount > 0 )


### PR DESCRIPTION
First, some context on how sentries work before explaining the problem:

- When a sentry is in the building state, it auto-heals up to its max health value. When the sentry is redeployed however, this max value is not the sentry's actual max health but rather how much health it had when you picked it up. This is intentional and ensures that the sentry cannot overheal when it's first spinning up to level 1.
- When a sentry is in its regular state, it can both heal and receive ammo / upgrade metals, with heals always being the priority.
- When a sentry is in the middle of the upgrade animation, it can be healed but **cannot** recover ammo or receive upgrade metals.
- When a lvl 2 or 3 sentry is redeployed, there is a _very brief_ period of time in between upgrades where the sentry is in its normal active mode before it starts upgrading again, which is why it beeps and then goes straight into upgrading to the next level.

With the way the code is structured today, the max health restriction on redeployed sentries applies not just to the initial building state but rather throughout the **entire upgrade process.** So if you're redeploying a level 3 sentry, its health will be capped until it returns to the level 3 state.

These facts combined can cause a very specific bug where if you time your wrench hits to land at precisely this moment where the sentry is in-between upgrades, the game will believe that a previously damaged sentry is actually at max health (due to the health being currently capped), and incorrectly result in metal being consumed to replenish ammo if possible. Gameplay-wise this is an issue because if it happens while repositioning sentries under fire, the player can end up accidentally running out of metal to heal the sentry.

Additionally, there is a second bug in this code where if the sentry has its health capped, gets damaged during redeployment, is in the upgrade animation, you heal it, and the heal amount overshoots the health cap, that heal will always cost zero metal regardless of the amount. The code makes it seem this might have been intentional but I'm guessing it's a bug because I've never seen this behavior documented anywhere (and it even plays the "failed" sound effect). (This one affects all buildings, not just the sentry)

These videos show the two problems. In the first one, you can see how the metal is consumed when the sentry upgrades to level 3 despite it being damaged, and the second one shows how heals can cost zero metal.

https://github.com/user-attachments/assets/2353f861-3d35-42ce-b834-147470bec032

https://github.com/user-attachments/assets/595a9bcb-9801-4fe1-b921-eb7a60cb24a5

Determining the right way to fix these issues depends on whether Valve intended for the health cap to apply all the way through or if that's a bug that was never addressed. So there are a couple of options:

- Option 1: If capping the health beyond the initial build step was not the intended behavior, removing it solves the issue and causes redeployed sentries to be able to be healed like normal sentries (buffs Engineer when redeploying damaged sentries)
- Option 2: If it's intentional, cap ammo the same way the health is capped to keep the behavior consistent, and fix the heal cost by calculating the correct difference rather than always setting the cost to zero
- Option 3: Make sentries go straight into the next upgrade state instead of having this brief moment where it becomes active (plus fix the heal cost like in 2.)

The PR itself implements option 1 because I feel that Valve probably didn't intend for the health cap or the zero cost thing to work the way it does today, but obviously it's up to Valve to confirm this. Option 2 is an easy fix and wouldn't affect balance. I'm not a fan of Option 3 because it might break interactions with things like the Red Tape Recorder.

Fixes https://github.com/ValveSoftware/Source-1-Games/issues/8244