### PR TITLE
[ALL] Enable toggle_duck on client for all games

### DIFF
--- a/src/game/client/in_main.cpp
+++ b/src/game/client/in_main.cpp
@@ -1632,10 +1632,7 @@ static ConCommand endgrenade2( "-grenade2", IN_Grenade2Up );
 static ConCommand startgrenade2( "+grenade2", IN_Grenade2Down );
 static ConCommand startattack3("+attack3", IN_Attack3Down);
 static ConCommand endattack3("-attack3", IN_Attack3Up);
-
-#ifdef TF_CLIENT_DLL
 static ConCommand toggle_duck( "toggle_duck", IN_DuckToggle );
-#endif
 
 // Xbox 360 stub commands
 static ConCommand xboxmove("xmove", IN_XboxStub);


### PR DESCRIPTION
Currently, the SDK only creates the `toggle_duck` command on the client for TF2. As a result, player duck state will not be properly predicted in any other game (e.g. HL2MP) when using `toggle_duck`.

**WARNING: DO NOT WATCH** `before.webm` **BELOW IF YOU HAVE VISUAL EPILEPSY.** It contains flashing visuals as a result of constant prediction errors in the player duck state.

[before.webm](https://github.com/user-attachments/assets/6f207661-b713-4375-bb3d-1d32494fe789)

[after.webm](https://github.com/user-attachments/assets/b5417b97-2b2c-4583-a1b3-c0e69068a005)
