### PR TITLE
[ALL] Predict trigger_push movement

### DIFF
--- a/src/game/client/movehelper_client.cpp
+++ b/src/game/client/movehelper_client.cpp
@@ -148,6 +148,7 @@ void C_TriggerPush::ApplyPush( C_BasePlayer *pPlayer )
 		pPlayer->SetGroundEntity( NULL );
 		Vector origin = pPlayer->GetAbsOrigin();
 		origin.z += 1.0f;
+		pPlayer->SetNetworkOrigin( origin );
 		pPlayer->SetAbsOrigin( origin );
 	}
 

--- a/src/game/client/movehelper_client.cpp
+++ b/src/game/client/movehelper_client.cpp
@@ -11,11 +11,170 @@
 #include "igamemovement.h"
 #include "engine/IEngineTrace.h"
 #include "engine/ivmodelinfo.h"
+#include "triggers_shared.h"
 
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"
 
 extern CMoveData *g_pMoveData;
+
+class C_TriggerPush : public C_BaseEntity
+{
+public:
+	DECLARE_CLASS( C_TriggerPush, C_BaseEntity );
+	DECLARE_CLIENTCLASS();
+	DECLARE_PREDICTABLE();
+
+	C_TriggerPush();
+	~C_TriggerPush();
+
+	bool ShouldPredict( void );
+	void OnDataChanged( DataUpdateType_t updateType );
+
+	static void PredictPushes( C_BasePlayer *pPlayer );
+
+private:
+	void ApplyPush( C_BasePlayer *pPlayer );
+	bool IsTouching( C_BasePlayer *pPlayer );
+
+	static CUtlVector<C_TriggerPush *> s_TriggerPushes;
+
+	Vector m_vecAbsPushDir;
+	float m_flPushSpeed;
+	int m_spawnflags;
+	bool m_bPushOnceFired;
+};
+
+CUtlVector<C_TriggerPush *> C_TriggerPush::s_TriggerPushes;
+
+IMPLEMENT_CLIENTCLASS_DT( C_TriggerPush, DT_TriggerPush, CTriggerPush )
+	RecvPropVector( RECVINFO( m_vecAbsPushDir ) ),
+	RecvPropFloat( RECVINFO( m_flPushSpeed ) ),
+	RecvPropInt( RECVINFO( m_spawnflags ) ),
+	RecvPropBool( RECVINFO( m_bPushOnceFired ) ),
+END_RECV_TABLE()
+
+BEGIN_PREDICTION_DATA( C_TriggerPush )
+	DEFINE_PRED_FIELD( m_vecAbsPushDir, FIELD_VECTOR, FTYPEDESC_INSENDTABLE | FTYPEDESC_NOERRORCHECK ),
+	DEFINE_PRED_FIELD( m_flPushSpeed, FIELD_FLOAT, FTYPEDESC_INSENDTABLE | FTYPEDESC_NOERRORCHECK ),
+	DEFINE_PRED_FIELD( m_spawnflags, FIELD_INTEGER, FTYPEDESC_INSENDTABLE | FTYPEDESC_NOERRORCHECK ),
+	DEFINE_PRED_FIELD( m_bPushOnceFired, FIELD_BOOLEAN, FTYPEDESC_INSENDTABLE ),
+END_PREDICTION_DATA()
+
+C_TriggerPush::C_TriggerPush()
+	: m_flPushSpeed( 0.0f ),
+	  m_spawnflags( 0 ),
+	  m_bPushOnceFired( false )
+{
+	m_vecAbsPushDir.Init();
+	SetPredictionEligible( true );
+}
+
+C_TriggerPush::~C_TriggerPush()
+{
+	s_TriggerPushes.FindAndRemove( this );
+}
+
+bool C_TriggerPush::ShouldPredict( void )
+{
+	return C_BasePlayer::GetLocalPlayer() != NULL && ( m_spawnflags & SF_TRIG_PUSH_ONCE ) != 0;
+}
+
+void C_TriggerPush::OnDataChanged( DataUpdateType_t updateType )
+{
+	BaseClass::OnDataChanged( updateType );
+
+	if ( updateType == DATA_UPDATE_CREATED )
+	{
+		int i = 0;
+		while ( i < s_TriggerPushes.Count() && s_TriggerPushes[i]->entindex() < entindex() )
+		{
+			++i;
+		}
+		s_TriggerPushes.InsertBefore( i, this );
+	}
+
+	if ( GetPredictable() && !ShouldPredict() )
+	{
+		ShutdownPredictable();
+	}
+}
+
+bool C_TriggerPush::IsTouching( C_BasePlayer *pPlayer )
+{
+	Ray_t ray;
+	trace_t trace;
+	ray.Init( pPlayer->GetAbsOrigin(), pPlayer->GetAbsOrigin(), pPlayer->WorldAlignMins(), pPlayer->WorldAlignMaxs() );
+	enginetrace->ClipRayToCollideable( ray, MASK_ALL, CollisionProp(), &trace );
+	return trace.startsolid;
+}
+
+void C_TriggerPush::ApplyPush( C_BasePlayer *pPlayer )
+{
+	if ( IsDormant() || !IsSolidFlagSet( FSOLID_TRIGGER ) || !IsTouching( pPlayer ) )
+		return;
+
+	if ( m_spawnflags & SF_TRIG_PUSH_ONCE )
+	{
+		if ( !GetPredictable() || m_bPushOnceFired )
+			return;
+
+		m_bPushOnceFired = true;
+		pPlayer->ApplyAbsVelocityImpulse( m_flPushSpeed * m_vecAbsPushDir );
+
+		if ( m_vecAbsPushDir.z > 0.0f )
+		{
+			pPlayer->SetGroundEntity( NULL );
+		}
+		return;
+	}
+
+	if ( pPlayer->GetMoveType() == MOVETYPE_NOCLIP || pPlayer->GetMoveType() == MOVETYPE_VPHYSICS )
+		return;
+
+#if defined( HL2_CLIENT_DLL )
+	if ( pPlayer->GetMoveType() == MOVETYPE_LADDER && !( m_spawnflags & SF_TRIG_PUSH_AFFECT_PLAYER_ON_LADDER ) )
+		return;
+#endif
+
+	Vector vecPush = m_flPushSpeed * m_vecAbsPushDir;
+	if ( pPlayer->GetFlags() & FL_BASEVELOCITY )
+	{
+		vecPush += pPlayer->GetBaseVelocity();
+	}
+
+	if ( vecPush.z > 0.0f && ( pPlayer->GetFlags() & FL_ONGROUND ) )
+	{
+		pPlayer->SetGroundEntity( NULL );
+		Vector origin = pPlayer->GetAbsOrigin();
+		origin.z += 1.0f;
+		pPlayer->SetAbsOrigin( origin );
+	}
+
+	pPlayer->SetBaseVelocity( vecPush );
+	pPlayer->AddFlag( FL_BASEVELOCITY );
+}
+
+void C_TriggerPush::PredictPushes( C_BasePlayer *pPlayer )
+{
+	if ( !pPlayer || pPlayer != C_BasePlayer::GetLocalPlayer() || !pPlayer->GetPredictable() ||
+		 !pPlayer->IsAlive() || !pPlayer->IsSolid() || pPlayer->GetMoveParent() || pPlayer->IsInAVehicle() )
+		return;
+
+	switch ( pPlayer->GetMoveType() )
+	{
+	case MOVETYPE_NONE:
+	case MOVETYPE_PUSH:
+		return;
+	default:
+		break;
+	}
+
+	for ( int i = 0; i < s_TriggerPushes.Count(); ++i )
+	{
+		s_TriggerPushes[i]->ApplyPush( pPlayer );
+	}
+}
 
 class CMoveHelperClient : public IMoveHelper
 {
@@ -155,12 +314,11 @@ void CMoveHelperClient::ProcessImpacts( void )
 	// Relink in order to build absorigin and absmin/max to reflect any changes
 	//  from prediction.  Relink will early out on SOLID_NOT
 
-	// TODO: Touch triggers on the client
-	//pPlayer->PhysicsTouchTriggers();
-
 	// Don't bother if the player ain't solid
 	if ( m_pHost->IsSolidFlagSet( FSOLID_NOT_SOLID ) )
 		return;
+
+	C_TriggerPush::PredictPushes( m_pHost );
 
 	// Save off the velocity, cause we need to temporarily reset it
 	Vector vOldLocalVel = m_pHost->GetLocalVelocity();

--- a/src/game/client/movehelper_client.cpp
+++ b/src/game/client/movehelper_client.cpp
@@ -105,8 +105,8 @@ bool C_TriggerPush::IsTouching( C_BasePlayer *pPlayer )
 	Ray_t ray;
 	trace_t trace;
 	ray.Init( pPlayer->GetAbsOrigin(), pPlayer->GetAbsOrigin(), pPlayer->WorldAlignMins(), pPlayer->WorldAlignMaxs() );
-	enginetrace->ClipRayToCollideable( ray, MASK_ALL, CollisionProp(), &trace );
-	return trace.startsolid;
+	enginetrace->ClipRayToCollideable( ray, MASK_SOLID, CollisionProp(), &trace );
+	return ( trace.contents & MASK_SOLID ) != 0;
 }
 
 void C_TriggerPush::ApplyPush( C_BasePlayer *pPlayer )

--- a/src/game/server/triggers.cpp
+++ b/src/game/server/triggers.cpp
@@ -2178,27 +2178,69 @@ class CTriggerPush : public CBaseTrigger
 {
 public:
 	DECLARE_CLASS( CTriggerPush, CBaseTrigger );
+	DECLARE_SERVERCLASS();
+
+	CTriggerPush();
 
 	void Spawn( void );
 	void Activate( void );
 	void Touch( CBaseEntity *pOther );
 	void Untouch( CBaseEntity *pOther );
+	int UpdateTransmitState( void );
+	int ShouldTransmit( const CCheckTransmitInfo *pInfo );
 
 	Vector m_vecPushDir;
+	CNetworkVector( m_vecAbsPushDir );
 
 	DECLARE_DATADESC();
 	
 	float m_flAlternateTicksFix; // Scale factor to apply to the push speed when running with alternate ticks
-	float m_flPushSpeed;
+	CNetworkVar( float, m_flPushSpeed );
+	CNetworkVar( bool, m_bPushOnceFired );
 };
 
 BEGIN_DATADESC( CTriggerPush )
 	DEFINE_KEYFIELD( m_vecPushDir, FIELD_VECTOR, "pushdir" ),
+	DEFINE_FIELD( m_vecAbsPushDir, FIELD_VECTOR ),
 	DEFINE_KEYFIELD( m_flAlternateTicksFix, FIELD_FLOAT, "alternateticksfix" ),
-	//DEFINE_FIELD( m_flPushSpeed, FIELD_FLOAT ),
+	DEFINE_FIELD( m_flPushSpeed, FIELD_FLOAT ),
+	DEFINE_FIELD( m_bPushOnceFired, FIELD_BOOLEAN ),
 END_DATADESC()
 
 LINK_ENTITY_TO_CLASS( trigger_push, CTriggerPush );
+
+IMPLEMENT_SERVERCLASS_ST( CTriggerPush, DT_TriggerPush )
+	SendPropVector( SENDINFO( m_vecAbsPushDir ), -1, SPROP_NOSCALE ),
+	SendPropFloat( SENDINFO( m_flPushSpeed ), 0, SPROP_NOSCALE ),
+	SendPropInt( SENDINFO( m_spawnflags ), 13, SPROP_UNSIGNED ),
+	SendPropBool( SENDINFO( m_bPushOnceFired ) ),
+END_SEND_TABLE()
+
+CTriggerPush::CTriggerPush()
+{
+	m_vecAbsPushDir.Init();
+	m_flPushSpeed = 0.0f;
+	m_bPushOnceFired = false;
+}
+
+
+int CTriggerPush::UpdateTransmitState()
+{
+	return SetTransmitState( FL_EDICT_FULLCHECK );
+}
+
+
+int CTriggerPush::ShouldTransmit( const CCheckTransmitInfo *pInfo )
+{
+	if ( GetMoveParent() )
+		return FL_EDICT_DONTSEND;
+
+	CBaseEntity *pRecipient = CBaseEntity::Instance( pInfo->m_pClientEnt );
+	if ( !pRecipient || !pRecipient->IsPlayer() || !PassesTriggerFilters( pRecipient ) )
+		return FL_EDICT_DONTSEND;
+
+	return FL_EDICT_ALWAYS;
+}
 
 
 //-----------------------------------------------------------------------------
@@ -2213,6 +2255,8 @@ void CTriggerPush::Spawn()
 
 	// Transform the vector into entity space
 	VectorIRotate( vecAbsDir, EntityToWorldTransform(), m_vecPushDir );
+	VectorRotate( m_vecPushDir, EntityToWorldTransform(), vecAbsDir );
+	m_vecAbsPushDir = vecAbsDir;
 
 	BaseClass::Spawn();
 
@@ -2264,10 +2308,15 @@ void CTriggerPush::Touch( CBaseEntity *pOther )
 	// Transform the push dir into global space
 	Vector vecAbsDir;
 	VectorRotate( m_vecPushDir, EntityToWorldTransform(), vecAbsDir );
+	m_vecAbsPushDir = vecAbsDir;
 
 	// Instant trigger, just transfer velocity and remove
 	if (HasSpawnFlags(SF_TRIG_PUSH_ONCE))
 	{
+		if ( m_bPushOnceFired )
+			return;
+
+		m_bPushOnceFired = true;
 		pOther->ApplyAbsVelocityImpulse( m_flPushSpeed * vecAbsDir );
 
 		if ( vecAbsDir.z > 0 )


### PR DESCRIPTION
Issue:

PR #862 fixed `FL_BASEVELOCITY` being truncated from the player flags sent to clients. However, the client still does not simulate trigger_push touches. After moving-ground prediction consumes the flag and base velocity, only the server restores them for the next command. The client then predicts subsequent commands without the push, causing repeated movement corrections. This remaining regression was documented in #2029.

Fix:

Network eligible static trigger_push entities to affected players and reproduce their pushes after predicted movement. Preserve trigger filters, enabled state, stacked base velocity, upward ground detachment, ladder behavior, alternate-tick scaling, and push-once state. Keep parented trigger_push entities server-authoritative because their movement is not command-predicted.

Before the fix:

https://github.com/user-attachments/assets/038bc9f1-4112-4ee8-a137-e4d1af6c6675

After the fix:

https://github.com/user-attachments/assets/0ab9aab6-9e83-4e09-8e94-02e02c385c71

