### PR TITLE
[TF2] Revert Tomislav's Firing Sounds Pitch

### DIFF
--- a/src/game/shared/tf/tf_weapon_minigun.cpp
+++ b/src/game/shared/tf/tf_weapon_minigun.cpp
@@ -1441,6 +1441,13 @@ void CTFMinigun::WeaponSoundUpdate()
 	if ( flSpeed != 1.0f )
 	{
 		flPitch = RemapValClamped( flSpeed, 1.5f, 0.5f, 80.f, 120.f );
+		// Tomislav - Fixes Tomislav's base firing sound pitch sounding lower than intended due to its base 20% slower firing speed penalty
+		if ( GetAttributeContainer()->GetItem()->GetItemDefIndex() == 424 )
+		{
+			//DevMsg( "Tomislav pitch correction: flSpeed BEFORE = %f, flPitch = %f\n", flSpeed, flPitch );
+			flPitch = RemapVal( flSpeed, 1.2f, 0.6f, 100.f, 120.f );
+			//DevMsg( "Tomislav pitch correction: flSpeed AFTER = %f, flPitch = %f\n", flSpeed, flPitch );
+		}
 	}
 
 	if ( m_bRageDraining )

--- a/src/game/shared/tf/tf_weapon_minigun.cpp
+++ b/src/game/shared/tf/tf_weapon_minigun.cpp
@@ -156,9 +156,6 @@ void CTFMinigun::WeaponReset( void )
 	m_iMinigunSoundCur = -1;
 	m_flMinigunSoundCurrentPitch = 1.0f;
 
-	m_flBasePostFireDelay = 1.0f;
-	CALL_ATTRIB_HOOK_FLOAT( m_flBasePostFireDelay, mult_postfiredelay );
-
 	StopMuzzleEffect();
 	StopBrassEffect();
 #endif
@@ -1443,16 +1440,7 @@ void CTFMinigun::WeaponSoundUpdate()
 	float flSpeed = ApplyFireDelay( 1.0f );
 	if ( flSpeed != 1.0f )
 	{
-		if ( m_flBasePostFireDelay != 1.0f )
-		{
-			// Pitch correction. Adjusts base firing sound pitch with the base firing speed.
-			// Fixes Tomislav's base firing sound pitch sounding lower than intended due to its base 20% slower firing speed penalty
-			// DevMsg( "Pitch correction: flSpeed BEFORE = %f, m_flBasePostFireDelay = %f, flPitch = %f\n", flSpeed, m_flBasePostFireDelay, flPitch );
-			flSpeed /= m_flBasePostFireDelay;
-		}
-
 		flPitch = RemapValClamped( flSpeed, 1.5f, 0.5f, 80.f, 120.f );
-		// DevMsg( "Pitch correction: flSpeed AFTER = %f, m_flBasePostFireDelay = %f, flPitch = %f\n", flSpeed, m_flBasePostFireDelay, flPitch );
 	}
 
 	if ( m_bRageDraining )

--- a/src/game/shared/tf/tf_weapon_minigun.cpp
+++ b/src/game/shared/tf/tf_weapon_minigun.cpp
@@ -1438,16 +1438,17 @@ void CTFMinigun::WeaponSoundUpdate()
 	float flPitch = 1.0f;
 
 	float flSpeed = ApplyFireDelay( 1.0f );
+
+	float flPitchScale = 1.0f;
+	CALL_ATTRIB_HOOK_FLOAT( flPitchScale, mult_minigun_pitch_scale );
+	if ( flPitchScale != 1.0f )
+	{
+		flSpeed /= ( flPitchScale );
+	}
+
 	if ( flSpeed != 1.0f )
 	{
 		flPitch = RemapValClamped( flSpeed, 1.5f, 0.5f, 80.f, 120.f );
-		// Tomislav - Fixes Tomislav's base firing sound pitch sounding lower than intended due to its base 20% slower firing speed penalty
-		if ( GetAttributeContainer()->GetItem()->GetItemDefIndex() == 424 )
-		{
-			//DevMsg( "Tomislav pitch correction: flSpeed BEFORE = %f, flPitch = %f\n", flSpeed, flPitch );
-			flPitch = RemapVal( flSpeed, 1.2f, 0.6f, 100.f, 120.f );
-			//DevMsg( "Tomislav pitch correction: flSpeed AFTER = %f, flPitch = %f\n", flSpeed, flPitch );
-		}
 	}
 
 	if ( m_bRageDraining )

--- a/src/game/shared/tf/tf_weapon_minigun.cpp
+++ b/src/game/shared/tf/tf_weapon_minigun.cpp
@@ -156,6 +156,9 @@ void CTFMinigun::WeaponReset( void )
 	m_iMinigunSoundCur = -1;
 	m_flMinigunSoundCurrentPitch = 1.0f;
 
+	m_flBasePostFireDelay = 1.0f;
+	CALL_ATTRIB_HOOK_FLOAT( m_flBasePostFireDelay, mult_postfiredelay );
+
 	StopMuzzleEffect();
 	StopBrassEffect();
 #endif
@@ -1440,7 +1443,16 @@ void CTFMinigun::WeaponSoundUpdate()
 	float flSpeed = ApplyFireDelay( 1.0f );
 	if ( flSpeed != 1.0f )
 	{
+		if ( m_flBasePostFireDelay != 1.0f )
+		{
+			// Pitch correction. Adjusts base firing sound pitch with the base firing speed.
+			// Fixes Tomislav's base firing sound pitch sounding lower than intended due to its base 20% slower firing speed penalty
+			// DevMsg( "Pitch correction: flSpeed BEFORE = %f, m_flBasePostFireDelay = %f, flPitch = %f\n", flSpeed, m_flBasePostFireDelay, flPitch );
+			flSpeed /= m_flBasePostFireDelay;
+		}
+
 		flPitch = RemapValClamped( flSpeed, 1.5f, 0.5f, 80.f, 120.f );
+		// DevMsg( "Pitch correction: flSpeed AFTER = %f, m_flBasePostFireDelay = %f, flPitch = %f\n", flSpeed, m_flBasePostFireDelay, flPitch );
 	}
 
 	if ( m_bRageDraining )

--- a/src/game/shared/tf/tf_weapon_minigun.h
+++ b/src/game/shared/tf/tf_weapon_minigun.h
@@ -167,7 +167,6 @@ private:
 	CSoundPatch		*m_pSoundCur;				// the weapon sound currently being played
 	int				m_iMinigunSoundCur;			// the enum value of the weapon sound currently being played
 	float			m_flMinigunSoundCurrentPitch;
-	float			m_flBasePostFireDelay;
 
 #ifdef GAME_DLL
 	float	m_flAegisCheckTime;

--- a/src/game/shared/tf/tf_weapon_minigun.h
+++ b/src/game/shared/tf/tf_weapon_minigun.h
@@ -167,6 +167,7 @@ private:
 	CSoundPatch		*m_pSoundCur;				// the weapon sound currently being played
 	int				m_iMinigunSoundCur;			// the enum value of the weapon sound currently being played
 	float			m_flMinigunSoundCurrentPitch;
+	float			m_flBasePostFireDelay;
 
 #ifdef GAME_DLL
 	float	m_flAegisCheckTime;


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

**_Works in Mann vs. Machine_**

## YouTube Video Explanation
(note: video shows outdated devlogs in the upper left corner of the screen, see commits instead)
[![Fixing the Tomislav's Sounds in TF2](https://img.youtube.com/vi/27k3fU-jiKs/0.jpg)](https://www.youtube.com/watch?v=27k3fU-jiKs)

# How to Fix:
See https://github.com/ValveSoftware/source-sdk-2013/pull/2046#issuecomment-5557285053 for more context. 

These must be added into items_game.txt for this PR to work. 

Make a new attribute called `mult_minigun_pitch_scale`, add it to the Tomislav's attribute fields, and set `mult_minigun_pitch_scale` value to 1.2.

_**4000 is an example attribute number, change the attribute number as needed**_

```
	"4000"
	{
		"name"	"minigun pitch scale"
		"attribute_class"	"mult_minigun_pitch_scale"
		"description_string"	"unused"
		"description_format"	"value_is_percentage"
		"hidden"	"1"
		"effect_type"	"neutral"
		"stored_as_integer"	"0"
	}
```
In the weapon_tomislav field, add "minigun pitch scale" with a value of 1.2:

```
		"weapon_tomislav"
		{
			...
			"attributes"
			{
				"minigun spinup time decreased"
				{
					"attribute_class"	"mult_minigun_spinup_time"
					"value" "0.8"
				}
				"minigun no spin sounds"
				{
					"attribute_class"	"minigun_no_spin_sounds"
					"value" "1"
				}
				"fire rate penalty"
				{
					"attribute_class"	"mult_postfiredelay"
					"value"	"1.2"
				}
				"weapon spread bonus"
				{
					"attribute_class"	"mult_spread_scale"
					"value"	"0.8"
				}
				"minigun pitch scale"
				{
					"attribute_class"	"mult_minigun_pitch_scale"
					"value" "1.2"
				}
			}
		}
```

# Description
Before the Love & War patch, the Tomislav used to have higher pitched sounds for firing and deploying. The sounds changed because the pitch ended up getting controlled by the 20% slower firing speed.

Because of this change, this makes the Tomislav's sounds in-game not in-sync with the actual ammo drain, as well as having an incorrect pitch.

For comparison, the original sounds for the Tomislav sounded like this:

[![Pre-Love and War Tomisalv Sounds](https://img.youtube.com/vi/2YgirY6n-vc/0.jpg)](https://www.youtube.com/watch?v=2YgirY6n-vc)

And for the Tomislav today:
[![Current Tomislav](https://img.youtube.com/vi/qHfbDjv2qvc/0.jpg)](https://www.youtube.com/watch?v=qHfbDjv2qvc)
Notice how the current Tomislav has a lower pitch for its deploying, firing, and stopping sounds.

I believe this is a bug because this change was undocumented (as noted in the [Official TF2 Wiki](https://wiki.teamfortress.com/wiki/June_18,_2014_Patch)), and the fact that the original sound files for the Tomislav is actually higher pitched than the sounds we currently hear in-game.

# Solution
This PR resolves this problem by correcting the pitch of the Tomislav to its intended pitch (and any other Minigun using the same mult_postfiredelay attribute as the Tomislav) while also preserving firing sound pitch adjustment when the firing speed is adjusted such as the firing speed upgrade in MvM.

This is done by setting flPitch back to 100. Previously, flPitch was set at 92.0 which resulted in sound de-synchronization with the ammo drain.

# Video Clips

**_Wearing headphones is a must!_**

## Before
Firing sounds:

https://github.com/user-attachments/assets/e54e1e3d-e363-4e96-84b5-754151989398


With MVM Firing speed upgrades:

https://github.com/user-attachments/assets/107a9044-60ad-48ef-bab1-b0fdf4e340c5


## After
Firing sounds:

https://github.com/user-attachments/assets/1f697b79-b569-4ec1-ba21-48adc992629c


With MVM Firing speed upgrades:

https://github.com/user-attachments/assets/555b0b77-073f-492a-a453-4a4ea09501cb



Fixes https://github.com/ValveSoftware/Source-1-Games/issues/4734 
Fixes https://github.com/ValveSoftware/source-sdk-2013/issues/1674