### PR TITLE
[HL2MP] Fix/prediction physcannon release state

### DIFF
--- a/src/game/shared/hl2mp/weapon_physcannon.cpp
+++ b/src/game/shared/hl2mp/weapon_physcannon.cpp
@@ -892,6 +892,8 @@ END_NETWORK_TABLE()
 
 #ifdef CLIENT_DLL
 BEGIN_PREDICTION_DATA( CWeaponPhysCannon )
+	DEFINE_PRED_FIELD( m_bActive, 		FIELD_BOOLEAN,	FTYPEDESC_INSENDTABLE ),
+	DEFINE_PRED_FIELD( m_hAttachedObject,	FIELD_EHANDLE,	FTYPEDESC_INSENDTABLE ),
 	DEFINE_PRED_FIELD( m_EffectState,	FIELD_INTEGER,	FTYPEDESC_INSENDTABLE | FTYPEDESC_NOERRORCHECK ),
 	DEFINE_PRED_FIELD( m_bOpen,			FIELD_BOOLEAN,	FTYPEDESC_INSENDTABLE | FTYPEDESC_NOERRORCHECK ),
 END_PREDICTION_DATA()
@@ -939,6 +941,8 @@ enum
 //-----------------------------------------------------------------------------
 CWeaponPhysCannon::CWeaponPhysCannon( void )
 {
+	m_bActive				= false;
+	m_hAttachedObject		= NULL;
 	m_bOpen					= false;
 	m_nChangeState			= ELEMENT_STATE_NONE;
 	m_flCheckSuppressTime	= 0.0f;
@@ -1999,12 +2003,12 @@ void CWeaponPhysCannon::UpdateObject( void )
 //-----------------------------------------------------------------------------
 void CWeaponPhysCannon::DetachObject( bool playSound, bool wasLaunched )
 {
+	if ( m_bActive == false )
+		return;
+
 #ifndef CLIENT_DLL
 	// misyl: Disable pred filtering in this server-only section.
 	CDisablePredictionFiltering disablePred;
-
-	if ( m_bActive == false )
-		return;
 
 	CHL2MP_Player *pOwner = (CHL2MP_Player *)ToBasePlayer( GetOwner() );
 	if( pOwner != NULL )
@@ -2027,10 +2031,6 @@ void CWeaponPhysCannon::DetachObject( bool playSound, bool wasLaunched )
 		pObject->SetOwnerEntity( NULL );
 	}
 
-	m_bActive = false;
-	m_hAttachedObject = NULL;
-
-	
 	if ( playSound )
 	{
 		//Play the detach sound
@@ -2038,14 +2038,18 @@ void CWeaponPhysCannon::DetachObject( bool playSound, bool wasLaunched )
 	}
 	
 #else
+	CBaseEntity *pObject = m_hAttachedObject.Get();
 
 	m_grabController.DetachEntity( wasLaunched );
 
-	if ( m_hAttachedObject )
+	if ( pObject )
 	{
-		m_hAttachedObject->VPhysicsDestroyObject();
+		pObject->VPhysicsDestroyObject();
 	}
 #endif
+
+	m_bActive = false;
+	m_hAttachedObject = NULL;
 
 	// Stop our looping sound
 	if ( GetMotorSound() )

--- a/src/game/shared/hl2mp/weapon_physcannon.cpp
+++ b/src/game/shared/hl2mp/weapon_physcannon.cpp
@@ -995,11 +995,36 @@ void CWeaponPhysCannon::OnRestore()
 //-----------------------------------------------------------------------------
 void CWeaponPhysCannon::UpdateOnRemove(void)
 {
+#ifdef CLIENT_DLL
+	ResetPredictedObject();
+#endif
 	DestroyEffects( );
 	BaseClass::UpdateOnRemove();
 }
 
 #ifdef CLIENT_DLL
+void CWeaponPhysCannon::ResetPredictedObject( void )
+{
+	CBaseEntity *pAttachedObject = m_hAttachedObject.Get();
+	CBaseEntity *pOldAttachedObject = m_hOldAttachedObject.Get();
+
+	m_grabController.DetachEntity( false );
+
+	if ( pAttachedObject )
+	{
+		pAttachedObject->VPhysicsDestroyObject();
+	}
+
+	if ( pOldAttachedObject && pOldAttachedObject != pAttachedObject )
+	{
+		pOldAttachedObject->VPhysicsDestroyObject();
+	}
+
+	m_bActive = false;
+	m_hAttachedObject = NULL;
+	m_hOldAttachedObject = NULL;
+}
+
 void CWeaponPhysCannon::OnDataChanged( DataUpdateType_t type )
 {
 	BaseClass::OnDataChanged( type );
@@ -1014,15 +1039,7 @@ void CWeaponPhysCannon::OnDataChanged( DataUpdateType_t type )
 
 	if ( GetOwner() == NULL )
 	{
-		if ( m_hAttachedObject )
-		{
-			m_hAttachedObject->VPhysicsDestroyObject();
-		}
-
-		if ( m_hOldAttachedObject )
-		{
-			m_hOldAttachedObject->VPhysicsDestroyObject();
-		}
+		ResetPredictedObject();
 	}
 
 	// Update effect state when out of parity with the server
@@ -3197,6 +3214,7 @@ void CWeaponPhysCannon::NotifyShouldTransmit( ShouldTransmitState_t state )
 
 	if ( state == SHOULDTRANSMIT_END )
 	{
+		ResetPredictedObject();
 		DoEffect( EFFECT_NONE );
 	}
 }

--- a/src/game/shared/hl2mp/weapon_physcannon.h
+++ b/src/game/shared/hl2mp/weapon_physcannon.h
@@ -420,6 +420,7 @@ protected:
 	bool			m_bOldOpen;			// Used for parity checks
 
 	void			NotifyShouldTransmit( ShouldTransmitState_t state );
+	void			ResetPredictedObject( void );
 
 #endif	// CLIENT_DLL
 


### PR DESCRIPTION
Issue:

The physcannon's active and attached-object state is networked but not recorded in prediction history. This causes a bug where the object is not fully detached from its client, resulting in stale client physics state that can survive and restore an object that should have been detached. You can see the physics object being non solid to its previous owner, and the physcannon rendering on screen when not spawned. It also causes the player to sometimes see the last place the object was dropped client-side, but is now de-synchronized with the server until they receive a full update or reconnect. `vcollide_wireframe` was turned on. Blue means server, red means client predicted.

Fix:

Initialize and predict the physcannon attachment state, clear it after client detach cleanup, and reset predicted held-object state when ownership is lost, transmission ends, or the weapon is removed.

Before:

https://github.com/user-attachments/assets/1a83bcf4-fed8-4055-a456-5f98986faf6e

After:

https://github.com/user-attachments/assets/c8c89bcc-4a7a-42cf-baeb-019cdaf790d5



