### PR TITLE
[ALL] Predict func_conveyor player movement

### DIFF
--- a/src/game/client/c_baseentity.h
+++ b/src/game/client/c_baseentity.h
@@ -959,6 +959,7 @@ public:
 
 	void					SetGroundEntity( C_BaseEntity *ground );
 	C_BaseEntity			*GetGroundEntity( void );
+	virtual bool			GetGroundVelocityToApply( Vector &vecGroundVel ) { vecGroundVel.Init(); return false; }
 
 	void					PhysicsPushEntity( const Vector& push, trace_t *pTrace );
 	void					PhysicsCheckWaterTransition( void );

--- a/src/game/client/c_func_conveyor.cpp
+++ b/src/game/client/c_func_conveyor.cpp
@@ -28,20 +28,39 @@ public:
 	C_FuncConveyor();
 
 	float GetConveyorSpeed() { return m_flConveyorSpeed; }
+	bool GetGroundVelocityToApply( Vector &vecGroundVel );
 
 private:
 	float m_flConveyorSpeed;
+	Vector m_vecConveyorVelocity;
+	bool m_bAffectsPlayerMovement;
 };
 
 
 IMPLEMENT_CLIENTCLASS_DT( C_FuncConveyor, DT_FuncConveyor, CFuncConveyor )
 	RecvPropFloat( RECVINFO( m_flConveyorSpeed ) ),
+	RecvPropVector( RECVINFO( m_vecConveyorVelocity ) ),
+	RecvPropBool( RECVINFO( m_bAffectsPlayerMovement ) ),
 END_RECV_TABLE()
 
 
 C_FuncConveyor::C_FuncConveyor()
 {
 	m_flConveyorSpeed = 0.0;
+	m_vecConveyorVelocity.Init();
+	m_bAffectsPlayerMovement = false;
+}
+
+bool C_FuncConveyor::GetGroundVelocityToApply( Vector &vecGroundVel )
+{
+	if ( !m_bAffectsPlayerMovement )
+	{
+		vecGroundVel.Init();
+		return false;
+	}
+
+	vecGroundVel = m_vecConveyorVelocity;
+	return true;
 }
 
 

--- a/src/game/client/prediction.cpp
+++ b/src/game/client/prediction.cpp
@@ -843,16 +843,14 @@ void CPrediction::RunPostThink( C_BasePlayer *player )
 //-----------------------------------------------------------------------------
 void CPrediction::CheckMovingGround( C_BasePlayer *player, double frametime )
 {
-#if 0
 	CBaseEntity	    *groundentity;
 
 	if ( player->GetFlags() & FL_ONGROUND )
 	{
 		groundentity = player->GetGroundEntity();
-		if ( groundentity && ( groundentity->GetFlags() & FL_CONVEYOR) )
+		Vector vecNewVelocity;
+		if ( groundentity && groundentity->GetGroundVelocityToApply( vecNewVelocity ) )
 		{
-			Vector vecNewVelocity;
-			groundentity->GetGroundVelocityToApply( vecNewVelocity );
 			if ( player->GetFlags() & FL_BASEVELOCITY )
 			{
 				vecNewVelocity += player->GetBaseVelocity();
@@ -861,7 +859,6 @@ void CPrediction::CheckMovingGround( C_BasePlayer *player, double frametime )
 			player->AddFlag( FL_BASEVELOCITY );
 		}
 	}
-#endif
 
 	if ( !( player->GetFlags() & FL_BASEVELOCITY ) )
 	{

--- a/src/game/server/bmodels.cpp
+++ b/src/game/server/bmodels.cpp
@@ -273,6 +273,7 @@ public:
 	CFuncConveyor();
 
 	void	Spawn( void );
+	void	OnRestore( void ) OVERRIDE;
 	void	Use( CBaseEntity *pActivator, CBaseEntity *pCaller, USE_TYPE useType, float value );
 	void	UpdateSpeed( float flNewSpeed );
 
@@ -286,6 +287,8 @@ private:
 
 	Vector m_vecMoveDir;
 	CNetworkVar( float, m_flConveyorSpeed );
+	CNetworkVector( m_vecConveyorVelocity );
+	CNetworkVar( bool, m_bAffectsPlayerMovement );
 };
 
 LINK_ENTITY_TO_CLASS( func_conveyor, CFuncConveyor );
@@ -303,12 +306,16 @@ END_DATADESC()
 
 IMPLEMENT_SERVERCLASS_ST(CFuncConveyor, DT_FuncConveyor)
 	SendPropFloat( SENDINFO(m_flConveyorSpeed), 0, SPROP_NOSCALE ),
+	SendPropVector( SENDINFO(m_vecConveyorVelocity), -1, SPROP_NOSCALE ),
+	SendPropBool( SENDINFO(m_bAffectsPlayerMovement) ),
 END_SEND_TABLE()
 
 
 CFuncConveyor::CFuncConveyor()
 {
 	m_flConveyorSpeed = 0.0;
+	m_vecConveyorVelocity.Init();
+	m_bAffectsPlayerMovement = false;
 }
 
 void CFuncConveyor::Spawn( void )
@@ -319,8 +326,11 @@ void CFuncConveyor::Spawn( void )
 
 	BaseClass::Spawn();
 
-	if ( !HasSpawnFlags(SF_CONVEYOR_VISUAL) )
+	m_bAffectsPlayerMovement = !HasSpawnFlags( SF_CONVEYOR_VISUAL );
+	if ( m_bAffectsPlayerMovement )
 		AddFlag( FL_CONVEYOR );
+	else
+		RemoveFlag( FL_CONVEYOR );
 
 	// HACKHACK - This is to allow for some special effects
 	if ( HasSpawnFlags( SF_CONVEYOR_NOTSOLID ) )
@@ -334,10 +344,23 @@ void CFuncConveyor::Spawn( void )
 	UpdateSpeed( m_flSpeed );
 }
 
+void CFuncConveyor::OnRestore( void )
+{
+	BaseClass::OnRestore();
+	m_bAffectsPlayerMovement = !HasSpawnFlags( SF_CONVEYOR_VISUAL );
+	if ( m_bAffectsPlayerMovement )
+		AddFlag( FL_CONVEYOR );
+	else
+		RemoveFlag( FL_CONVEYOR );
+	UpdateSpeed( m_flSpeed );
+}
+
 
 void CFuncConveyor::UpdateSpeed( float flNewSpeed )
 {
+	m_flSpeed = flNewSpeed;
 	m_flConveyorSpeed = flNewSpeed;
+	m_vecConveyorVelocity = m_bAffectsPlayerMovement ? m_vecMoveDir * flNewSpeed : vec3_origin;
 }
 
 
@@ -366,7 +389,7 @@ void CFuncConveyor::InputSetSpeed( inputdata_t &inputdata )
 //-----------------------------------------------------------------------------
 void CFuncConveyor::GetGroundVelocityToApply( Vector &vecGroundVel )
 {
-	vecGroundVel = m_vecMoveDir * m_flSpeed;
+	vecGroundVel = m_vecConveyorVelocity;
 }
 
 


### PR DESCRIPTION
Issue:

While looking for some additional prediction errors, I found that the server applies `func_conveyor` velocity to grounded players in `CheckMovingGround`, while the equivalent client prediction path is disabled. The client therefore predicts movement without the conveyor's base velocity, causing movement prediction errors and server corrections.

Fix:

Network the conveyor movement state and apply its velocity during client prediction. Rebuild the conveyor state after restore and speed changes so the client and server simulate the same movement.

Before (affects accuracy of my movement here):

https://github.com/user-attachments/assets/b828302f-55d1-4568-b67d-100feabbe744

After (clearing this level much faster and smoothly now):

https://github.com/user-attachments/assets/bb1a40c8-b301-4b68-99db-99cbded34846