### PR TITLE
[HL2MP] Make melee cooldown prediction deterministic

### DIFF
--- a/src/game/shared/hl2mp/weapon_hl2mpbasebasebludgeon.cpp
+++ b/src/game/shared/hl2mp/weapon_hl2mpbasebasebludgeon.cpp
@@ -361,6 +361,8 @@ void CBaseHL2MPBludgeonWeapon::Swing( int bIsSecondary )
 	pOwner->SetAnimation( PLAYER_ATTACK1 );
 
 	//Setup our next attack times
-	m_flNextPrimaryAttack = gpGlobals->curtime + GetFireRate();
-	m_flNextSecondaryAttack = gpGlobals->curtime + SequenceDuration();
+	const float flNextAttack = gpGlobals->curtime + GetFireRate();
+	m_flNextPrimaryAttack = flNextAttack;
+	m_flNextSecondaryAttack = flNextAttack;
+	SetWeaponIdleTime( flNextAttack );
 }


### PR DESCRIPTION
Issue:

HL2MP melee weapons schedule their primary attack from `GetFireRate()` but their secondary attack from `SequenceDuration()`. Hit and miss animation state can differ between client prediction and the lag-compensated server, causing their attack deadlines to diverge.

Fix:

Use one `GetFireRate()` deadline for primary attack, secondary attack, and weapon idle timing.