### PR TITLE
[HL2MP] Implement crossbow FOV and zoom-state prediction and correction

### DIFF
--- a/src/game/shared/hl2mp/weapon_crossbow.cpp
+++ b/src/game/shared/hl2mp/weapon_crossbow.cpp
@@ -725,8 +725,6 @@ void CWeaponCrossbow::ToggleZoom( void )
 	if ( pPlayer == NULL )
 		return;
 
-#ifndef CLIENT_DLL
-
 	if ( m_bInZoom )
 	{
 		if ( pPlayer->SetFOV( this, 0, 0.2f ) )
@@ -741,7 +739,6 @@ void CWeaponCrossbow::ToggleZoom( void )
 			m_bInZoom = true;
 		}
 	}
-#endif
 }
 
 #define	BOLT_TIP_ATTACHMENT	2


### PR DESCRIPTION
Issue:

Crossbow zoom transitions only run on the server. Under latency, the client can briefly retain the wrong zoom state and field of view.

Fix:

Run the existing zoom transition on both the client and server while keeping the server authoritative.