### PR TITLE
[ALL] Track and record water-jump velocity for prediction

### DIFF
--- a/src/game/client/c_baseplayer.cpp
+++ b/src/game/client/c_baseplayer.cpp
@@ -381,6 +381,7 @@ BEGIN_PREDICTION_DATA( C_BasePlayer )
 
 	DEFINE_FIELD( m_nButtons, FIELD_INTEGER ),
 	DEFINE_FIELD( m_flWaterJumpTime, FIELD_FLOAT ),
+	DEFINE_FIELD( m_vecWaterJumpVel, FIELD_VECTOR ),
 	DEFINE_FIELD( m_nImpulse, FIELD_INTEGER ),
 	DEFINE_FIELD( m_flStepSoundTime, FIELD_FLOAT ),
 	DEFINE_FIELD( m_flSwimSoundTime, FIELD_FLOAT ),
@@ -434,6 +435,7 @@ C_BasePlayer::C_BasePlayer() : m_iv_vecViewOffset( "C_BasePlayer::m_iv_vecViewOf
 
 	m_flPredictionErrorTime = -100;
 	m_StuckLast = 0;
+	m_vecWaterJumpVel.Init();
 	m_bWasFrozen = false;
 
 	m_bResampleWaterSurface = true;

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -609,6 +609,7 @@ CBasePlayer::CBasePlayer( )
 	m_bLagCompensation = false;
 	m_flLaggedMovementValue = 1.0f;
 	m_StuckLast = 0;
+	m_vecWaterJumpVel.Init();
 	m_impactEnergyScale = 1.0f;
 	m_fLastPlayerTalkTime = 0.0f;
 	m_fLastPlayerTalkAttemptTime = 0.0f;


### PR DESCRIPTION
Issue:

Water-jump velocity is not initialized or stored in prediction history. Replayed movement can therefore use a different velocity from the original water jump.

Fix:

Initialize and retain water-jump velocity on both the client and server.