### PR TITLE
[ALL] Implement prediction for forced and disabled player input masks

### DIFF
--- a/src/game/client/c_baseplayer.cpp
+++ b/src/game/client/c_baseplayer.cpp
@@ -235,6 +235,8 @@ END_RECV_TABLE()
 
 		RecvPropInt			( RECVINFO( m_nTickBase ) ),
 		RecvPropInt			( RECVINFO( m_nNextThinkTick ) ),
+		RecvPropInt			( RECVINFO( m_afButtonDisabled ) ),
+		RecvPropInt			( RECVINFO( m_afButtonForced ) ),
 
 		RecvPropEHandle		( RECVINFO( m_hLastWeapon ) ),
 		RecvPropEHandle		( RECVINFO( m_hGroundEntity ) ),
@@ -390,6 +392,8 @@ BEGIN_PREDICTION_DATA( C_BasePlayer )
 	DEFINE_FIELD( m_afButtonLast, FIELD_INTEGER ),
 	DEFINE_FIELD( m_afButtonPressed, FIELD_INTEGER ),
 	DEFINE_FIELD( m_afButtonReleased, FIELD_INTEGER ),
+	DEFINE_PRED_FIELD( m_afButtonDisabled, FIELD_INTEGER, FTYPEDESC_INSENDTABLE ),
+	DEFINE_PRED_FIELD( m_afButtonForced, FIELD_INTEGER, FTYPEDESC_INSENDTABLE ),
 	// DEFINE_FIELD( m_vecOldViewAngles, FIELD_VECTOR ),
 
 	// DEFINE_ARRAY( m_iOldAmmo, FIELD_INTEGER,  MAX_AMMO_TYPES ),
@@ -434,6 +438,8 @@ C_BasePlayer::C_BasePlayer() : m_iv_vecViewOffset( "C_BasePlayer::m_iv_vecViewOf
 
 	m_flPredictionErrorTime = -100;
 	m_StuckLast = 0;
+	m_afButtonDisabled = 0;
+	m_afButtonForced = 0;
 	m_bWasFrozen = false;
 
 	m_bResampleWaterSurface = true;

--- a/src/game/client/c_baseplayer.h
+++ b/src/game/client/c_baseplayer.h
@@ -435,6 +435,8 @@ public:
 	int				m_afButtonLast;
 	int				m_afButtonPressed;
 	int				m_afButtonReleased;
+	int				m_afButtonDisabled;
+	int				m_afButtonForced;
 
 	int				m_nButtons;
 

--- a/src/game/client/prediction.cpp
+++ b/src/game/client/prediction.cpp
@@ -197,7 +197,6 @@ void CPrediction::CheckError( int commands_acknowledged )
 	}
 #endif
 }
-
 //-----------------------------------------------------------------------------
 // Purpose: 
 //-----------------------------------------------------------------------------
@@ -397,7 +396,6 @@ bool CPrediction::ShouldDumpEntity( C_BaseEntity *ent )
 	{
 		if ( cl_predictionentitydumpbyclass.GetString()[ 0 ] == 0 )
 			return false;
-
 		if ( !FClassnameIs( ent, cl_predictionentitydumpbyclass.GetString() ) )
 			return false;
 	}
@@ -597,7 +595,6 @@ void CPrediction::PostNetworkDataReceived( int commands_acknowledged )
 	}
 #endif
 #endif
-
 }
 
 //-----------------------------------------------------------------------------
@@ -888,10 +885,9 @@ void CPrediction::RunCommand( C_BasePlayer *player, CUserCmd *ucmd, IMoveHelper 
 	Q_snprintf( sz, sizeof( sz ), "runcommand%04d", ucmd->command_number );
 	PREDICTION_TRACKVALUECHANGESCOPE( sz );
 #endif
-	CUserCmd effectiveCmd( *ucmd );
-	effectiveCmd.buttons |= player->m_afButtonForced;
-	effectiveCmd.buttons &= ~player->m_afButtonDisabled;
-	ucmd = &effectiveCmd;
+	const int nOriginalButtons = ucmd->buttons;
+	ucmd->buttons |= player->m_afButtonForced;
+	ucmd->buttons &= ~player->m_afButtonDisabled;
 
 	StartCommand( player, ucmd );
 
@@ -976,6 +972,7 @@ void CPrediction::RunCommand( C_BasePlayer *player, CUserCmd *ucmd, IMoveHelper 
 	g_pGameMovement->FinishTrackPredictionErrors( player );
 
 	FinishCommand( player );
+	ucmd->buttons = nOriginalButtons;
 
 	if ( gpGlobals->frametime > 0 )
 	{

--- a/src/game/client/prediction.cpp
+++ b/src/game/client/prediction.cpp
@@ -888,6 +888,11 @@ void CPrediction::RunCommand( C_BasePlayer *player, CUserCmd *ucmd, IMoveHelper 
 	Q_snprintf( sz, sizeof( sz ), "runcommand%04d", ucmd->command_number );
 	PREDICTION_TRACKVALUECHANGESCOPE( sz );
 #endif
+	CUserCmd effectiveCmd( *ucmd );
+	effectiveCmd.buttons |= player->m_afButtonForced;
+	effectiveCmd.buttons &= ~player->m_afButtonDisabled;
+	ucmd = &effectiveCmd;
+
 	StartCommand( player, ucmd );
 
 	// Set globals appropriately

--- a/src/game/client/prediction.cpp
+++ b/src/game/client/prediction.cpp
@@ -197,6 +197,7 @@ void CPrediction::CheckError( int commands_acknowledged )
 	}
 #endif
 }
+
 //-----------------------------------------------------------------------------
 // Purpose: 
 //-----------------------------------------------------------------------------
@@ -396,6 +397,7 @@ bool CPrediction::ShouldDumpEntity( C_BaseEntity *ent )
 	{
 		if ( cl_predictionentitydumpbyclass.GetString()[ 0 ] == 0 )
 			return false;
+
 		if ( !FClassnameIs( ent, cl_predictionentitydumpbyclass.GetString() ) )
 			return false;
 	}
@@ -595,6 +597,7 @@ void CPrediction::PostNetworkDataReceived( int commands_acknowledged )
 	}
 #endif
 #endif
+
 }
 
 //-----------------------------------------------------------------------------

--- a/src/game/client/prediction.cpp
+++ b/src/game/client/prediction.cpp
@@ -849,7 +849,7 @@ void CPrediction::CheckMovingGround( C_BasePlayer *player, double frametime )
 	if ( player->GetFlags() & FL_ONGROUND )
 	{
 		groundentity = player->GetGroundEntity();
-		if ( groundentity && (groundentity->GetFlags() & FL_CONVEYOR) )
+		if ( groundentity && ( groundentity->GetFlags() & FL_CONVEYOR) )
 		{
 			Vector vecNewVelocity;
 			groundentity->GetGroundVelocityToApply( vecNewVelocity );
@@ -1103,7 +1103,7 @@ void CPrediction::RemoveStalePredictedEntities( int sequence_number )
 
 		// If it was ack'd then the server sent us the entity.
 		// Leave it unless it wasn't made dormant this frame, in
-		//  which case it can be removed now
+			//  which case it can be removed now
 		if ( ent->m_PredictableID.GetAcknowledged() )
 		{
 			// Hasn't become dormant yet!!!

--- a/src/game/client/prediction.cpp
+++ b/src/game/client/prediction.cpp
@@ -849,7 +849,7 @@ void CPrediction::CheckMovingGround( C_BasePlayer *player, double frametime )
 	if ( player->GetFlags() & FL_ONGROUND )
 	{
 		groundentity = player->GetGroundEntity();
-		if ( groundentity && ( groundentity->GetFlags() & FL_CONVEYOR) )
+		if ( groundentity && (groundentity->GetFlags() & FL_CONVEYOR) )
 		{
 			Vector vecNewVelocity;
 			groundentity->GetGroundVelocityToApply( vecNewVelocity );
@@ -888,7 +888,6 @@ void CPrediction::RunCommand( C_BasePlayer *player, CUserCmd *ucmd, IMoveHelper 
 	Q_snprintf( sz, sizeof( sz ), "runcommand%04d", ucmd->command_number );
 	PREDICTION_TRACKVALUECHANGESCOPE( sz );
 #endif
-	const int nOriginalButtons = ucmd->buttons;
 	ucmd->buttons |= player->m_afButtonForced;
 	ucmd->buttons &= ~player->m_afButtonDisabled;
 
@@ -975,7 +974,6 @@ void CPrediction::RunCommand( C_BasePlayer *player, CUserCmd *ucmd, IMoveHelper 
 	g_pGameMovement->FinishTrackPredictionErrors( player );
 
 	FinishCommand( player );
-	ucmd->buttons = nOriginalButtons;
 
 	if ( gpGlobals->frametime > 0 )
 	{

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -8133,6 +8133,8 @@ void CMovementSpeedMod::InputSpeedMod(inputdata_t &data)
 
 		SendPropInt			( SENDINFO( m_nTickBase ), -1, SPROP_CHANGES_OFTEN ),
 		SendPropInt			( SENDINFO( m_nNextThinkTick ) ),
+		SendPropInt			( SENDINFO( m_afButtonDisabled ), 32, SPROP_UNSIGNED ),
+		SendPropInt			( SENDINFO( m_afButtonForced ), 32, SPROP_UNSIGNED ),
 
 		SendPropEHandle		( SENDINFO( m_hLastWeapon ) ),
 		SendPropEHandle		( SENDINFO( m_hGroundEntity ), SPROP_CHANGES_OFTEN ),

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -888,8 +888,8 @@ public:
 	int						m_afButtonPressed;
 	int						m_afButtonReleased;
 	int						m_afButtonLast;
-	int						m_afButtonDisabled;	// A mask of input flags that are cleared automatically
-	int						m_afButtonForced;	// These are forced onto the player's inputs
+	CNetworkVar( int,		m_afButtonDisabled );	// A mask of input flags that are cleared automatically
+	CNetworkVar( int,		m_afButtonForced );	// These are forced onto the player's inputs
 
 	CNetworkVar( bool, m_fOnTarget );		//Is the crosshair on a target?
 


### PR DESCRIPTION
Issue:

The server can force or disable player buttons without telling the owning client. The client then predicts movement using inputs that the server changes.

Fix:

Send the button masks to the owning client and apply them to the existing prediction command context before client-side simulation.