### PR TITLE
[HL2MP] Fix empty-fire cooldown scheduling for .357 and crossbow

### DIFF
--- a/src/game/shared/hl2mp/weapon_357.cpp
+++ b/src/game/shared/hl2mp/weapon_357.cpp
@@ -108,7 +108,7 @@ void CWeapon357::PrimaryAttack( void )
 		else
 		{
 			WeaponSound( EMPTY );
-			m_flNextPrimaryAttack = 0.15;
+			m_flNextPrimaryAttack = gpGlobals->curtime + 0.15f;
 		}
 
 		return;

--- a/src/game/shared/hl2mp/weapon_crossbow.cpp
+++ b/src/game/shared/hl2mp/weapon_crossbow.cpp
@@ -630,7 +630,7 @@ void CWeaponCrossbow::FireBolt( void )
 		else
 		{
 			WeaponSound( EMPTY );
-			m_flNextPrimaryAttack = 0.15;
+			m_flNextPrimaryAttack = gpGlobals->curtime + 0.15f;
 		}
 
 		return;


### PR DESCRIPTION
Issue:

The .357 and crossbow set their empty-fire cooldown to a fixed map time. Once the map has been running longer than that value, holding fire repeatedly enters the empty-fire path.

Fix:

Schedule the empty-fire cooldown relative to the current time.