### PR TITLE
Fix trigger_push prediction

### DIFF
--- a/src/game/client/prediction.cpp
+++ b/src/game/client/prediction.cpp
@@ -836,44 +836,6 @@ void CPrediction::RunPostThink( C_BasePlayer *player )
 }
 
 //-----------------------------------------------------------------------------
-// Purpose: Checks if the player is standing on a moving entity and adjusts velocity and 
-//  basevelocity appropriately
-// Input  : *player - 
-//			frametime - 
-//-----------------------------------------------------------------------------
-void CPrediction::CheckMovingGround( C_BasePlayer *player, double frametime )
-{
-#if 0
-	CBaseEntity	    *groundentity;
-
-	if ( player->GetFlags() & FL_ONGROUND )
-	{
-		groundentity = player->GetGroundEntity();
-		if ( groundentity && ( groundentity->GetFlags() & FL_CONVEYOR) )
-		{
-			Vector vecNewVelocity;
-			groundentity->GetGroundVelocityToApply( vecNewVelocity );
-			if ( player->GetFlags() & FL_BASEVELOCITY )
-			{
-				vecNewVelocity += player->GetBaseVelocity();
-			}
-			player->SetBaseVelocity( vecNewVelocity );
-			player->AddFlag( FL_BASEVELOCITY );
-		}
-	}
-#endif
-
-	if ( !( player->GetFlags() & FL_BASEVELOCITY ) )
-	{
-		// Apply momentum (add in half of the previous frame of velocity first)
-		player->ApplyAbsVelocityImpulse( (1.0 + ( frametime * 0.5 )) * player->GetBaseVelocity() );
-		player->SetBaseVelocity( vec3_origin );
-	}
-
-	player->RemoveFlag( FL_BASEVELOCITY );
-}
-
-//-----------------------------------------------------------------------------
 // Purpose: Predicts a single movement command for player
 // Input  : *moveHelper - 
 //			*player - 
@@ -926,7 +888,7 @@ void CPrediction::RunCommand( C_BasePlayer *player, CUserCmd *ucmd, IMoveHelper 
 	player->UpdateButtonState( ucmd->buttons );
 
 // TODO
-	CheckMovingGround( player, gpGlobals->frametime );
+//	CheckMovingGround( player, gpGlobals->frametime );
 
 // TODO
 //	g_pMoveData->m_vecOldAngles = player->pl.v_angle;

--- a/src/game/client/prediction.h
+++ b/src/game/client/prediction.h
@@ -90,7 +90,6 @@ protected:
 	// Helpers to call pre and post think for player, and to call think if a think function is set
 	void			RunPreThink( C_BasePlayer *player );
 	void			RunThink (C_BasePlayer *ent, double frametime );
-	void			CheckMovingGround( C_BasePlayer* player, double frametime );
 	void			RunPostThink( C_BasePlayer *player );
 
 private:


### PR DESCRIPTION
Removes CPrediction::CheckMovingGround.

After the addition of CheckMovingGround to client code in the sdk update, push triggers have had their prediction broken. Before simulating player movement, this function will check whether FL_BASEVELOCITY isn't set, and if that is so, it will apply an impulse of one second plus half a frame of the player's current base velocity, set base velocity to 0 and remove FL_BASEVELOCITY. This is fine on the server, because after player movement the trigger_push will reapply the base velocity and FL_BASEVELOCITY flag, making it so that the CheckMovingGround code won't run until the player leaves the push trigger, but on the client side there's nothing to set the player's base velocity and add the flag. So after CheckMovingGround resets base velocity for the first time, the client will simulate movement as if the player has no base velocity until it receives another update from the server, resulting in prediction errors.

With CheckMovingGround:

https://github.com/user-attachments/assets/9da110f1-be24-42a1-821d-e16fcf7e4225

Without CheckMovingGround:

https://github.com/user-attachments/assets/2948aef2-5416-4b75-aeac-4a8442c757b4

