### PR TITLE
[HL2MP] Fix/prediction shared weapon recoil rng

### DIFF
--- a/src/game/shared/hl2mp/weapon_357.cpp
+++ b/src/game/shared/hl2mp/weapon_357.cpp
@@ -147,7 +147,7 @@ void CWeapon357::PrimaryAttack( void )
 	}
 #endif // CLIENT_DLL
 
-	pPlayer->ViewPunch( QAngle( -8, random->RandomFloat( -2, 2 ), 0 ) );
+	pPlayer->ViewPunch( QAngle( -8, SharedRandomFloat( "357punchyaw", -2, 2 ), 0 ) );
 
 	if ( !m_iClip1 && pPlayer->GetAmmoCount( m_iPrimaryAmmoType ) <= 0 )
 	{

--- a/src/game/shared/hl2mp/weapon_357.cpp
+++ b/src/game/shared/hl2mp/weapon_357.cpp
@@ -147,7 +147,7 @@ void CWeapon357::PrimaryAttack( void )
 	}
 #endif // CLIENT_DLL
 
-	pPlayer->ViewPunch( QAngle( -8, SharedRandomFloat( "357punchyaw", -2, 2 ), 0 ) );
+	pPlayer->ViewPunch( QAngle( -8, SharedRandomFloat( "CWeapon357::ViewPunchYaw", -2, 2 ), 0 ) );
 
 	if ( !m_iClip1 && pPlayer->GetAmmoCount( m_iPrimaryAmmoType ) <= 0 )
 	{

--- a/src/game/shared/hl2mp/weapon_physcannon.cpp
+++ b/src/game/shared/hl2mp/weapon_physcannon.cpp
@@ -1360,7 +1360,7 @@ void CWeaponPhysCannon::PuntVPhysics( CBaseEntity *pEntity, const Vector &vecFor
 
 #endif
 	// Add recoil
-	QAngle	recoil = QAngle( random->RandomFloat( 1.0f, 2.0f ), random->RandomFloat( -1.0f, 1.0f ), 0 );
+	QAngle	recoil = QAngle( SharedRandomFloat( "physcannonpax", 1.0f, 2.0f ), SharedRandomFloat( "physcannonpay", -1.0f, 1.0f ), 0 );
 	pOwner->ViewPunch( recoil );
 
 	//Explosion effect

--- a/src/game/shared/hl2mp/weapon_physcannon.cpp
+++ b/src/game/shared/hl2mp/weapon_physcannon.cpp
@@ -1360,7 +1360,7 @@ void CWeaponPhysCannon::PuntVPhysics( CBaseEntity *pEntity, const Vector &vecFor
 
 #endif
 	// Add recoil
-	QAngle	recoil = QAngle( SharedRandomFloat( "physcannonpax", 1.0f, 2.0f ), SharedRandomFloat( "physcannonpay", -1.0f, 1.0f ), 0 );
+	QAngle	recoil = QAngle( SharedRandomFloat( "CWeaponPhysCannon::ViewPunchPitch", 1.0f, 2.0f ), SharedRandomFloat( "CWeaponPhysCannon::ViewPunchYaw", -1.0f, 1.0f ), 0 );
 	pOwner->ViewPunch( recoil );
 
 	//Explosion effect


### PR DESCRIPTION
Issue:

The .357 and physcannon generate random view-punch components independently on the client and server while running shared predicted attack code. Their recoil state can therefore diverge and cause prediction corrections. Because `ViewPunch` is not merely a local camera effect, we cannot simply move this to being fully client-sided. This is because it changes predicted, networked player state:
```
m_Local.m_vecPunchAngleVel += angleOffset * 20;
```

Therefore, both `m_vecPunchAngle` and `m_vecPunchAngleVel` are:

- maintained authoritatively by the server
- sent to the owning client
- stored in client prediction history
- decayed during movement simulation on both sides
- used by the server when calculating aim with `EyeAngles()` + `m_vecPunchAngle`

Shooting with the current setup will always show the following:
```
[Tick 1858] 001 CPlayerLocalData::m_vecPunchAngleVel - vec[] differs (1st diff) (net -160.000000 -9.218750 0.000000 - pred -160.000000 2.080131 0.000000) delta(0.000000 11.298881 0.000000)
[Tick 1858] Full latch reset!

[Tick 2198] 001 CPlayerLocalData::m_vecPunchAngleVel - vec[] differs (1st diff) (net -160.000000 -3.625000 0.000000 - pred -160.000000 18.189096 0.000000) delta(0.000000 21.814096 0.000000)
[Tick 2198] Full latch reset!

[Tick 2667] 001 CPlayerLocalData::m_vecPunchAngleVel - vec[] differs (1st diff) (net -160.000000 -39.000000 0.000000 - pred -160.000000 17.259556 0.000000) delta(0.000000 56.259556 0.000000)
[Tick 2667] Full latch reset!
```

Fix:

Use command-seeded shared random values for their variable recoil components.

Before:

https://github.com/user-attachments/assets/e1a48c56-32b5-4ebd-a29a-a8a4fffbb055

After:

https://github.com/user-attachments/assets/19c76ca4-4907-4306-bd2e-9036d29e428b

Note that this is a complementary fix to https://github.com/ValveSoftware/source-sdk-2013/pull/954