### PR TITLE
Fix interpolated predicted fields getting stuck after a teleport

### DIFF
--- a/src/game/client/c_baseentity.cpp
+++ b/src/game/client/c_baseentity.cpp
@@ -5866,13 +5866,14 @@ void C_BaseEntity::EstimateAbsVelocity( Vector& vel )
 void C_BaseEntity::Interp_Reset( VarMapping_t *map )
 {
 	PREDICTION_TRACKVALUECHANGESCOPE_ENTITY( this, "reset" );
+	const bool bUpdateLastNetworkedValue = !GetPredictable();
 	int c = map->m_Entries.Count();
 	for ( int i = 0; i < c; i++ )
 	{
 		VarMapEntry_t *e = &map->m_Entries[ i ];
 		IInterpolatedVar *watcher = e->watcher;
 
-		watcher->Reset();
+		watcher->Reset( bUpdateLastNetworkedValue );
 	}
 }
 

--- a/src/game/client/interpolatedvar.h
+++ b/src/game/client/interpolatedvar.h
@@ -160,7 +160,7 @@ public:
 	// Returns true if the new value is different from the prior most recent value.
 	virtual void NoteLastNetworkedValue() = 0;
 	virtual bool NoteChanged( float changetime, bool bUpdateLastNetworkedValue ) = 0;
-	virtual void Reset() = 0;
+	virtual void Reset( bool bUpdateLastNetworkedValue = true ) = 0;
 	
 	// Returns 1 if the value will always be the same if currentTime is always increasing.
 	virtual int Interpolate( float currentTime ) = 0;
@@ -449,7 +449,7 @@ public:
 	virtual void SetInterpolationAmount( float seconds );
 	virtual void NoteLastNetworkedValue();
 	virtual bool NoteChanged( float changetime, bool bUpdateLastNetworkedValue );
-	virtual void Reset();
+	virtual void Reset( bool bUpdateLastNetworkedValue = true );
 	virtual int Interpolate( float currentTime );
 	virtual int GetType() const;
 	virtual void RestoreToLastNetworked();
@@ -737,7 +737,7 @@ inline void CInterpolatedVarArrayBase<Type, IS_ARRAY>::AddToHead( float changeTi
 }
 
 template< typename Type, bool IS_ARRAY >
-inline void CInterpolatedVarArrayBase<Type, IS_ARRAY>::Reset()
+inline void CInterpolatedVarArrayBase<Type, IS_ARRAY>::Reset( bool bUpdateLastNetworkedValue )
 {
 	ClearHistory();
 
@@ -747,7 +747,8 @@ inline void CInterpolatedVarArrayBase<Type, IS_ARRAY>::Reset()
 		AddToHead( gpGlobals->curtime, m_pValue, false );
 		AddToHead( gpGlobals->curtime, m_pValue, false );
 
-		memcpy( m_LastNetworkedValue, m_pValue, m_nMaxCount * sizeof( Type ) );
+		if ( bUpdateLastNetworkedValue )
+			memcpy( m_LastNetworkedValue, m_pValue, m_nMaxCount * sizeof( Type ) );
 	}
 }
 


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
PR #1392 made the predicted field `m_vecPunchAngle` interpolated, which revealed an issue with interpolated, predicted fields:
On a frame where `IsNoInterpolationFrame()` is set (when the player teleports), `ResetLatched` runs after prediction, so `CInterpolatedVar::Reset` stores the predicted punch angle in `m_LastNetworkedValue`. Every update then restores it from there, and since the server only sends `m_vecPunchAngle` when it changes, nothing corrects it and the view punch sticks until it changes again, like when firing a weapon.

This means if the client mispredicts view punch on the teleport frame, like on servers that disable rough landing effects via plugins (also see #2028), the client predicts a view punch the server never sets, and the misprediction sticks and never decays:
```
[Tick 52114] 001 CPlayerLocalData::m_vecPunchAngle - vec[] differs (1st diff) (net 0.000000 0.000000 23.919640 - pred 0.000000 0.000000 23.700041) delta(0.000000 0.000000 -0.219599)
[Tick 52114] Full latch reset!

[Tick 52115] 001 CPlayerLocalData::m_vecPunchAngle - vec[] differs (1st diff) (net 0.000000 0.000000 23.919640 - pred 0.000000 0.000000 23.700041) delta(0.000000 0.000000 -0.219599)
[Tick 52115] Full latch reset!

...
```

This fixes the issue that people are experiencing on many CS:S bhop and surf servers right now.

EDIT: corrected explanation