### PR TITLE
[HL2MP] Modernize the chat looks

### DIFF
--- a/src/game/client/clientmode_shared.cpp
+++ b/src/game/client/clientmode_shared.cpp
@@ -37,6 +37,9 @@
 #include "hud_vote.h"
 #include "ienginevgui.h"
 #include "sourcevr/isourcevirtualreality.h"
+#ifdef HL2MP
+#include "hl2mp_gamerules.h"
+#endif
 #if defined( _X360 )
 #include "xbox/xbox_console.h"
 #endif
@@ -1110,37 +1113,79 @@ void ClientModeShared::FireGameEvent( IGameEvent *event )
 			bool bUsingCustomTeamName = false;
 #ifdef TF_CLIENT_DLL
 			C_TFTeam *pTeam = GetGlobalTFTeam( team );
-			const wchar_t *wszTeam = pTeam ? pTeam->Get_Localized_Name() : L"";
+			const wchar_t *pwszTeam = pTeam ? pTeam->Get_Localized_Name() : L"";
 			bUsingCustomTeamName = pTeam ? pTeam->IsUsingCustomTeamName() : false;
 #else
 			wchar_t wszTeam[64];
 			C_Team *pTeam = GetGlobalTeam( team );
-			if ( pTeam )
+			if ( pTeam && pTeam->Get_Name()[0] )
 			{
 				g_pVGuiLocalize->ConvertANSIToUnicode( pTeam->Get_Name(), wszTeam, sizeof(wszTeam) );
 			}
+#ifdef HL2MP
+			else if ( team == TEAM_UNASSIGNED )
+			{
+				V_wcsncpy( wszTeam, L"Unassigned", sizeof( wszTeam ) );
+			}
+			else if ( team == TEAM_SPECTATOR )
+			{
+				V_wcsncpy( wszTeam, L"Spectator", sizeof( wszTeam ) );
+			}
+			else if ( team == TEAM_COMBINE )
+			{
+				V_wcsncpy( wszTeam, L"Combine", sizeof( wszTeam ) );
+			}
+			else if ( team == TEAM_REBELS )
+			{
+				V_wcsncpy( wszTeam, L"Rebels", sizeof( wszTeam ) );
+			}
+#endif
 			else
 			{
 				_snwprintf ( wszTeam, sizeof( wszTeam ) / sizeof( wchar_t ), L"%d", team );
 			}
+
+			const wchar_t *pwszTeam = wszTeam;
+#ifdef HL2MP
+			wchar_t wszColoredTeam[80];
+			const Color *pTeamColor = NULL;
+			if ( team == TEAM_COMBINE )
+			{
+				pTeamColor = &g_ColorBlue;
+			}
+			else if ( team == TEAM_REBELS )
+			{
+				pTeamColor = &g_ColorRed;
+			}
+
+			if ( pTeamColor )
+			{
+				V_snwprintf( wszColoredTeam, ARRAYSIZE( wszColoredTeam ), L"%c%02X%02X%02X%ls%c", COLOR_HEXCODE, (unsigned int)pTeamColor->r(), (unsigned int)pTeamColor->g(), (unsigned int)pTeamColor->b(), wszTeam, COLOR_NORMAL );
+				pwszTeam = wszColoredTeam;
+			}
+#endif
 #endif
 
 			if ( !IsInCommentaryMode() )
 			{
-				wchar_t wszLocalized[100];
+				wchar_t wszLocalized[256];
 				if ( bAutoTeamed )
 				{
-					g_pVGuiLocalize->ConstructString_safe( wszLocalized, bUsingCustomTeamName ? g_pVGuiLocalize->Find( "#game_player_joined_autoteam_party_leader" ) : g_pVGuiLocalize->Find( "#game_player_joined_autoteam" ), 2, wszPlayerName, wszTeam );
+					g_pVGuiLocalize->ConstructString_safe( wszLocalized, bUsingCustomTeamName ? g_pVGuiLocalize->Find( "#game_player_joined_autoteam_party_leader" ) : g_pVGuiLocalize->Find( "#game_player_joined_autoteam" ), 2, wszPlayerName, pwszTeam );
 				}
 				else
 				{
-					g_pVGuiLocalize->ConstructString_safe( wszLocalized, bUsingCustomTeamName ? g_pVGuiLocalize->Find( "#game_player_joined_team_party_leader" ) : g_pVGuiLocalize->Find( "#game_player_joined_team" ), 2, wszPlayerName, wszTeam );
+					g_pVGuiLocalize->ConstructString_safe( wszLocalized, bUsingCustomTeamName ? g_pVGuiLocalize->Find( "#game_player_joined_team_party_leader" ) : g_pVGuiLocalize->Find( "#game_player_joined_team" ), 2, wszPlayerName, pwszTeam );
 				}
 
-				char szLocalized[100];
+				char szLocalized[256];
 				g_pVGuiLocalize->ConvertUnicodeToANSI( wszLocalized, szLocalized, sizeof(szLocalized) );
 
+#ifdef HL2MP
+				hudChat->Printf( CHAT_FILTER_TEAMCHANGE, "%c%s", COLOR_NORMAL, szLocalized );
+#else
 				hudChat->Printf( CHAT_FILTER_TEAMCHANGE, "%s", szLocalized );
+#endif
 			}
 		}
 

--- a/src/game/client/hl2mp/hl2mp_hud_chat.cpp
+++ b/src/game/client/hl2mp/hl2mp_hud_chat.cpp
@@ -7,16 +7,22 @@
 #include "cbase.h"
 #include "hl2mp_hud_chat.h"
 #include "hud_macros.h"
+#include "iclientmode.h"
 #include "text_message.h"
 #include "vguicenterprint.h"
+#include "vgui/Cursor.h"
+#include "vgui/IInput.h"
 #include "vgui/ILocalize.h"
+#include "vgui/ISurface.h"
+#include "vgui_controls/CheckButton.h"
+#include "vgui_controls/RichText.h"
+#include "vgui_controls/TextEntry.h"
 #include "c_team.h"
 #include "c_playerresource.h"
 #include "c_hl2mp_player.h"
 #include "hl2mp_gamerules.h"
 #include "ihudlcd.h"
-
-
+#include <time.h>
 
 DECLARE_HUDELEMENT( CHudChat );
 
@@ -24,6 +30,11 @@ DECLARE_HUD_MESSAGE( CHudChat, SayText );
 DECLARE_HUD_MESSAGE( CHudChat, SayText2 );
 DECLARE_HUD_MESSAGE( CHudChat, TextMsg );
 
+ConVar cl_chat_timestamps( "cl_chat_timestamps", "0", FCVAR_CLIENTDLL | FCVAR_ARCHIVE, "Show local timestamps in text chat." );
+ConVar cl_chat_window_x( "cl_chat_window_x", "-1", FCVAR_CLIENTDLL | FCVAR_ARCHIVE, "Normalized horizontal position of the chat window." );
+ConVar cl_chat_window_y( "cl_chat_window_y", "-1", FCVAR_CLIENTDLL | FCVAR_ARCHIVE, "Normalized vertical position of the chat window." );
+ConVar cl_chat_window_w( "cl_chat_window_w", "-1", FCVAR_CLIENTDLL | FCVAR_ARCHIVE, "Normalized width of the chat window." );
+ConVar cl_chat_window_h( "cl_chat_window_h", "-1", FCVAR_CLIENTDLL | FCVAR_ARCHIVE, "Normalized height of the chat window." );
 
 //=====================
 //CHudChatLine
@@ -49,7 +60,22 @@ void CHudChatInputLine::ApplySchemeSettings(vgui::IScheme *pScheme)
 
 CHudChat::CHudChat( const char *pElementName ) : BaseClass( pElementName )
 {
-	
+	m_iLastScreenWide = 0;
+	m_iLastScreenTall = 0;
+	m_bLastActive = false;
+	m_bWindowBoundsInitialized = false;
+	m_iWindowDragMode = WINDOW_DRAG_NONE;
+	m_iDragStartCursorX = 0;
+	m_iDragStartCursorY = 0;
+	m_iDragStartX = 0;
+	m_iDragStartY = 0;
+	m_iDragStartWide = 0;
+	m_iDragStartTall = 0;
+	m_iWindowMargin = 12;
+	m_iMinWindowWide = 440;
+	m_iMinWindowTall = 260;
+	m_iHeaderTall = 26;
+	m_iResizeGripSize = 7;
 }
 
 void CHudChat::CreateChatInputLine( void )
@@ -67,8 +93,43 @@ void CHudChat::CreateChatLines( void )
 void CHudChat::ApplySchemeSettings( vgui::IScheme *pScheme )
 {
 	BaseClass::ApplySchemeSettings( pScheme );
+	m_bWindowBoundsInitialized = false;
+
+	if ( m_ChatLine )
+	{
+		m_ChatLine->SetPaintBackgroundEnabled( true );
+		m_ChatLine->SetPaintBorderEnabled( true );
+	}
+	if ( m_pChatInput )
+	{
+		m_pChatInput->SetPaintBackgroundEnabled( true );
+		m_pChatInput->SetPaintBorderEnabled( true );
+	}
+	if ( GetChatHistory() )
+	{
+		GetChatHistory()->SetPaintBackgroundEnabled( true );
+		GetChatHistory()->SetPaintBorderEnabled( true );
+	}
+	if ( m_pFiltersButton )
+	{
+		m_pFiltersButton->SetText( "Filters" );
+		m_pFiltersButton->SetPaintBackgroundEnabled( true );
+		m_pFiltersButton->SetPaintBorderEnabled( true );
+	}
+	if ( m_pFilterPanel )
+	{
+		m_pFilterPanel->SetPaintBackgroundType( 2 );
+		m_pFilterPanel->SetPaintBackgroundEnabled( true );
+		m_pFilterPanel->SetPaintBorderEnabled( true );
+	}
+	UpdateLayout();
 }
 
+void CHudChat::PerformLayout( void )
+{
+	BaseClass::PerformLayout();
+	UpdateLayout();
+}
 
 void CHudChat::Init( void )
 {
@@ -86,13 +147,223 @@ void CHudChat::Reset( void )
 {
 }
 
+void CHudChat::OnTick( void )
+{
+	BaseClass::OnTick();
+
+	int screenWide, screenTall;
+	vgui::surface()->GetScreenSize( screenWide, screenTall );
+
+	const bool active = GetMessageMode() != MM_NONE;
+	if ( screenWide != m_iLastScreenWide || screenTall != m_iLastScreenTall || active != m_bLastActive )
+	{
+		if ( screenWide != m_iLastScreenWide || screenTall != m_iLastScreenTall )
+		{
+			m_bWindowBoundsInitialized = false;
+		}
+
+		m_iLastScreenWide = screenWide;
+		m_iLastScreenTall = screenTall;
+		m_bLastActive = active;
+		UpdateLayout();
+	}
+
+	if ( m_pFiltersButton )
+	{
+		m_pFiltersButton->SetVisible( active );
+	}
+}
+
+void CHudChat::StartMessageMode( int iMessageModeType )
+{
+	BaseClass::StartMessageMode( iMessageModeType );
+	UpdateMessageModePrompt();
+	UpdateLayout();
+
+	if ( GetChatHistory() )
+	{
+		int cursorX, cursorY;
+		GetChatHistory()->GetSize( cursorX, cursorY );
+		cursorX /= 2;
+		cursorY /= 2;
+		GetChatHistory()->LocalToScreen( cursorX, cursorY );
+		vgui::input()->SetCursorPos( cursorX, cursorY );
+	}
+}
+
+void CHudChat::StopMessageMode( void )
+{
+	FinishWindowDrag( true );
+	BaseClass::StopMessageMode();
+
+	if ( m_pChatInput )
+	{
+		m_pChatInput->SetVisible( false );
+	}
+
+	if ( m_pFiltersButton )
+	{
+		m_pFiltersButton->SetVisible( false );
+	}
+
+	UpdateLayout();
+}
+
+void CHudChat::OnCursorMoved( int x, int y )
+{
+	if ( m_iWindowDragMode != WINDOW_DRAG_NONE )
+	{
+		if ( !vgui::input()->IsMouseDown( MOUSE_LEFT ) )
+		{
+			FinishWindowDrag( true );
+			return;
+		}
+
+		int cursorX, cursorY;
+		vgui::input()->GetCursorPos( cursorX, cursorY );
+		const int deltaX = cursorX - m_iDragStartCursorX;
+		const int deltaY = cursorY - m_iDragStartCursorY;
+		int screenWide, screenTall;
+		vgui::surface()->GetScreenSize( screenWide, screenTall );
+
+		int left = m_iDragStartX;
+		int top = m_iDragStartY;
+		int right = m_iDragStartX + m_iDragStartWide;
+		int bottom = m_iDragStartY + m_iDragStartTall;
+
+		if ( m_iWindowDragMode == WINDOW_DRAG_MOVE )
+		{
+			left = clamp( m_iDragStartX + deltaX, m_iWindowMargin, screenWide - m_iWindowMargin - m_iDragStartWide );
+			top = clamp( m_iDragStartY + deltaY, m_iWindowMargin, screenTall - m_iWindowMargin - m_iDragStartTall );
+			right = left + m_iDragStartWide;
+			bottom = top + m_iDragStartTall;
+		}
+		else
+		{
+			if ( m_iWindowDragMode & WINDOW_DRAG_LEFT )
+				left = clamp( m_iDragStartX + deltaX, m_iWindowMargin, right - m_iMinWindowWide );
+			if ( m_iWindowDragMode & WINDOW_DRAG_RIGHT )
+				right = clamp( m_iDragStartX + m_iDragStartWide + deltaX, left + m_iMinWindowWide, screenWide - m_iWindowMargin );
+			if ( m_iWindowDragMode & WINDOW_DRAG_TOP )
+				top = clamp( m_iDragStartY + deltaY, m_iWindowMargin, bottom - m_iMinWindowTall );
+			if ( m_iWindowDragMode & WINDOW_DRAG_BOTTOM )
+				bottom = clamp( m_iDragStartY + m_iDragStartTall + deltaY, top + m_iMinWindowTall, screenTall - m_iWindowMargin );
+		}
+
+		SetBounds( left, top, right - left, bottom - top );
+		UpdateLayout();
+		Repaint();
+		return;
+	}
+
+	int cursorX, cursorY;
+	vgui::input()->GetCursorPos( cursorX, cursorY );
+	ScreenToLocal( cursorX, cursorY );
+	SetWindowCursor( GetWindowDragMode( cursorX, cursorY ) );
+	BaseClass::OnCursorMoved( x, y );
+}
+
+void CHudChat::OnMousePressed( vgui::MouseCode code )
+{
+	if ( code != MOUSE_LEFT || GetMessageMode() == MM_NONE )
+	{
+		BaseClass::OnMousePressed( code );
+		return;
+	}
+
+	int cursorX, cursorY;
+	vgui::input()->GetCursorPos( cursorX, cursorY );
+	m_iDragStartCursorX = cursorX;
+	m_iDragStartCursorY = cursorY;
+	ScreenToLocal( cursorX, cursorY );
+	m_iWindowDragMode = GetWindowDragMode( cursorX, cursorY );
+
+	if ( m_iWindowDragMode == WINDOW_DRAG_NONE )
+	{
+		BaseClass::OnMousePressed( code );
+		return;
+	}
+
+	GetBounds( m_iDragStartX, m_iDragStartY, m_iDragStartWide, m_iDragStartTall );
+	vgui::input()->SetMouseCapture( GetVPanel() );
+	SetWindowCursor( m_iWindowDragMode );
+}
+
+void CHudChat::OnMouseReleased( vgui::MouseCode code )
+{
+	if ( code == MOUSE_LEFT && m_iWindowDragMode != WINDOW_DRAG_NONE )
+	{
+		FinishWindowDrag( true );
+		return;
+	}
+
+	BaseClass::OnMouseReleased( code );
+}
+
+void CHudChat::OnMouseCaptureLost( void )
+{
+	FinishWindowDrag( false );
+	BaseClass::OnMouseCaptureLost();
+}
+
+void CHudChat::ChatPrintf( int iPlayerIndex, int iFilter, const char *fmt, ... )
+{
+	va_list marker;
+	char msg[4096];
+
+	va_start( marker, fmt );
+	Q_vsnprintf( msg, sizeof( msg ), fmt, marker );
+	va_end( marker );
+
+	char output[4096];
+	output[0] = 0;
+	const bool useFilterColor = ( iFilter & CHAT_FILTER_SERVERMSG ) != 0;
+
+	if ( useFilterColor )
+	{
+		SetCustomColor( g_ColorYellow );
+	}
+
+	if ( cl_chat_timestamps.GetBool() )
+	{
+		time_t now = time( NULL );
+		struct tm localTime;
+		bool validTime = false;
+
+#ifdef _WIN32
+		validTime = localtime_s( &localTime, &now ) == 0;
+#else
+		validTime = localtime_r( &now, &localTime ) != NULL;
+#endif
+
+		if ( validTime )
+		{
+			Q_snprintf( output, sizeof( output ), "%c[%02d:%02d] %c%s", COLOR_NORMAL, localTime.tm_hour, localTime.tm_min, useFilterColor ? COLOR_CUSTOM : COLOR_NORMAL, msg );
+		}
+	}
+
+	if ( !output[0] )
+	{
+		if ( useFilterColor )
+		{
+			Q_snprintf( output, sizeof( output ), "%c%s", COLOR_CUSTOM, msg );
+		}
+		else
+		{
+			Q_strncpy( output, msg, sizeof( output ) );
+		}
+	}
+
+	BaseClass::ChatPrintf( iPlayerIndex, iFilter, "%s", output );
+}
+
 int CHudChat::GetChatInputOffset( void )
 {
 	if ( m_pChatInput->IsVisible() )
 	{
 		return m_iFontHeight;
 	}
-	else
+
 		return 0;
 }
 
@@ -106,11 +377,204 @@ Color CHudChat::GetClientColor( int clientIndex )
 	{
 		switch ( g_PR->GetTeam( clientIndex ) )
 		{
-		case TEAM_COMBINE	: return g_ColorBlue;
-		case TEAM_REBELS	: return g_ColorRed;
-		default	: return g_ColorYellow;
+		case TEAM_COMBINE:
+			return g_ColorBlue;
+			case TEAM_REBELS:
+				return g_ColorRed;
+			default:
+				return g_ColorYellow;
+			}
 		}
-	}
 
 	return g_ColorYellow;
+}
+void CHudChat::UpdateLayout( void )
+{
+	if ( !m_pChatInput || !GetChatHistory() )
+		return;
+
+	int screenWide, screenTall;
+	vgui::surface()->GetScreenSize( screenWide, screenTall );
+
+	const float scale = MAX( 0.65f, screenTall / 1080.0f );
+	const int pad = MAX( 8, (int)( 10 * scale ) );
+	const int gap = MAX( 5, (int)( 6 * scale ) );
+	const int inputTall = MAX( 26, (int)( 32 * scale ) );
+	const int filterWide = MAX( 68, (int)( 82 * scale ) );
+	const int filterTall = MAX( 22, (int)( 26 * scale ) );
+	const int filterPad = MAX( 8, (int)( 10 * scale ) );
+	const int filterRowGap = MAX( 1, (int)( 2 * scale ) );
+	const int minFilterRowTall = MAX( 18, (int)( 20 * scale ) );
+	const int filterContentTop = filterPad;
+	const int minFilterPanelTall = filterContentTop + filterPad + filterRowGap * 5 + minFilterRowTall * 6;
+	m_iWindowMargin = MAX( 12, (int)( 22 * scale ) );
+	m_iMinWindowWide = MIN( screenWide - m_iWindowMargin * 2, (int)( 440 * scale ) );
+	m_iHeaderTall = MAX( 22, (int)( 26 * scale ) );
+	m_iResizeGripSize = MAX( 6, (int)( 7 * scale ) );
+	m_iMinWindowTall = MIN( screenTall - m_iWindowMargin * 2, MAX( (int)( 260 * scale ), m_iHeaderTall + pad + inputTall + gap * 2 + minFilterPanelTall ) );
+
+	if ( !m_bWindowBoundsInitialized )
+	{
+		RestoreWindowBounds( screenWide, screenTall, scale );
+	}
+
+	int panelWide, panelTall;
+	GetSize( panelWide, panelTall );
+
+	const bool active = GetMessageMode() != MM_NONE;
+	if ( active )
+	{
+		const int historyY = m_iHeaderTall + gap;
+		const int historyTall = panelTall - historyY - pad - inputTall - gap;
+		GetChatHistory()->SetBounds( pad, historyY, panelWide - pad * 2, MAX( 1, historyTall ) );
+		m_pChatInput->SetBounds( pad, panelTall - pad - inputTall, panelWide - pad * 2 - filterWide - gap, inputTall );
+
+		if ( m_pFiltersButton )
+		{
+			m_pFiltersButton->SetBounds( panelWide - pad - filterWide, panelTall - pad - filterTall, filterWide, filterTall );
+		}
+
+		if ( m_pFilterPanel )
+		{
+			const int filterPanelWide = MIN( panelWide - pad * 2, MAX( 210, (int)( 230 * scale ) ) );
+			const int filterPanelTall = MIN( panelTall - m_iHeaderTall - pad - inputTall - gap * 2, MAX( minFilterPanelTall, (int)( 190 * scale ) ) );
+			const int filterRowTall = MAX( minFilterRowTall, ( filterPanelTall - filterContentTop - filterPad - filterRowGap * 5 ) / 6 );
+			m_pFilterPanel->SetBounds( panelWide - pad - filterPanelWide, panelTall - pad - inputTall - gap - filterPanelTall, filterPanelWide, filterPanelTall );
+			m_pFilterPanel->SetZPos( 100 );
+
+			int filterRow = 0;
+			for ( int i = 0; i < m_pFilterPanel->GetChildCount(); ++i )
+			{
+				vgui::CheckButton *button = dynamic_cast< vgui::CheckButton * >( m_pFilterPanel->GetChild( i ) );
+				if ( !button )
+					continue;
+
+				button->SetBounds( filterPad, filterContentTop + filterRow * ( filterRowTall + filterRowGap ), filterPanelWide - filterPad * 2, filterRowTall );
+				++filterRow;
+			}
+		}
+	}
+	else
+	{
+		GetChatHistory()->SetBounds( 0, 0, panelWide, panelTall );
+	}
+}
+
+void CHudChat::RestoreWindowBounds( int screenWide, int screenTall, float scale )
+{
+	const int availableWide = MAX( 1, screenWide - m_iWindowMargin * 2 );
+	const int availableTall = MAX( 1, screenTall - m_iWindowMargin * 2 );
+	const int defaultWide = clamp( (int)( screenWide * 0.36f ), m_iMinWindowWide, MIN( availableWide, (int)( 680 * scale ) ) );
+	const int defaultTall = clamp( (int)( screenTall * 0.34f ), m_iMinWindowTall, MIN( availableTall, (int)( 380 * scale ) ) );
+	const bool hasSavedBounds = cl_chat_window_x.GetFloat() >= 0.0f && cl_chat_window_y.GetFloat() >= 0.0f && cl_chat_window_w.GetFloat() > 0.0f && cl_chat_window_h.GetFloat() > 0.0f;
+
+	int wide = defaultWide;
+	int tall = defaultTall;
+	int x = m_iWindowMargin;
+	int y = MAX( m_iWindowMargin, screenTall - tall - MAX( 82, (int)( 118 * scale ) ) );
+
+	if ( hasSavedBounds )
+	{
+		wide = clamp( (int)( screenWide * cl_chat_window_w.GetFloat() + 0.5f ), m_iMinWindowWide, availableWide );
+		tall = clamp( (int)( screenTall * cl_chat_window_h.GetFloat() + 0.5f ), m_iMinWindowTall, availableTall );
+		x = m_iWindowMargin + (int)( ( availableWide - wide ) * clamp( cl_chat_window_x.GetFloat(), 0.0f, 1.0f ) + 0.5f );
+		y = m_iWindowMargin + (int)( ( availableTall - tall ) * clamp( cl_chat_window_y.GetFloat(), 0.0f, 1.0f ) + 0.5f );
+	}
+
+	SetBounds( x, y, wide, tall );
+	m_bWindowBoundsInitialized = true;
+}
+
+void CHudChat::SaveWindowBounds( void )
+{
+	int screenWide, screenTall;
+	vgui::surface()->GetScreenSize( screenWide, screenTall );
+	int x, y, wide, tall;
+	GetBounds( x, y, wide, tall );
+	const int availableWide = MAX( 1, screenWide - m_iWindowMargin * 2 );
+	const int availableTall = MAX( 1, screenTall - m_iWindowMargin * 2 );
+	const int moveWide = MAX( 1, availableWide - wide );
+	const int moveTall = MAX( 1, availableTall - tall );
+
+	cl_chat_window_x.SetValue( clamp( (float)( x - m_iWindowMargin ) / moveWide, 0.0f, 1.0f ) );
+	cl_chat_window_y.SetValue( clamp( (float)( y - m_iWindowMargin ) / moveTall, 0.0f, 1.0f ) );
+	cl_chat_window_w.SetValue( clamp( (float)wide / screenWide, 0.0f, 1.0f ) );
+	cl_chat_window_h.SetValue( clamp( (float)tall / screenTall, 0.0f, 1.0f ) );
+}
+
+int CHudChat::GetWindowDragMode( int x, int y )
+{
+	int wide, tall;
+	GetSize( wide, tall );
+	int dragMode = WINDOW_DRAG_NONE;
+
+	if ( x < m_iResizeGripSize )
+		dragMode |= WINDOW_DRAG_LEFT;
+	else if ( x >= wide - m_iResizeGripSize )
+		dragMode |= WINDOW_DRAG_RIGHT;
+
+	if ( y < m_iResizeGripSize )
+		dragMode |= WINDOW_DRAG_TOP;
+	else if ( y >= tall - m_iResizeGripSize )
+		dragMode |= WINDOW_DRAG_BOTTOM;
+
+	if ( dragMode == WINDOW_DRAG_NONE && y < m_iHeaderTall )
+		dragMode = WINDOW_DRAG_MOVE;
+
+	return dragMode;
+}
+
+void CHudChat::SetWindowCursor( int dragMode )
+{
+	vgui::HCursor cursor = vgui::dc_arrow;
+	if ( dragMode == ( WINDOW_DRAG_LEFT | WINDOW_DRAG_TOP ) || dragMode == ( WINDOW_DRAG_RIGHT | WINDOW_DRAG_BOTTOM ) )
+		cursor = vgui::dc_sizenwse;
+	else if ( dragMode == ( WINDOW_DRAG_RIGHT | WINDOW_DRAG_TOP ) || dragMode == ( WINDOW_DRAG_LEFT | WINDOW_DRAG_BOTTOM ) )
+		cursor = vgui::dc_sizenesw;
+	else if ( dragMode & ( WINDOW_DRAG_LEFT | WINDOW_DRAG_RIGHT ) )
+		cursor = vgui::dc_sizewe;
+	else if ( dragMode & ( WINDOW_DRAG_TOP | WINDOW_DRAG_BOTTOM ) )
+		cursor = vgui::dc_sizens;
+	else if ( dragMode == WINDOW_DRAG_MOVE )
+		cursor = vgui::dc_sizeall;
+
+	SetCursor( cursor );
+}
+
+void CHudChat::FinishWindowDrag( bool releaseCapture )
+{
+	if ( m_iWindowDragMode == WINDOW_DRAG_NONE )
+		return;
+
+	m_iWindowDragMode = WINDOW_DRAG_NONE;
+	if ( releaseCapture )
+		vgui::input()->SetMouseCapture( NULL );
+	SaveWindowBounds();
+	SetWindowCursor( WINDOW_DRAG_NONE );
+
+	if ( m_pChatInput && GetMessageMode() != MM_NONE )
+		m_pChatInput->RequestFocus();
+}
+
+void CHudChat::UpdateMessageModePrompt( void )
+{
+	if ( !m_pChatInput )
+		return;
+
+	const wchar_t *prompt = NULL;
+	switch ( GetMessageMode() )
+	{
+	case MM_SAY:
+		prompt = g_pVGuiLocalize->Find( "#chat_say" );
+		m_pChatInput->SetPrompt( prompt ? prompt : L"Say :" );
+		break;
+	case MM_SAY_TEAM:
+		prompt = g_pVGuiLocalize->Find( "#chat_say_team" );
+		m_pChatInput->SetPrompt( prompt ? prompt : L"Say (TEAM) :" );
+		break;
+	case MM_SAY_PARTY:
+		prompt = g_pVGuiLocalize->Find( "#chat_say_party" );
+		m_pChatInput->SetPrompt( prompt ? prompt : L"Say (PARTY) :" );
+		break;
+	}
 }

--- a/src/game/client/hl2mp/hl2mp_hud_chat.h
+++ b/src/game/client/hl2mp/hl2mp_hud_chat.h
@@ -56,10 +56,55 @@ public:
 	virtual void	Init( void );
 	virtual void	Reset( void );
 	virtual void	ApplySchemeSettings(vgui::IScheme *pScheme);
+	virtual void PerformLayout( void );
+	virtual void OnTick( void );
+	virtual void StartMessageMode( int iMessageModeType );
+	virtual void StopMessageMode( void );
+	virtual void OnCursorMoved( int x, int y );
+	virtual void OnMousePressed( vgui::MouseCode code );
+	virtual void OnMouseReleased( vgui::MouseCode code );
+	virtual void OnMouseCaptureLost( void );
+	virtual void ChatPrintf( int iPlayerIndex, int iFilter, PRINTF_FORMAT_STRING const char *fmt, ... ) FMTFUNCTION( 4, 5 );
 
 	int				GetChatInputOffset( void );
 
 	virtual Color	GetClientColor( int clientIndex );
+
+private:
+	enum WindowDragMode
+	{
+		WINDOW_DRAG_NONE = 0,
+		WINDOW_DRAG_LEFT = 1,
+		WINDOW_DRAG_RIGHT = 2,
+		WINDOW_DRAG_TOP = 4,
+		WINDOW_DRAG_BOTTOM = 8,
+		WINDOW_DRAG_MOVE = 16
+};
+
+	void UpdateLayout( void );
+	void UpdateMessageModePrompt( void );
+	void RestoreWindowBounds( int screenWide, int screenTall, float scale );
+	void SaveWindowBounds( void );
+	int GetWindowDragMode( int x, int y );
+	void SetWindowCursor( int dragMode );
+	void FinishWindowDrag( bool releaseCapture );
+
+	int m_iLastScreenWide;
+	int m_iLastScreenTall;
+	bool m_bLastActive;
+	bool m_bWindowBoundsInitialized;
+	int m_iWindowDragMode;
+	int m_iDragStartCursorX;
+	int m_iDragStartCursorY;
+	int m_iDragStartX;
+	int m_iDragStartY;
+	int m_iDragStartWide;
+	int m_iDragStartTall;
+	int m_iWindowMargin;
+	int m_iMinWindowWide;
+	int m_iMinWindowTall;
+	int m_iHeaderTall;
+	int m_iResizeGripSize;
 };
 
 #endif	//CS_HUD_CHAT_H

--- a/src/game/client/hud_basechat.cpp
+++ b/src/game/client/hud_basechat.cpp
@@ -254,7 +254,7 @@ void CBaseHudChatLine::ApplySchemeSettings(vgui::IScheme *pScheme)
 void CBaseHudChatLine::PerformFadeout( void )
 {
 	// Flash + Extra bright when new
-	float curtime = gpGlobals->curtime;
+	float curtime = gpGlobals->realtime;
 
 	int lr = m_clrText[0];
 	int lg = m_clrText[1];
@@ -327,7 +327,7 @@ void CBaseHudChatLine::PerformFadeout( void )
 //-----------------------------------------------------------------------------
 void CBaseHudChatLine::SetExpireTime( void )
 {
-	m_flStartTime = gpGlobals->curtime;
+	m_flStartTime = gpGlobals->realtime;
 	m_flExpireTime = m_flStartTime + hud_saytext_time.GetFloat();
 	m_nCount = CBaseHudChat::m_nLineCounter++;
 }
@@ -350,7 +350,7 @@ bool CBaseHudChatLine::IsReadyToExpire( void )
 	if ( !engine->IsInGame() && !engine->IsConnected() )
 		return true;
 
-	if ( gpGlobals->curtime >= m_flExpireTime )
+	if ( gpGlobals->realtime >= m_flExpireTime )
 		return true;
 	return false;
 }
@@ -577,7 +577,12 @@ void CHudChatFilterButton::DoClick( void )
 			else
 			{
 				pChat->GetChatFilterPanel()->SetVisible( true );
+#ifdef HL2MP
+				pChat->GetChatFilterPanel()->SetZPos( 100 );
+				pChat->GetChatFilterPanel()->MoveToFront();
+#else
 				pChat->GetChatFilterPanel()->MakePopup();
+#endif
 				pChat->GetChatFilterPanel()->SetMouseInputEnabled( true );
 			}
 		}
@@ -1229,7 +1234,7 @@ void CBaseHudChat::StartMessageMode( int iMessageModeType )
 	GetChatHistory()->GetBounds( x, y, w, h );
 	vgui::input()->SetCursorPos( x + ( w/2), y + (h/2) );
 
-	m_flHistoryFadeTime = gpGlobals->curtime + CHAT_HISTORY_FADE_TIME;
+	m_flHistoryFadeTime = gpGlobals->realtime + CHAT_HISTORY_FADE_TIME;
 
 	m_pFilterPanel->SetVisible( false );
 
@@ -1266,7 +1271,7 @@ void CBaseHudChat::StopMessageMode( void )
 	//hide filter panel
 	m_pFilterPanel->SetVisible( false );
 
-	m_flHistoryFadeTime = gpGlobals->curtime + CHAT_HISTORY_FADE_TIME;
+	m_flHistoryFadeTime = gpGlobals->realtime + CHAT_HISTORY_FADE_TIME;
 
 	m_nMessageMode = MM_NONE;
 #endif
@@ -1290,7 +1295,7 @@ void CBaseHudChat::OnChatEntryStopMessageMode( void )
 
 void CBaseHudChat::FadeChatHistory( void )
 {
-	float frac = ( m_flHistoryFadeTime -  gpGlobals->curtime ) / CHAT_HISTORY_FADE_TIME;
+	float frac = ( m_flHistoryFadeTime - gpGlobals->realtime ) / CHAT_HISTORY_FADE_TIME;
 
 	int alpha = frac * CHAT_HISTORY_ALPHA;
 	alpha = clamp( alpha, 0, CHAT_HISTORY_ALPHA );

--- a/src/game/server/hl2mp/hl2mp_client.cpp
+++ b/src/game/server/hl2mp/hl2mp_client.cpp
@@ -60,7 +60,18 @@ void FinishClientPutInServer( CHL2MP_Player *pPlayer )
 
 	if ( HL2MPRules()->IsTeamplay() == true )
 	{
+		const int iTeam = pPlayer->GetTeamNumber();
+		if ( iTeam == TEAM_COMBINE || iTeam == TEAM_REBELS )
+		{
+			const Color teamColor = iTeam == TEAM_COMBINE ? COLOR_BLUE : COLOR_RED;
+			char szTeamMessage[128];
+			Q_snprintf( szTeamMessage, sizeof( szTeamMessage ), "\x01You are on team \x07%02X%02X%02X%s\x01\n", (unsigned int)teamColor.r(), (unsigned int)teamColor.g(), (unsigned int)teamColor.b(), pPlayer->GetTeam()->GetName() );
+			ClientPrint( pPlayer, HUD_PRINTTALK, szTeamMessage );
+		}
+		else
+		{
 		ClientPrint( pPlayer, HUD_PRINTTALK, "You are on team %s1\n", pPlayer->GetTeam()->GetName() );
+		}
 	}
 
 	const ConVar *hostname = cvar->FindVar( "hostname" );

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -8771,8 +8771,8 @@ void CBasePlayer::DeactivateMovementConstraint( )
 bool CBasePlayer::ArePlayerTalkMessagesAvailable( void )
 {
 	// How long since we last tried to chat?
-	float flTimeElapsedSinceLastMsg = gpGlobals->curtime - m_fLastPlayerTalkAttemptTime;
-	m_fLastPlayerTalkAttemptTime = gpGlobals->curtime;
+	float flTimeElapsedSinceLastMsg = gpGlobals->realtime - m_fLastPlayerTalkAttemptTime;
+	m_fLastPlayerTalkAttemptTime = gpGlobals->realtime;
 
 	// The max messages we can have available
 	// Tier 1 is for short-term spam
@@ -8810,7 +8810,7 @@ bool CBasePlayer::CanPlayerTalk()
 {
 	const float talk_interval = 0.66; // min time between say commands from a client
 
-	bool bRateLimitAllowed = LastTimePlayerTalked() + talk_interval < gpGlobals->curtime;
+	bool bRateLimitAllowed = LastTimePlayerTalked() + talk_interval < gpGlobals->realtime;
 
 	bool bTokenBucketLimitAllowed = ArePlayerTalkMessagesAvailable();
 

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -774,7 +774,7 @@ public:
 
 	// talk control
 	virtual bool CanPlayerTalk();
-	void	NotePlayerTalked() { m_fLastPlayerTalkTime = gpGlobals->curtime; }
+	void	NotePlayerTalked() { m_fLastPlayerTalkTime = gpGlobals->realtime; }
 	float	LastTimePlayerTalked() const { return m_fLastPlayerTalkTime; }
 	bool	ArePlayerTalkMessagesAvailable();
 


### PR DESCRIPTION
The chat in HL2MP has long been an ancient system. It uses a fixed legacy layout that does not scale cleanly, while its fade and rate-limit timers pause with simulation time. When the game is paused with `sv_pausable 1`, the chat depends on `gpGlobals->curtime`, which is, to me, wrong. It should be using `gpGlobals->realtime`, otherwise, you are stuck with a partial rendered UI, the inability to send another message beyond one due to the 0.66s second talk time delay and anti chat spam time. Also, everything is yellow and ugly.

So, let's switch it out for a sleek, modern panel that’s responsive and includes optional timestamps, all while keeping a subtle color hierarchy. Apply some team names and assign them distinct colors. Server messages remain neutral, and use the accent color for server and ConVar messages. For fading and rate limiting, move it to using `gpGlobals->realtime`. Finally, it is now possible to drag and resize the chat. This helps player move the chat where they want now rather than having to edit resource files to do just that.

End results:

https://github.com/user-attachments/assets/bded0311-441b-4f1a-8239-5b6e690c9697

<img width="1948" height="1146" alt="image" src="https://github.com/user-attachments/assets/9d615efc-8708-4feb-a390-a9d9f49e0325" />


