### PR TITLE
[HL2MP] Fix stunstick activation sounds

### DIFF
--- a/src/game/server/hl2mp/hl2mp_player.cpp
+++ b/src/game/server/hl2mp/hl2mp_player.cpp
@@ -218,6 +218,8 @@ void CHL2MP_Player::GiveAllItems( void )
 	CBasePlayer::GiveAmmo( 1,	"grenade" );
 	CBasePlayer::GiveAmmo( 2,	"slam" );
 
+	GiveNamedItem( "weapon_physcannon" );
+
 	GiveNamedItem( "weapon_crowbar" );
 	GiveNamedItem( "weapon_stunstick" );
 	GiveNamedItem( "weapon_pistol" );
@@ -234,8 +236,6 @@ void CHL2MP_Player::GiveAllItems( void )
 	GiveNamedItem( "weapon_rpg" );
 
 	GiveNamedItem( "weapon_slam" );
-
-	GiveNamedItem( "weapon_physcannon" );
 	
 }
 
@@ -249,6 +249,8 @@ void CHL2MP_Player::GiveDefaultItems( void )
 	CBasePlayer::GiveAmmo( 6,	"Buckshot");
 	CBasePlayer::GiveAmmo( 6,	"357" );
 
+	GiveNamedItem( "weapon_physcannon" );
+
 	if ( GetPlayerModelType() == PLAYER_SOUNDS_METROPOLICE || GetPlayerModelType() == PLAYER_SOUNDS_COMBINESOLDIER )
 	{
 		GiveNamedItem( "weapon_stunstick" );
@@ -261,7 +263,6 @@ void CHL2MP_Player::GiveDefaultItems( void )
 	GiveNamedItem( "weapon_pistol" );
 	GiveNamedItem( "weapon_smg1" );
 	GiveNamedItem( "weapon_frag" );
-	GiveNamedItem( "weapon_physcannon" );
 
 	const char *szDefaultWeaponName = engine->GetClientConVarValue( engine->IndexOfEdict( edict() ), "cl_defaultweapon" );
 

--- a/src/game/shared/hl2mp/weapon_stunstick.cpp
+++ b/src/game/shared/hl2mp/weapon_stunstick.cpp
@@ -175,8 +175,6 @@ IMPLEMENT_ACTTABLE(CWeaponStunStick);
 //-----------------------------------------------------------------------------
 CWeaponStunStick::CWeaponStunStick( void )
 {
-	// HACK:  Don't call SetStunState because this tried to Emit a sound before
-	//  any players are connected which is a bug
 	m_bActive = false;
 
 #ifdef CLIENT_DLL
@@ -433,12 +431,22 @@ void CWeaponStunStick::SetStunState( bool state )
 		g_pEffects->Sparks( vecAttachment );
 
 		//FIXME: END - Move to client-side
-
-		EmitSound( "Weapon_StunStick.Activate" );
 	}
-	else
+
+#ifdef CLIENT_DLL
+	// Workaround to prevent sounds from playing on other players when they leave PVS.
+	if ( GetPredictable() )
+#endif
 	{
-		EmitSound( "Weapon_StunStick.Deactivate" );
+		CBaseEntity *pEntity = GetOwner() != NULL ? GetOwnerEntity() : this;
+		const char *sound = m_bActive ? "Weapon_StunStick.Activate" : "Weapon_StunStick.Deactivate";
+
+		CPASAttenuationFilter filter( pEntity, sound );
+
+		if ( IsPredicted() && CBaseEntity::GetPredictionPlayer() )
+			filter.UsePredictionRules();
+
+		EmitSound( filter, pEntity->entindex(), sound );
 	}
 }
 


### PR DESCRIPTION
This addresses a few issues regarding the stunstick activation sounds:
* Sounds now only emit on the first prediction frame.
    * This prevents the sounds from emitting in rapid succession over several frames, noticable with high network latency.
* Sounds now emit on the correct entity (the owner if they exist, otherwise the weapon itself)
    * This makes the sounds emit correctly for other players when emitted from the server.
* Sounds no longer emit when the stunstick becomes dormant.
    * This prevents the sounds from emitting when leaving the PVS of a player with a stunstick in their inventory.
    * This is related to an issue regarding `C_BaseCombatWeapon::SetDormant` in which weapons are holstered on the client, even if they aren't currently equipped, and only for non-local players. This is probably a bug, but there would likely be consequences if it were changed, so I used a local workaround instead.

Initially these changes introduced an issue where the sounds would emit after a player spawned with the stunstick in their inventory. This was fixed by making `weapon_physcannon` the first weapon to be added in the default loadout instead of the stunstick/crowbar, causing the stunstick to not be deployed/holstered immediately.

NOTE: Please unmute the audio on the following videos before playing them.

Before:

[before.webm](https://github.com/user-attachments/assets/5fbd2053-f7e3-453f-8e99-283ed150ac53)

[before-2.webm](https://github.com/user-attachments/assets/dab55f8a-db65-476b-abda-546d9daddade)

After:

[after.webm](https://github.com/user-attachments/assets/a8981b13-dd9b-4fd4-9a77-60d447038773)

[after-2.webm](https://github.com/user-attachments/assets/666e7887-635a-42f5-880c-a3cbed7cc9c6)


