### PR TITLE
[HL2MP] Modernize the scoreboard

### DIFF
--- a/src/game/client/hl2mp/ui/hl2mpclientscoreboard.cpp
+++ b/src/game/client/hl2mp/ui/hl2mpclientscoreboard.cpp
@@ -6,34 +6,31 @@
 //=============================================================================//
 
 #include "cbase.h"
-#include "hud.h"
 #include "hl2mpclientscoreboard.h"
 #include "c_team.h"
 #include "c_playerresource.h"
-#include "c_hl2mp_player.h"
 #include "hl2mp_gamerules.h"
 
 #include <KeyValues.h>
+#include <tier1/strtools.h>
 
 #include <vgui/IScheme.h>
 #include <vgui/ILocalize.h>
 #include <vgui/ISurface.h>
-#include <vgui/IVGui.h>
+#include <vgui_controls/Label.h>
+#include <vgui_controls/ScrollBar.h>
 #include <vgui_controls/SectionedListPanel.h>
 
-#include "voice_status.h"
-
 using namespace vgui;
-
-#define TEAM_MAXCOUNT			5
 
 // id's of sections used in the scoreboard
 enum EScoreboardSections
 {
-	SCORESECTION_COMBINE = 1,
-	SCORESECTION_REBELS = 2,
-	SCORESECTION_FREEFORALL = 3,
-	SCORESECTION_SPECTATOR = 4
+	SCORESECTION_HEADER = 0,
+	SCORESECTION_COMBINE,
+	SCORESECTION_REBELS,
+	SCORESECTION_FREEFORALL,
+	SCORESECTION_SPECTATOR
 };
 
 const int NumSegments = 7;
@@ -48,13 +45,56 @@ static int coord[NumSegments+1] = {
 	10
 };
 
+class CHL2MPScoreboardHeader : public SectionedListPanelHeader
+{
+public:
+	CHL2MPScoreboardHeader( SectionedListPanel *parent, const char *name, int sectionID ) :
+		SectionedListPanelHeader( parent, name, sectionID )
+	{
+	}
+
+	void PerformLayout() OVERRIDE
+	{
+		SectionedListPanelHeader::PerformLayout();
+
+		int x = 0;
+		const int columnCount = m_pListPanel->GetColumnCountBySection( m_iSectionID );
+		for ( int i = 0; i < columnCount; ++i )
+		{
+			const int columnWidth = m_pListPanel->GetColumnWidthBySection( m_iSectionID, i );
+			const int columnFlags = m_pListPanel->GetColumnFlagsBySection( m_iSectionID, i );
+			IImage *image = GetImageAtIndex( i );
+
+			if ( image && ( columnFlags & SectionedListPanel::COLUMN_CENTER ) )
+			{
+				int contentWide, contentTall;
+				image->GetContentSize( contentWide, contentTall );
+				const int offset = ( columnWidth / 2 ) - ( contentWide / 2 );
+				SetImageBounds( i, x + offset, columnWidth - offset - SectionedListPanel::COLUMN_DATA_GAP );
+			}
+
+			x += columnWidth;
+		}
+	}
+};
+
 //-----------------------------------------------------------------------------
 // Purpose: Konstructor
 //-----------------------------------------------------------------------------
-CHL2MPClientScoreBoardDialog::CHL2MPClientScoreBoardDialog(IViewPort *pViewPort):CClientScoreBoardDialog(pViewPort)
+CHL2MPClientScoreBoardDialog::CHL2MPClientScoreBoardDialog( IViewPort *pViewPort ) :
+	CClientScoreBoardDialog( pViewPort ),
+	m_pServerName( NULL ),
+	m_bgColor( 18, 19, 18, 238 ),
+	m_borderColor( 92, 88, 78, 190 ),
+	m_spectatorTextColor( 148, 151, 146, 255 ),
+	m_dividerColor( 128, 128, 128, 96 )
 {
 	SetProportional( true );
 	m_bAllowGrowth = false;
+
+	m_pServerName = dynamic_cast<Label *>( FindChildByName( "ServerName" ) );
+
+	ListenForGameEvent( "server_cvar" );
 }
 
 //-----------------------------------------------------------------------------
@@ -62,6 +102,32 @@ CHL2MPClientScoreBoardDialog::CHL2MPClientScoreBoardDialog(IViewPort *pViewPort)
 //-----------------------------------------------------------------------------
 CHL2MPClientScoreBoardDialog::~CHL2MPClientScoreBoardDialog()
 {
+}
+
+void CHL2MPClientScoreBoardDialog::Update()
+{
+	BaseClass::Update();
+	UpdateMatchInfo();
+	InvalidateLayout();
+}
+
+void CHL2MPClientScoreBoardDialog::FireGameEvent( IGameEvent *event )
+{
+	if ( event && !Q_strcmp( event->GetName(), "server_cvar" ) && !Q_strcmp( event->GetString( "cvarname" ), "hostname" ) )
+	{
+		if ( !m_pServerName )
+		{
+			m_pServerName = dynamic_cast<Label *>( FindChildByName( "ServerName" ) );
+		}
+
+		if ( m_pServerName )
+		{
+			m_pServerName->SetText( event->GetString( "cvarvalue" ) );
+			m_pServerName->MoveToFront();
+		}
+	}
+
+	BaseClass::FireGameEvent( event );
 }
 
 //-----------------------------------------------------------------------------
@@ -311,19 +377,93 @@ void CHL2MPClientScoreBoardDialog::PaintBorder()
 //-----------------------------------------------------------------------------
 // Purpose: Apply scheme settings
 //-----------------------------------------------------------------------------
-void CHL2MPClientScoreBoardDialog::ApplySchemeSettings( vgui::IScheme *pScheme )
+void CHL2MPClientScoreBoardDialog::ApplySchemeSettings( IScheme *pScheme )
 {
 	BaseClass::ApplySchemeSettings( pScheme );
+	const Color classicBackground = GetSchemeColor( "SectionedListPanel.BgColor", GetBgColor(), pScheme );
 
-	m_bgColor = GetSchemeColor("SectionedListPanel.BgColor", GetBgColor(), pScheme);
+	SetBgColor( Color( 0, 0, 0, 0 ) );
+	SetBorder( pScheme->GetBorder( "BaseBorder" ) );
+	m_bgColor = classicBackground;
 	m_borderColor = pScheme->GetColor( "FgColor", Color( 0, 0, 0, 0 ) );
 
-	SetBgColor( Color(0, 0, 0, 0) );
-	SetBorder( pScheme->GetBorder( "BaseBorder" ) );
-
 	m_pPlayerList->SetProportional( true );
+	m_pPlayerList->SetBgColor( Color(0, 0, 0, 0) );
+	m_pPlayerList->SetBorder(NULL);
+
+	HFont headerFont = pScheme->GetFont( "DefaultSmall", true );
+	if ( headerFont == INVALID_FONT )
+	{
+		headerFont = pScheme->GetFont( "Default", true );
+	}
+
+	HFont rowFont = pScheme->GetFont( "Default", true );
+	HFont titleFont = pScheme->GetFont( "DefaultLarge", true );
+	if ( titleFont == INVALID_FONT )
+	{
+		titleFont = rowFont;
+	}
+
+	m_pPlayerList->SetHeaderFont( headerFont );
+	m_pPlayerList->SetRowFont( rowFont );
+
+	if ( !m_pServerName )
+	{
+		m_pServerName = dynamic_cast<Label *>( FindChildByName( "ServerName" ) );
+	}
+
+	if ( m_pServerName )
+	{
+		m_pServerName->SetFont( titleFont );
+		m_pServerName->SetFgColor( pScheme->GetColor( "FgColor", Color( 255, 255, 255, 255 ) ) );
+		m_pServerName->SetPaintBackgroundEnabled( false );
+		m_pServerName->SetContentAlignment( Label::a_west );
+	}
+
 }
 
+void CHL2MPClientScoreBoardDialog::PerformLayout()
+{
+	BaseClass::PerformLayout();
+
+	int workspaceX, workspaceY, workspaceWide, workspaceTall;
+	surface()->GetWorkspaceBounds( workspaceX, workspaceY, workspaceWide, workspaceTall );
+
+	const int targetWide = (int)( workspaceWide * 0.66f );
+	const int minimumWide = MIN( (int)( workspaceWide * 0.90f ), scheme()->GetProportionalScaledValueEx( GetScheme(), 460 ) );
+	const int maximumWide = MIN( (int)( workspaceWide * 0.70f ), (int)( workspaceTall * 1.50f ) );
+	const int panelWide = MIN( MAX( targetWide, minimumWide ), maximumWide );
+
+	const int horizontalPadding = scheme()->GetProportionalScaledValueEx( GetScheme(), 12 );
+	const int topPadding = scheme()->GetProportionalScaledValueEx( GetScheme(), 12 );
+	const int titleTall = scheme()->GetProportionalScaledValueEx( GetScheme(), 20 );
+	const int titleGap = scheme()->GetProportionalScaledValueEx( GetScheme(), 2 );
+	const int bottomPadding = scheme()->GetProportionalScaledValueEx( GetScheme(), 10 );
+	const int listTop = topPadding + titleTall + titleGap;
+	const int listWide = panelWide - horizontalPadding * 2;
+	const int maximumPanelTall = (int)( workspaceTall * 0.88f );
+	const int maximumListTall = MAX( scheme()->GetProportionalScaledValueEx( GetScheme(), 80 ), maximumPanelTall - listTop - bottomPadding );
+
+	if ( m_pServerName )
+	{
+		m_pServerName->SetBounds( horizontalPadding, topPadding, listWide, titleTall );
+		m_pServerName->MoveToFront();
+	}
+
+	m_pPlayerList->SetBounds( horizontalPadding, listTop, listWide, maximumListTall );
+	UpdateColumnWidths( listWide );
+
+	int contentWide, contentTall;
+	m_pPlayerList->GetContentSize( contentWide, contentTall );
+
+	const int minimumListTall = scheme()->GetProportionalScaledValueEx( GetScheme(), 80 );
+	const int listTall = MIN( MAX( contentTall, minimumListTall ), maximumListTall );
+	const int panelTall = listTop + listTall + bottomPadding;
+
+	SetSize( panelWide, panelTall );
+	m_pPlayerList->SetBounds( horizontalPadding, listTop, listWide, listTall );
+	SetPos( workspaceX + ( workspaceWide - panelWide ) / 2, workspaceY + ( workspaceTall - panelTall ) / 2 );
+}
 
 //-----------------------------------------------------------------------------
 // Purpose: sets up base sections
@@ -332,21 +472,41 @@ void CHL2MPClientScoreBoardDialog::InitScoreboardSections()
 {
 	m_pPlayerList->SetBgColor( Color(0, 0, 0, 0) );
 	m_pPlayerList->SetBorder(NULL);
+	m_pPlayerList->ClearSelection();
 
 	// fill out the structure of the scoreboard
 	AddHeader();
+	AddSection( TYPE_TEAM, TEAM_COMBINE );
+	AddSection( TYPE_TEAM, TEAM_REBELS );
+	AddSection( TYPE_TEAM, TEAM_UNASSIGNED );
+	AddSection( TYPE_SPECTATORS, TEAM_SPECTATOR );
+}
 
-	if ( HL2MPRules()->IsTeamplay() )
+void CHL2MPClientScoreBoardDialog::SetSectionHeader( int teamNumber, const wchar_t *teamName, int playerCount, int score, bool showScore )
+{
+	const int sectionID = GetSectionFromTeamNumber( teamNumber );
+	wchar_t sectionText[256];
+	V_snwprintf( sectionText, ARRAYSIZE( sectionText ), L"%ls  \x2022  %d", teamName, playerCount );
+
+	m_pPlayerList->ModifyColumn( sectionID, "name", sectionText );
+	if ( teamNumber == TEAM_SPECTATOR )
 	{
-		// add the team sections
-		AddSection( TYPE_TEAM, TEAM_COMBINE );
-		AddSection( TYPE_TEAM, TEAM_REBELS );
+		return;
+	}
+
+	m_pPlayerList->ModifyColumn( sectionID, "deaths", L"" );
+	m_pPlayerList->ModifyColumn( sectionID, "ping", L"" );
+
+	if ( showScore )
+	{
+		wchar_t scoreText[16];
+		V_snwprintf( scoreText, ARRAYSIZE( scoreText ), L"%d", score );
+		m_pPlayerList->ModifyColumn( sectionID, "frags", scoreText );
 	}
 	else
 	{
-		AddSection( TYPE_TEAM, TEAM_UNASSIGNED );
+		m_pPlayerList->ModifyColumn( sectionID, "frags", L"" );
 	}
-	AddSection( TYPE_TEAM, TEAM_SPECTATOR );
 }
 
 //-----------------------------------------------------------------------------
@@ -354,93 +514,69 @@ void CHL2MPClientScoreBoardDialog::InitScoreboardSections()
 //-----------------------------------------------------------------------------
 void CHL2MPClientScoreBoardDialog::UpdateTeamInfo()
 {
-	if ( g_PR == NULL )
-		return;
-
-	int iNumPlayersInGame = 0;
-
-	for ( int j = 1; j <= gpGlobals->maxClients; j++ )
-	{	
-		if ( g_PR->IsConnected( j ) )
-		{
-			iNumPlayersInGame++;
-		}
-	}
-
-	// update the team sections in the scoreboard
-	for ( int i = TEAM_SPECTATOR; i < TEAM_MAXCOUNT; i++ )
+	if ( !g_PR )
 	{
-		wchar_t *teamName = NULL;
-		int sectionID = 0;
-		C_Team *team = GetGlobalTeam(i);
+		return;
+	}
 
-		if ( team )
+	int activePlayers = 0;
+	int spectatorPlayers = 0;
+
+	for ( int playerIndex = 1; playerIndex <= gpGlobals->maxClients; ++playerIndex )
+	{
+		if ( !g_PR->IsConnected( playerIndex ) )
 		{
-			sectionID = GetSectionFromTeamNumber( i );
-	
-			// update team name
-			wchar_t name[64];
-			wchar_t string1[1024];
-			wchar_t wNumPlayers[6];
+			continue;
+		}
 
-			if ( HL2MPRules()->IsTeamplay() == false )
-			{
-				_snwprintf( wNumPlayers, ARRAYSIZE(wNumPlayers), L"%i", iNumPlayersInGame );
-#ifdef WIN32
-				_snwprintf( name, ARRAYSIZE(name), L"%s", g_pVGuiLocalize->Find("#ScoreBoard_Deathmatch") );
-#else
-				_snwprintf( name, ARRAYSIZE(name), L"%S", g_pVGuiLocalize->Find("#ScoreBoard_Deathmatch") );
-#endif
-				
-				teamName = name;
-
-				if ( iNumPlayersInGame == 1)
-				{
-					g_pVGuiLocalize->ConstructString( string1, sizeof(string1), g_pVGuiLocalize->Find("#ScoreBoard_Player"), 2, teamName, wNumPlayers );
-				}
-				else
-				{
-					g_pVGuiLocalize->ConstructString( string1, sizeof(string1), g_pVGuiLocalize->Find("#ScoreBoard_Players"), 2, teamName, wNumPlayers );
-				}
-			}
-			else
-			{
-				_snwprintf(wNumPlayers, ARRAYSIZE(wNumPlayers), L"%i", team->Get_Number_Players());
-
-				if (!teamName && team)
-				{
-					g_pVGuiLocalize->ConvertANSIToUnicode(team->Get_Name(), name, sizeof(name));
-					teamName = name;
-				}
-
-				if (team->Get_Number_Players() == 1)
-				{
-					g_pVGuiLocalize->ConstructString( string1, sizeof(string1), g_pVGuiLocalize->Find("#ScoreBoard_Player"), 2, teamName, wNumPlayers );
-				}
-				else
-				{
-					g_pVGuiLocalize->ConstructString( string1, sizeof(string1), g_pVGuiLocalize->Find("#ScoreBoard_Players"), 2, teamName, wNumPlayers );
-				}
-
-				// update stats
-				wchar_t val[6];
-				V_snwprintf(val, ARRAYSIZE(val), L"%d", team->Get_Score());
-				m_pPlayerList->ModifyColumn(sectionID, "frags", val);
-				if (team->Get_Ping() < 1)
-				{
-					m_pPlayerList->ModifyColumn(sectionID, "ping", L"");
-				}
-				else
-				{
-					V_snwprintf(val, ARRAYSIZE(val), L"%d", team->Get_Ping());
-					m_pPlayerList->ModifyColumn(sectionID, "ping", val);
-				}
-
-			}
-		
-			m_pPlayerList->ModifyColumn(sectionID, "name", string1);
+		if ( g_PR->GetTeam( playerIndex ) == TEAM_SPECTATOR )
+		{
+			++spectatorPlayers;
+		}
+		else
+		{
+			++activePlayers;
 		}
 	}
+
+	if ( HL2MPRules()->IsTeamplay() )
+	{
+		for ( int teamNumber = TEAM_COMBINE; teamNumber <= TEAM_REBELS; ++teamNumber )
+		{
+			C_Team *team = GetGlobalTeam( teamNumber );
+			if ( !team )
+			{
+				continue;
+			}
+
+			wchar_t teamName[64];
+			g_pVGuiLocalize->ConvertANSIToUnicode( team->Get_Name(), teamName, sizeof( teamName ) );
+			SetSectionHeader( teamNumber, teamName, team->Get_Number_Players(), team->Get_Score(), true );
+		}
+	}
+	else
+	{
+		const wchar_t *deathmatchName = g_pVGuiLocalize->Find( "#ScoreBoard_Deathmatch" );
+		wchar_t fallbackName[64];
+		if ( !deathmatchName )
+		{
+			g_pVGuiLocalize->ConvertANSIToUnicode( "Deathmatch", fallbackName, sizeof( fallbackName ) );
+			deathmatchName = fallbackName;
+		}
+		SetSectionHeader( TEAM_UNASSIGNED, deathmatchName, activePlayers, 0, false );
+	}
+
+	C_Team *spectatorTeam = GetGlobalTeam( TEAM_SPECTATOR );
+	wchar_t spectatorName[64];
+	if ( spectatorTeam )
+	{
+		g_pVGuiLocalize->ConvertANSIToUnicode( spectatorTeam->Get_Name(), spectatorName, sizeof( spectatorName ) );
+	}
+	else
+	{
+		g_pVGuiLocalize->ConvertANSIToUnicode( "Spectators", spectatorName, sizeof( spectatorName ) );
+	}
+	SetSectionHeader( TEAM_SPECTATOR, spectatorName, spectatorPlayers, 0, false );
 }
 
 //-----------------------------------------------------------------------------
@@ -448,16 +584,20 @@ void CHL2MPClientScoreBoardDialog::UpdateTeamInfo()
 //-----------------------------------------------------------------------------
 void CHL2MPClientScoreBoardDialog::AddHeader()
 {
-	// add the top header
-	m_pPlayerList->AddSection(0, "");
-	m_pPlayerList->SetSectionAlwaysVisible(0);
-	m_pPlayerList->AddColumnToSection(0, "avatar", "", 0, m_iAvatarWidth * 2 );
-	m_pPlayerList->AddColumnToSection(0, "name", "", 0, scheme()->GetProportionalScaledValueEx( GetScheme(), CSTRIKE_NAME_WIDTH ) - ( m_iAvatarWidth * 2 ) );
-	m_pPlayerList->AddColumnToSection(0, "frags", "#PlayerScore", 0 | SectionedListPanel::COLUMN_RIGHT, scheme()->GetProportionalScaledValueEx( GetScheme(), CSTRIKE_SCORE_WIDTH ) );
-	m_pPlayerList->AddColumnToSection(0, "deaths", "#PlayerDeath", 0 | SectionedListPanel::COLUMN_RIGHT, scheme()->GetProportionalScaledValueEx( GetScheme(), CSTRIKE_DEATH_WIDTH ) );
-	m_pPlayerList->AddColumnToSection(0, "ping", "#PlayerPing", 0 | SectionedListPanel::COLUMN_RIGHT, scheme()->GetProportionalScaledValueEx( GetScheme(), CSTRIKE_PING_WIDTH ) );
-//	m_pPlayerList->AddColumnToSection(0, "voice", "#PlayerVoice", SectionedListPanel::COLUMN_IMAGE | SectionedListPanel::HEADER_TEXT| SectionedListPanel::COLUMN_CENTER, scheme()->GetProportionalScaledValueEx( GetScheme(), CSTRIKE_VOICE_WIDTH ) );
-//	m_pPlayerList->AddColumnToSection(0, "tracker", "#PlayerTracker", SectionedListPanel::COLUMN_IMAGE | SectionedListPanel::HEADER_TEXT, scheme()->GetProportionalScaledValueEx( GetScheme(), CSTRIKE_FRIENDS_WIDTH ) );
+	const int timeWide = scheme()->GetProportionalScaledValueEx( GetScheme(), 80 );
+	const int infoWide = MAX( 0, scheme()->GetProportionalScaledValueEx( GetScheme(), SCOREBOARD_NAME_WIDTH ) - timeWide );
+	m_pPlayerList->AddSection( SCORESECTION_HEADER, new CHL2MPScoreboardHeader( m_pPlayerList, "", SCORESECTION_HEADER ) );
+	m_pPlayerList->SetSectionAlwaysVisible( SCORESECTION_HEADER );
+	m_pPlayerList->SetSectionFgColor( SCORESECTION_HEADER, scheme()->GetIScheme( GetScheme() )->GetColor( "FgColor", Color( 255, 255, 255, 255 ) ) );
+	m_pPlayerList->SetSectionDividerColor( SCORESECTION_HEADER, m_dividerColor );
+	m_pPlayerList->SetSectionDrawDividerBar( SCORESECTION_HEADER, true );
+
+	m_pPlayerList->AddColumnToSection( SCORESECTION_HEADER, "info", "", SectionedListPanel::COLUMN_BRIGHT, infoWide );
+	m_pPlayerList->AddColumnToSection( SCORESECTION_HEADER, "time", "", SectionedListPanel::COLUMN_BRIGHT | SectionedListPanel::COLUMN_CENTER, timeWide );
+	m_pPlayerList->AddColumnToSection( SCORESECTION_HEADER, "timepad", L" ", 0, 0 );
+	m_pPlayerList->AddColumnToSection( SCORESECTION_HEADER, "frags", "#PlayerScore", SectionedListPanel::COLUMN_BRIGHT | SectionedListPanel::COLUMN_CENTER, scheme()->GetProportionalScaledValueEx( GetScheme(), SCOREBOARD_SCORE_WIDTH ) );
+	m_pPlayerList->AddColumnToSection( SCORESECTION_HEADER, "deaths", "#PlayerDeath", SectionedListPanel::COLUMN_BRIGHT | SectionedListPanel::COLUMN_CENTER, scheme()->GetProportionalScaledValueEx( GetScheme(), SCOREBOARD_DEATH_WIDTH ) );
+	m_pPlayerList->AddColumnToSection( SCORESECTION_HEADER, "ping", "#PlayerPing", SectionedListPanel::COLUMN_BRIGHT | SectionedListPanel::COLUMN_CENTER, scheme()->GetProportionalScaledValueEx( GetScheme(), SCOREBOARD_PING_WIDTH ) );
 }
 
 //-----------------------------------------------------------------------------
@@ -465,40 +605,42 @@ void CHL2MPClientScoreBoardDialog::AddHeader()
 //-----------------------------------------------------------------------------
 void CHL2MPClientScoreBoardDialog::AddSection(int teamType, int teamNumber)
 {
-	int sectionID = GetSectionFromTeamNumber( teamNumber );
-	if ( teamType == TYPE_TEAM )
+	const int sectionID = GetSectionFromTeamNumber( teamNumber );
+	m_pPlayerList->AddSection( sectionID, new CHL2MPScoreboardHeader( m_pPlayerList, "", sectionID ), StaticPlayerSortFunc );
+	m_pPlayerList->SetSectionDrawDividerBar( sectionID, true );
+
+	if ( teamType == TYPE_SPECTATORS )
 	{
- 		m_pPlayerList->AddSection(sectionID, "", StaticPlayerSortFunc);
-
-		// setup the columns
-		if ( ShowAvatars() )
-		{
-			m_pPlayerList->AddColumnToSection( sectionID, "avatar", "", SectionedListPanel::COLUMN_IMAGE, ( m_iAvatarWidth * 2 ) );
-		}
-
-		m_pPlayerList->AddColumnToSection(sectionID, "name", "", 0, scheme()->GetProportionalScaledValueEx( GetScheme(), CSTRIKE_NAME_WIDTH ) - ( m_iAvatarWidth * 2 ) );
-		m_pPlayerList->AddColumnToSection(sectionID, "frags", "", SectionedListPanel::COLUMN_RIGHT, scheme()->GetProportionalScaledValueEx( GetScheme(), CSTRIKE_SCORE_WIDTH ) );
-		m_pPlayerList->AddColumnToSection(sectionID, "deaths", "", SectionedListPanel::COLUMN_RIGHT, scheme()->GetProportionalScaledValueEx( GetScheme(), CSTRIKE_DEATH_WIDTH ) );
-		m_pPlayerList->AddColumnToSection(sectionID, "ping", "", SectionedListPanel::COLUMN_RIGHT, scheme()->GetProportionalScaledValueEx( GetScheme(), CSTRIKE_PING_WIDTH ) );
-
-		// set the section to have the team color
-		if ( teamNumber )
-		{
-			if ( GameResources() )
-				m_pPlayerList->SetSectionFgColor(sectionID,  GameResources()->GetTeamColor(teamNumber));
-		}
-
-		m_pPlayerList->SetSectionAlwaysVisible(sectionID);
+		m_pPlayerList->AddColumnToSection( sectionID, "name", "", 0, scheme()->GetProportionalScaledValueEx( GetScheme(), SCOREBOARD_NAME_WIDTH ) );
+		m_pPlayerList->SetSectionFgColor( sectionID, m_spectatorTextColor );
+		m_pPlayerList->SetSectionDividerColor( sectionID, m_dividerColor );
+		m_pPlayerList->SetSectionAlwaysVisible( sectionID, false );
+		return;
 	}
-	else if ( teamType == TYPE_SPECTATORS )
+
+	if ( ShowAvatars() )
 	{
-		m_pPlayerList->AddSection(sectionID, "");
-		if ( ShowAvatars() )
-		{
-			m_pPlayerList->AddColumnToSection( sectionID, "avatar", "", SectionedListPanel::COLUMN_IMAGE | SectionedListPanel::COLUMN_RIGHT, ( m_iAvatarWidth * 2 ) );
-		}
-		m_pPlayerList->AddColumnToSection(sectionID, "name", "#Spectators", 0, scheme()->GetProportionalScaledValueEx( GetScheme(), CSTRIKE_NAME_WIDTH ) - ( m_iAvatarWidth * 2 ) );
+		m_pPlayerList->AddColumnToSection( sectionID, "avatar", "", SectionedListPanel::COLUMN_IMAGE, m_iAvatarWidth * 2 );
 	}
+
+	m_pPlayerList->AddColumnToSection( sectionID, "name", "", 0, scheme()->GetProportionalScaledValueEx( GetScheme(), SCOREBOARD_NAME_WIDTH ) );
+	m_pPlayerList->AddColumnToSection( sectionID, "frags", "", SectionedListPanel::COLUMN_CENTER, scheme()->GetProportionalScaledValueEx( GetScheme(), SCOREBOARD_SCORE_WIDTH ) );
+	m_pPlayerList->AddColumnToSection( sectionID, "deaths", "", SectionedListPanel::COLUMN_CENTER, scheme()->GetProportionalScaledValueEx( GetScheme(), SCOREBOARD_DEATH_WIDTH ) );
+	m_pPlayerList->AddColumnToSection( sectionID, "ping", "", SectionedListPanel::COLUMN_CENTER, scheme()->GetProportionalScaledValueEx( GetScheme(), SCOREBOARD_PING_WIDTH ) );
+
+	IGameResources *resources = GameResources();
+	const Color sectionColor = resources ? resources->GetTeamColor( teamNumber ) : scheme()->GetIScheme( GetScheme() )->GetColor( "FgColor", Color( 255, 255, 255, 255 ) );
+	m_pPlayerList->SetSectionFgColor( sectionID, sectionColor );
+	if ( teamNumber == TEAM_COMBINE || teamNumber == TEAM_REBELS )
+	{
+		m_pPlayerList->SetSectionDividerColor( sectionID, Color( sectionColor.r(), sectionColor.g(), sectionColor.b(), m_dividerColor.a() ) );
+	}
+	else
+	{
+		m_pPlayerList->SetSectionDividerColor( sectionID, m_dividerColor );
+	}
+
+	m_pPlayerList->SetSectionAlwaysVisible( sectionID, false );
 }
 
 int CHL2MPClientScoreBoardDialog::GetSectionFromTeamNumber( int teamNumber )
@@ -514,7 +656,6 @@ int CHL2MPClientScoreBoardDialog::GetSectionFromTeamNumber( int teamNumber )
 	default:
 		return SCORESECTION_FREEFORALL;
 	}
-	return SCORESECTION_FREEFORALL;
 }
 
 //-----------------------------------------------------------------------------
@@ -527,70 +668,17 @@ bool CHL2MPClientScoreBoardDialog::GetPlayerScoreInfo(int playerIndex, KeyValues
 	kv->SetString("name", g_PR->GetPlayerName(playerIndex) );
 	kv->SetInt("deaths", g_PR->GetDeaths( playerIndex ));
 	kv->SetInt("frags", g_PR->GetPlayerScore( playerIndex ));
-	
+
 	if (g_PR->GetPing( playerIndex ) < 1)
 	{
-		if ( g_PR->IsFakePlayer( playerIndex ) )
-		{
-			kv->SetString("ping", "BOT");
-		}
-		else
-		{
-			kv->SetString("ping", "");
-		}
+		kv->SetString( "ping", g_PR->IsFakePlayer( playerIndex ) ? "BOT" : "" );
 	}
 	else
 	{
 		kv->SetInt("ping", g_PR->GetPing( playerIndex ));
 	}
-	
+
 	return true;
-}
-
-enum {
-	MAX_PLAYERS_PER_TEAM = 16,
-	MAX_SCOREBOARD_PLAYERS = 32
-};
-struct PlayerScoreInfo
-{
-	int index;
-	int frags;
-	int deaths;
-	bool important;
-	bool alive;
-};
-
-int PlayerScoreInfoSort( const PlayerScoreInfo *p1, const PlayerScoreInfo *p2 )
-{
-	// check local
-	if ( p1->important )
-		return -1;
-	if ( p2->important )
-		return 1;
-
-	// check alive
-	if ( p1->alive && !p2->alive )
-		return -1;
-	if ( p2->alive && !p1->alive )
-		return 1;
-
-	// check frags
-	if ( p1->frags > p2->frags )
-		return -1;
-	if ( p2->frags > p1->frags )
-		return 1;
-
-	// check deaths
-	if ( p1->deaths < p2->deaths )
-		return -1;
-	if ( p2->deaths < p1->deaths )
-		return 1;
-
-	// check index
-	if ( p1->index < p2->index )
-		return -1;
-
-	return 1;
 }
 
 //-----------------------------------------------------------------------------
@@ -598,64 +686,210 @@ int PlayerScoreInfoSort( const PlayerScoreInfo *p1, const PlayerScoreInfo *p2 )
 //-----------------------------------------------------------------------------
 void CHL2MPClientScoreBoardDialog::UpdatePlayerInfo()
 {
-	m_iSectionId = 0; // 0'th row is a header
-	int selectedRow = -1;
-	int i;
-
-	CBasePlayer *pPlayer = C_BasePlayer::GetLocalPlayer();
-
-	if ( !pPlayer || !g_PR )
-		return;
-
-	// walk all the players and make sure they're in the scoreboard
-	for ( i = 1; i <= gpGlobals->maxClients; i++ )
+	CBasePlayer *localPlayer = C_BasePlayer::GetLocalPlayer();
+	if ( !localPlayer || !g_PR )
 	{
-		bool shouldShow = g_PR->IsConnected( i );
-		if ( shouldShow )
+		return;
+	}
+
+	m_pPlayerList->ClearSelection();
+	int selectedRow = -1;
+
+	const bool teamplay = HL2MPRules() && HL2MPRules()->IsTeamplay();
+	IGameResources *resources = GameResources();
+
+	for ( int playerIndex = 1; playerIndex <= gpGlobals->maxClients; ++playerIndex )
+	{
+		if ( !g_PR->IsConnected( playerIndex ) )
 		{
-			// add the player to the list
-			KeyValues *playerData = new KeyValues("data");
-			GetPlayerScoreInfo( i, playerData );
-			UpdatePlayerAvatar( i, playerData );
-			int itemID = FindItemIDForPlayerIndex( i );
-  			int sectionID = GetSectionFromTeamNumber( g_PR->GetTeam( i ) );
-						
-			if (itemID == -1)
+			const int itemID = FindItemIDForPlayerIndex( playerIndex );
+			if ( itemID != -1 )
 			{
-				// add a new row
-				itemID = m_pPlayerList->AddItem( sectionID, playerData );
+				m_pPlayerList->RemoveItem( itemID );
 			}
-			else
-			{
-				// modify the current row
-				m_pPlayerList->ModifyItem( itemID, sectionID, playerData );
-			}
+			continue;
+		}
 
-			if ( i == pPlayer->entindex() )
-			{
-				selectedRow = itemID;	// this is the local player, hilight this row
-			}
+		KeyValues *playerData = new KeyValues( "data" );
+		GetPlayerScoreInfo( playerIndex, playerData );
 
-			// set the row color based on the players team
-			m_pPlayerList->SetItemFgColor( itemID, g_PR->GetTeamColor( g_PR->GetTeam( i ) ) );
+		const bool spectator = g_PR->GetTeam( playerIndex ) == TEAM_SPECTATOR;
+		if ( !spectator )
+		{
+			UpdatePlayerAvatar( playerIndex, playerData );
+		}
 
-			playerData->deleteThis();
+		int itemID = FindItemIDForPlayerIndex( playerIndex );
+		const int sectionID = GetSectionFromTeamNumber( g_PR->GetTeam( playerIndex ) );
+
+		if ( itemID == -1 )
+		{
+			itemID = m_pPlayerList->AddItem( sectionID, playerData );
 		}
 		else
 		{
-			// remove the player
-			int itemID = FindItemIDForPlayerIndex( i );
-			if (itemID != -1)
-			{
-				m_pPlayerList->RemoveItem(itemID);
-			}
+			m_pPlayerList->ModifyItem( itemID, sectionID, playerData );
 		}
+
+		Color playerColor = spectator ? m_spectatorTextColor : scheme()->GetIScheme( GetScheme() )->GetColor( "FgColor", Color( 255, 255, 255, 255 ) );
+		if ( !spectator && resources )
+		{
+			playerColor = resources->GetTeamColor( teamplay ? g_PR->GetTeam( playerIndex ) : TEAM_UNASSIGNED );
+		}
+
+		m_pPlayerList->SetItemFgColor( itemID, playerColor );
+		m_pPlayerList->SetItemBgColor( itemID, Color( 0, 0, 0, 0 ) );
+		if ( playerIndex == localPlayer->entindex() )
+		{
+			selectedRow = itemID;
+		}
+		playerData->deleteThis();
 	}
 
 	if ( selectedRow != -1 )
 	{
-		m_pPlayerList->SetSelectedItem(selectedRow);
+		m_pPlayerList->SetSelectedItem( selectedRow );
+	}
+}
+
+int CHL2MPClientScoreBoardDialog::GetConnectedPlayerCount() const
+{
+	if ( !g_PR )
+	{
+		return 0;
 	}
 
-	
+	int playerCount = 0;
+	for ( int playerIndex = 1; playerIndex <= gpGlobals->maxClients; ++playerIndex )
+	{
+		if ( g_PR->IsConnected( playerIndex ) )
+		{
+			++playerCount;
+		}
+	}
+	return playerCount;
+}
+
+void CHL2MPClientScoreBoardDialog::UpdateMatchInfo()
+{
+	wchar_t mapName[128];
+	char shortLevelName[MAX_PATH] = "-";
+	const char *levelName = engine->GetLevelName();
+	if ( levelName && levelName[0] )
+	{
+		V_FileBase( levelName, shortLevelName, sizeof( shortLevelName ) );
+	}
+	g_pVGuiLocalize->ConvertANSIToUnicode( shortLevelName, mapName, sizeof( mapName ) );
+
+	const bool teamplay = HL2MPRules() && HL2MPRules()->IsTeamplay();
+	const wchar_t *modeName = g_pVGuiLocalize->Find( teamplay ? "#ScoreBoard_TeamDeathmatch" : "#ScoreBoard_Deathmatch" );
+	wchar_t fallbackMode[64];
+	if ( !modeName )
+	{
+		g_pVGuiLocalize->ConvertANSIToUnicode( teamplay ? "Team Deathmatch" : "Deathmatch", fallbackMode, sizeof( fallbackMode ) );
+		modeName = fallbackMode;
+	}
+
+	wchar_t timeValue[16];
+	static ConVarRef mpTimeLimit( "mp_timelimit" );
+	if ( mpTimeLimit.IsValid() && mpTimeLimit.GetFloat() > 0.0f )
+	{
+		const float remainingTime = HL2MPRules() ? MAX( 0.0f, HL2MPRules()->GetMapRemainingTime() ) : 0.0f;
+		int remainingSeconds = (int)remainingTime;
+		if ( (float)remainingSeconds < remainingTime )
+		{
+			++remainingSeconds;
+		}
+		if ( remainingSeconds >= 3600 )
+		{
+			V_snwprintf( timeValue, ARRAYSIZE( timeValue ), L"%02d:%02d:%02d", remainingSeconds / 3600, remainingSeconds / 60 % 60, remainingSeconds % 60 );
+		}
+		else
+		{
+			V_snwprintf( timeValue, ARRAYSIZE( timeValue ), L"%02d:%02d", remainingSeconds / 60, remainingSeconds % 60 );
+		}
+	}
+	else
+	{
+		V_wcsncpy( timeValue, L"--:--", sizeof( timeValue ) );
+	}
+
+	wchar_t fragLimitText[64];
+	static ConVarRef fragLimit( "mp_fraglimit" );
+	if ( fragLimit.IsValid() && fragLimit.GetInt() > 0 )
+	{
+		V_snwprintf( fragLimitText, ARRAYSIZE( fragLimitText ), L"Frag limit %d", fragLimit.GetInt() );
+	}
+	else
+	{
+		V_wcsncpy( fragLimitText, L"No frag limit", sizeof( fragLimitText ) );
+	}
+
+	wchar_t matchInfo[512];
+	V_snwprintf(
+		matchInfo,
+		ARRAYSIZE( matchInfo ),
+		L"%ls  \x2022  %ls  \x2022  %d/%d  \x2022  %ls",
+		mapName,
+		modeName,
+		GetConnectedPlayerCount(),
+		gpGlobals->maxClients,
+		fragLimitText );
+	m_pPlayerList->ModifyColumn( SCORESECTION_HEADER, "info", matchInfo );
+	m_pPlayerList->ModifyColumn( SCORESECTION_HEADER, "time", timeValue );
+}
+
+void CHL2MPClientScoreBoardDialog::UpdateColumnWidths( int listWide )
+{
+	const int scoreWide = scheme()->GetProportionalScaledValueEx( GetScheme(), SCOREBOARD_SCORE_WIDTH );
+	const int deathWide = scheme()->GetProportionalScaledValueEx( GetScheme(), SCOREBOARD_DEATH_WIDTH );
+	const int pingWide = scheme()->GetProportionalScaledValueEx( GetScheme(), SCOREBOARD_PING_WIDTH );
+	const int avatarWide = ShowAvatars() ? m_iAvatarWidth * 2 : 0;
+	ScrollBar *scrollBar = m_pPlayerList->GetScrollBar();
+	const int scrollWide = scrollBar && scrollBar->IsVisible() ? scrollBar->GetWide() : 0;
+	const int columnAreaWide = MAX( 0, listWide - 10 - scrollWide );
+	const int nameWide = MAX( scheme()->GetProportionalScaledValueEx( GetScheme(), 180 ), columnAreaWide - avatarWide - scoreWide - deathWide - pingWide );
+	int timeTextWide, timeTextTall;
+	surface()->GetTextSize( m_pPlayerList->GetHeaderFont(), L"00:00:00", timeTextWide, timeTextTall );
+	const wchar_t *timeText = m_pPlayerList->GetColumnTextBySection( SCORESECTION_HEADER, 1 );
+	if ( timeText && timeText[0] )
+	{
+		int currentTimeWide, currentTimeTall;
+		surface()->GetTextSize( m_pPlayerList->GetHeaderFont(), timeText, currentTimeWide, currentTimeTall );
+		timeTextWide = MAX( timeTextWide, currentTimeWide );
+	}
+	const int identityWide = avatarWide + nameWide;
+	const int timeWide = MIN( identityWide, timeTextWide + scheme()->GetProportionalScaledValueEx( GetScheme(), 12 ) );
+	const int infoWide = MIN( identityWide - timeWide, MAX( 0, columnAreaWide / 2 - timeWide / 2 ) );
+	const int timePadWide = identityWide - infoWide - timeWide;
+
+	m_pPlayerList->SetColumnWidthBySection( SCORESECTION_HEADER, "info", infoWide );
+	m_pPlayerList->SetColumnWidthBySection( SCORESECTION_HEADER, "time", timeWide );
+	m_pPlayerList->SetColumnWidthBySection( SCORESECTION_HEADER, "timepad", timePadWide );
+	m_pPlayerList->SetColumnWidthBySection( SCORESECTION_HEADER, "frags", scoreWide );
+	m_pPlayerList->SetColumnWidthBySection( SCORESECTION_HEADER, "deaths", deathWide );
+	m_pPlayerList->SetColumnWidthBySection( SCORESECTION_HEADER, "ping", pingWide );
+
+	const int activeSections[] =
+	{
+		SCORESECTION_COMBINE,
+		SCORESECTION_REBELS,
+		SCORESECTION_FREEFORALL
+	};
+
+	for ( int i = 0; i < ARRAYSIZE( activeSections ); ++i )
+	{
+		const int sectionID = activeSections[i];
+		if ( ShowAvatars() )
+		{
+			m_pPlayerList->SetColumnWidthBySection( sectionID, "avatar", avatarWide );
+		}
+		m_pPlayerList->SetColumnWidthBySection( sectionID, "name", nameWide );
+		m_pPlayerList->SetColumnWidthBySection( sectionID, "frags", scoreWide );
+		m_pPlayerList->SetColumnWidthBySection( sectionID, "deaths", deathWide );
+		m_pPlayerList->SetColumnWidthBySection( sectionID, "ping", pingWide );
+	}
+
+	m_pPlayerList->SetColumnWidthBySection( SCORESECTION_SPECTATOR, "name", columnAreaWide );
+	m_pPlayerList->InvalidateLayout();
 }

--- a/src/game/client/hl2mp/ui/hl2mpclientscoreboard.h
+++ b/src/game/client/hl2mp/ui/hl2mpclientscoreboard.h
@@ -13,6 +13,11 @@
 
 #include <clientscoreboarddialog.h>
 
+namespace vgui
+{
+class Label;
+}
+
 //-----------------------------------------------------------------------------
 // Purpose: Game ScoreBoard
 //-----------------------------------------------------------------------------
@@ -20,44 +25,50 @@ class CHL2MPClientScoreBoardDialog : public CClientScoreBoardDialog
 {
 private:
 	DECLARE_CLASS_SIMPLE(CHL2MPClientScoreBoardDialog, CClientScoreBoardDialog);
-	
+
 public:
 	CHL2MPClientScoreBoardDialog(IViewPort *pViewPort);
-	~CHL2MPClientScoreBoardDialog();
+	~CHL2MPClientScoreBoardDialog() OVERRIDE;
 
+	void Update() OVERRIDE;
+	void FireGameEvent( IGameEvent *event ) OVERRIDE;
 
 protected:
 	// scoreboard overrides
-	virtual void InitScoreboardSections();
-	virtual void UpdateTeamInfo();
-	virtual bool GetPlayerScoreInfo(int playerIndex, KeyValues *outPlayerInfo);
-	virtual void UpdatePlayerInfo();
+	void InitScoreboardSections() OVERRIDE;
+	void UpdateTeamInfo() OVERRIDE;
+	bool GetPlayerScoreInfo( int playerIndex, KeyValues *outPlayerInfo ) OVERRIDE;
+	void UpdatePlayerInfo() OVERRIDE;
 
 	// vgui overrides for rounded corner background
-	virtual void PaintBackground();
-	virtual void PaintBorder();
-	virtual void ApplySchemeSettings( vgui::IScheme *pScheme );
+	void PaintBackground() OVERRIDE;
+	void PaintBorder() OVERRIDE;
+	void ApplySchemeSettings( vgui::IScheme *pScheme ) OVERRIDE;
+	void PerformLayout() OVERRIDE;
 
 private:
-	virtual void AddHeader(); // add the start header of the scoreboard
-	virtual void AddSection(int teamType, int teamNumber); // add a new section header for a team
-
+	void AddHeader() OVERRIDE; // add the start header of the scoreboard
+	void AddSection( int teamType, int teamNumber ) OVERRIDE; // add a new section header for a team
 	int GetSectionFromTeamNumber( int teamNumber );
+	void SetSectionHeader( int teamNumber, const wchar_t *teamName, int playerCount, int score, bool showScore );
+	void UpdateMatchInfo();
+	void UpdateColumnWidths( int listWide );
+	int GetConnectedPlayerCount() const;
+
 	enum 
 	{ 
-		CSTRIKE_NAME_WIDTH = 320,
-		CSTRIKE_CLASS_WIDTH = 56,
-		CSTRIKE_SCORE_WIDTH = 40,
-		CSTRIKE_DEATH_WIDTH = 46,
-		CSTRIKE_PING_WIDTH = 46,
-//		CSTRIKE_VOICE_WIDTH = 40, 
-//		CSTRIKE_FRIENDS_WIDTH = 24,
+		SCOREBOARD_NAME_WIDTH = 320,
+		SCOREBOARD_SCORE_WIDTH = 52,
+		SCOREBOARD_DEATH_WIDTH = 58,
+		SCOREBOARD_PING_WIDTH = 54,
 	};
 
+	vgui::Label *m_pServerName;
 	// rounded corners
-	Color					 m_bgColor;
+	Color m_bgColor;
 	Color					 m_borderColor;
+	Color m_spectatorTextColor;
+	Color m_dividerColor;
 };
-
 
 #endif // CHL2MPCLIENTSCOREBOARDDIALOG_H

--- a/src/game/server/hl2mp/hl2mp_cvars.cpp
+++ b/src/game/server/hl2mp/hl2mp_cvars.cpp
@@ -7,8 +7,47 @@
 
 #include "cbase.h"
 #include "hl2mp_cvars.h"
+#include "igamesystem.h"
 
+static void HL2MPHostnameChanged( IConVar *pConVar, const char *, float )
+{
+	if ( Q_strcmp( pConVar->GetName(), "hostname" ) )
+	{
+		return;
+	}
 
+	ConVarRef hostname( pConVar );
+	IGameEvent *event = gameeventmanager->CreateEvent( "server_cvar" );
+	if ( !event )
+	{
+		return;
+	}
+
+	event->SetString( "cvarname", "hostname" );
+	event->SetString( "cvarvalue", hostname.GetString() );
+	gameeventmanager->FireEvent( event );
+}
+
+class CHL2MPHostnameNotifier : public CAutoGameSystem
+{
+public:
+	CHL2MPHostnameNotifier() : CAutoGameSystem( "CHL2MPHostnameNotifier" )
+	{
+	}
+
+	bool Init() OVERRIDE
+	{
+		cvar->InstallGlobalChangeCallback( HL2MPHostnameChanged );
+		return true;
+	}
+
+	void Shutdown() OVERRIDE
+	{
+		cvar->RemoveGlobalChangeCallback( HL2MPHostnameChanged );
+	}
+};
+
+static CHL2MPHostnameNotifier g_HL2MPHostnameNotifier;
 
 // Ready restart
 ConVar mp_readyrestart(


### PR DESCRIPTION
The scoreboard was updated ever so slightly for the anniversary update, but I think so much more could have been done to make it better. I tried to modernize the scoreboard a bit by having it responsive, adjusting its size dynamically based on the number of players, and added some additional server information containing current map, mode, player-count, frag-limit, and time information. The hostname also updates immediately when it is changed by the server op. Spectators are now shown as a dim entry.

<img width="1920" height="1080" alt="20260905220404_1" src="https://github.com/user-attachments/assets/04dd6a10-11f6-44e6-a6ec-9db054557629" />

<img width="1920" height="1080" alt="20260905220430_1" src="https://github.com/user-attachments/assets/a46b720a-9e5f-4496-920f-99324591be91" />
