### PR TITLE
[HL2MP] Modernize the spectator HUD

### DIFF
--- a/src/game/client/c_basecombatweapon.cpp
+++ b/src/game/client/c_basecombatweapon.cpp
@@ -132,29 +132,33 @@ void C_BaseCombatWeapon::OnDataChanged( DataUpdateType_t updateType )
 	// find the registered weapon for this ID
 
 	C_BasePlayer *pPlayer = C_BasePlayer::GetLocalPlayer();
+	C_BasePlayer *pHudPlayer = GetHudPlayer();
 	C_BaseCombatCharacter *pOwner = GetOwner();
 
 	// check if weapon is carried by local player
 	bool bIsLocalPlayer = pPlayer && pPlayer == pOwner;
-	if ( bIsLocalPlayer && ShouldDrawLocalPlayerViewModel() )		// TODO: figure out the purpose of the ShouldDrawLocalPlayer() test.
+	bool bDrawsLocalViewModel = bIsLocalPlayer && ShouldDrawLocalPlayerViewModel(); // TODO: figure out the purpose of the ShouldDrawLocalPlayer() test.
+	bool bReportPickup = bDrawsLocalViewModel;
+#ifdef HL2MP
+	bReportPickup = bReportPickup || ( pPlayer && pPlayer->IsObserver() && pHudPlayer && pHudPlayer == pOwner );
+#endif
+	if ( bReportPickup &&
+		(m_iState != WEAPON_NOT_CARRIED ) && (m_iOldState == WEAPON_NOT_CARRIED) && ShouldDrawPickup() )
 	{
-		// If I was just picked up, or created & immediately carried, add myself to this client's list of weapons
-		if ( (m_iState != WEAPON_NOT_CARRIED ) && (m_iOldState == WEAPON_NOT_CARRIED) )
+		CHudHistoryResource *pHudHistory = GET_HUDELEMENT( CHudHistoryResource );
+		if ( pHudHistory && pHudHistory->IsTrackingPlayer( pHudPlayer ) )
 		{
 			// Tell the HUD this weapon's been picked up
-			if ( ShouldDrawPickup() )
-			{
-				CBaseHudWeaponSelection *pHudSelection = GetHudWeaponSelection();
-				if ( pHudSelection )
-				{
-					pHudSelection->OnWeaponPickup( this );
-				}
-
-				pPlayer->EmitSound( "Player.PickupWeapon" );
-			}
+			CBaseHudWeaponSelection *pHudSelection = GetHudWeaponSelection();
+			if ( pHudSelection )
+				pHudSelection->OnWeaponPickup( this );
 		}
+
+		if ( bDrawsLocalViewModel )
+			pPlayer->EmitSound( "Player.PickupWeapon" );
 	}
-	else // weapon carried by other player or not at all
+
+	if ( !bDrawsLocalViewModel )
 	{
 		int overrideModelIndex = CalcOverrideModelIndex();
 		if( overrideModelIndex != -1 && overrideModelIndex != GetModelIndex() )

--- a/src/game/client/c_baseplayer.cpp
+++ b/src/game/client/c_baseplayer.cpp
@@ -230,6 +230,10 @@ END_RECV_TABLE()
 		RecvPropFloat		( RECVINFO(m_flFriction) ),
 
 		RecvPropArray3		( RECVINFO_ARRAY(m_iAmmo), RecvPropInt( RECVINFO(m_iAmmo[0])) ),
+
+#ifdef HL2MP
+		RecvPropInt			( RECVINFO_NAME(m_iArmorValue, m_ArmorValue) ),
+#endif
 		
 		RecvPropInt			( RECVINFO(m_fOnTarget) ),
 
@@ -417,6 +421,10 @@ LINK_ENTITY_TO_CLASS( player, C_BasePlayer );
 // -------------------------------------------------------------------------------- //
 C_BasePlayer::C_BasePlayer() : m_iv_vecViewOffset( "C_BasePlayer::m_iv_vecViewOffset" )
 {
+#ifdef HL2MP
+	m_iArmorValue = 0;
+#endif
+
 	AddVar( &m_vecViewOffset, &m_iv_vecViewOffset, LATCH_SIMULATION_VAR );
 
 	AddVar( &m_Local.m_vecPunchAngle, &m_Local.m_iv_vecPunchAngle, LATCH_SIMULATION_VAR );
@@ -1008,6 +1016,14 @@ void C_BasePlayer::OnRestore()
 	}
 }
 
+void C_BasePlayer::ResetHudAmmoHistory( void )
+{
+	for ( int i = 0; i < MAX_AMMO_TYPES; ++i )
+	{
+		m_iOldAmmo[i] = GetAmmoCount( i );
+	}
+}
+
 //-----------------------------------------------------------------------------
 // Purpose: Process incoming data
 //-----------------------------------------------------------------------------
@@ -1022,12 +1038,10 @@ void C_BasePlayer::OnDataChanged( DataUpdateType_t updateType )
 
 	BaseClass::OnDataChanged( updateType );
 
-	// Only care about this for local player
-	if ( IsLocalPlayer() )
+	C_BasePlayer *pHudPlayer = GetHudPlayer();
+	CHudHistoryResource *pHudHR = GET_HUDELEMENT( CHudHistoryResource );
+	if ( this == pHudPlayer && pHudHR && pHudHR->IsTrackingPlayer( this ) )
 	{
-		// Reset engine areabits pointer
-		render->SetAreaState( m_Local.m_chAreaBits, m_Local.m_chAreaPortalBits );
-
 		// Check for Ammo pickups.
 		for ( int i = 0; i < MAX_AMMO_TYPES; i++ )
 		{
@@ -1039,14 +1053,16 @@ void C_BasePlayer::OnDataChanged( DataUpdateType_t updateType )
 				if ( !pWeaponData || !( pWeaponData->iFlags & ITEM_FLAG_NOAMMOPICKUPS ) )
 				{
 					// We got more ammo for this ammo index. Add it to the ammo history
-					CHudHistoryResource *pHudHR = GET_HUDELEMENT( CHudHistoryResource );
-					if( pHudHR )
-					{
-						pHudHR->AddToHistory( HISTSLOT_AMMO, i, abs(GetAmmoCount(i) - m_iOldAmmo[i]) );
-					}
+					pHudHR->AddToHistory( HISTSLOT_AMMO, i, abs(GetAmmoCount(i) - m_iOldAmmo[i]) );
 				}
 			}
 		}
+	}
+
+	if ( IsLocalPlayer() )
+	{
+		// Reset engine areabits pointer
+		render->SetAreaState( m_Local.m_chAreaBits, m_Local.m_chAreaPortalBits );
 
 		Soundscape_Update( m_Local.m_audio );
 

--- a/src/game/client/c_baseplayer.h
+++ b/src/game/client/c_baseplayer.h
@@ -86,6 +86,7 @@ public:
 	// IClientEntity overrides.
 	virtual void	OnPreDataChanged( DataUpdateType_t updateType );
 	virtual void	OnDataChanged( DataUpdateType_t updateType );
+	void			ResetHudAmmoHistory( void );
 
 	virtual void	PreDataUpdate( DataUpdateType_t updateType );
 	virtual void	PostDataUpdate( DataUpdateType_t updateType );
@@ -177,6 +178,9 @@ public:
 
 
 	bool			IsSuitEquipped( void ) { return m_Local.m_bWearingSuit; };
+#ifdef HL2MP
+	int			ArmorValue( void ) const { return m_iArmorValue; }
+#endif
 
 	// Team handlers
 	virtual void	TeamChange( int iNewTeam );
@@ -411,6 +415,9 @@ public:
 	
 	// Data for only the local player
 	CNetworkVarEmbedded( CPlayerLocalData, m_Local );
+#ifdef HL2MP
+	int						m_iArmorValue;
+#endif
 
 #if defined USES_ECON_ITEMS
 	CNetworkVarEmbedded( CAttributeList, m_AttributeList );

--- a/src/game/client/cdll_util.cpp
+++ b/src/game/client/cdll_util.cpp
@@ -31,9 +31,9 @@
 
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"
-																						
+
 ConVar localplayer_visionflags( "localplayer_visionflags", "0", FCVAR_DEVELOPMENTONLY );
-																						
+
 //-----------------------------------------------------------------------------
 // ConVars
 //-----------------------------------------------------------------------------
@@ -162,6 +162,26 @@ int GetSpectatorTarget( void )
 	{
 		return  0;	// game not started yet
 	}
+}
+
+C_BasePlayer *GetHudPlayer( void )
+{
+	C_BasePlayer *pPlayer = C_BasePlayer::GetLocalPlayer();
+
+#ifdef HL2MP
+	if ( pPlayer )
+	{
+		int iObserverMode = pPlayer->GetObserverMode();
+		if ( iObserverMode == OBS_MODE_IN_EYE || iObserverMode == OBS_MODE_CHASE )
+		{
+			C_BasePlayer *pTarget = ToBasePlayer( pPlayer->GetObserverTarget() );
+			if ( pTarget && pTarget != pPlayer && !pTarget->IsObserver() )
+				return pTarget;
+		}
+	}
+#endif
+
+	return pPlayer;
 }
 
 int GetLocalPlayerTeam( void ) 

--- a/src/game/client/cdll_util.h
+++ b/src/game/client/cdll_util.h
@@ -31,6 +31,7 @@ class IClientEntity;
 class CHudTexture;
 class CGameTrace;
 class C_BaseEntity;
+class C_BasePlayer;
 
 struct Ray_t;
 struct client_textmessage_t;
@@ -112,7 +113,7 @@ bool GetTargetInScreenSpace( C_BaseEntity *pTargetEntity, int& iX, int& iY, Vect
 bool GetTargetInHudSpace( C_BaseEntity *pTargetEntity, int& iX, int& iY, Vector *vecOffset = NULL );
 
 // prints messages through the HUD (stub in client .dll right now )
-class C_BasePlayer;
+C_BasePlayer *GetHudPlayer( void );
 void ClientPrint( C_BasePlayer *player, int msg_dest, const char *msg_name, const char *param1 = NULL, const char *param2 = NULL, const char *param3 = NULL, const char *param4 = NULL );
 
 // Pass in an array of pointers and an array size, it fills the array and returns the number inserted

--- a/src/game/client/clientmode_shared.cpp
+++ b/src/game/client/clientmode_shared.cpp
@@ -741,7 +741,8 @@ int ClientModeShared::HandleSpectatorKeyInput( int down, ButtonCode_t keynum, co
 	// we are in spectator mode, open spectator menu
 	if ( down && pszCurrentBinding && Q_strcmp( pszCurrentBinding, "+duck" ) == 0 )
 	{
-		m_pViewport->ShowPanel( PANEL_SPECMENU, true );
+		IViewPortPanel *pSpectatorMenu = m_pViewport->FindPanelByName( PANEL_SPECMENU );
+		m_pViewport->ShowPanel( PANEL_SPECMENU, !pSpectatorMenu || !pSpectatorMenu->IsVisible() );
 		return 0; // we handled it, don't handle twice or send to server
 	}
 	else if ( down && pszCurrentBinding && Q_strcmp( pszCurrentBinding, "+attack" ) == 0 )

--- a/src/game/client/game_controls/SpectatorGUI.cpp
+++ b/src/game/client/game_controls/SpectatorGUI.cpp
@@ -99,12 +99,28 @@ private:
 	}
 };
 
+class CSpecComboBox : public ComboBox
+{
+	DECLARE_CLASS_SIMPLE( CSpecComboBox, ComboBox );
+
+public:
+	CSpecComboBox( Panel *parent, const char *panelName, int numLines ) : ComboBox( parent, panelName, numLines, false ) {}
+
+private:
+	MESSAGE_FUNC( OnMenuItemSelected, "MenuItemSelected" )
+	{
+		BaseClass::OnMenuItemSelected();
+		PostActionSignal( new KeyValues( "ItemSelected" ) );
+	}
+};
+
 //-----------------------------------------------------------------------------
 // Purpose: Constructor
 //-----------------------------------------------------------------------------
 CSpectatorMenu::CSpectatorMenu( IViewPort *pViewPort ) : Frame( NULL, PANEL_SPECMENU )
 {
 	m_iDuckKey = BUTTON_CODE_INVALID;
+	m_bDuckKeyReleased = false;
 		
 	m_pViewPort = pViewPort;
 
@@ -117,14 +133,16 @@ CSpectatorMenu::CSpectatorMenu( IViewPort *pViewPort ) : Frame( NULL, PANEL_SPEC
 
 	SetScheme("ClientScheme");
 
-	m_pPlayerList = new ComboBox(this, "playercombo", 10 , false);
+	m_pPlayerList = new CSpecComboBox( this, "playercombo", 10 );
+	m_pPlayerList->AddActionSignalTarget( this );
 	HFont hFallbackFont = scheme()->GetIScheme( GetScheme() )->GetFont( "DefaultVerySmallFallBack", false );
 	if ( INVALID_FONT != hFallbackFont )
 	{
 		m_pPlayerList->SetUseFallbackFont( true, hFallbackFont );
 	}
 
-	m_pViewOptions = new ComboBox(this, "viewcombo", 10 , false );
+	m_pViewOptions = new CSpecComboBox( this, "viewcombo", 10 );
+	m_pViewOptions->AddActionSignalTarget( this );
 	m_pConfigSettings = new ComboBox(this, "settingscombo", 10 , false );	
 
 	m_pLeftButton = new CSpecButton( this, "specprev");
@@ -146,9 +164,20 @@ CSpectatorMenu::CSpectatorMenu( IViewPort *pViewPort ) : Frame( NULL, PANEL_SPEC
 	m_pConfigSettings->SetMenu( menu );	// attach menu to combo box
 
 	// create view mode menu
+#ifdef HL2MP
+	KeyValues *pModeData = new KeyValues( "UserData" );
+	pModeData->SetInt( "mode", OBS_MODE_IN_EYE );
+	m_pViewOptions->AddItem( "#Spec_Mode3", pModeData );
+	pModeData->SetInt( "mode", OBS_MODE_CHASE );
+	m_pViewOptions->AddItem( "#Spec_Mode4", pModeData );
+	pModeData->SetInt( "mode", OBS_MODE_ROAMING );
+	m_pViewOptions->AddItem( "#Spec_Mode5", pModeData );
+	pModeData->deleteThis();
+#else
 	menu = new CommandMenu(m_pViewOptions, "spectatormodes", gViewPortInterface);
 	menu->LoadFromFile("Resource/spectatormodes.res");
 	m_pViewOptions->SetMenu( menu );	// attach menu to combo box
+#endif
 
 	LoadControlSettings( "Resource/UI/BottomSpectator.res" );
 
@@ -176,10 +205,11 @@ void CSpectatorMenu::ApplySchemeSettings(IScheme *pScheme)
 //-----------------------------------------------------------------------------
 void CSpectatorMenu::PerformLayout()
 {
+	BaseClass::PerformLayout();
+
 	int w,h;
 	GetHudSize(w, h);
 
-	// fill the screen
 	SetSize(w,GetTall());
 }
 
@@ -197,24 +227,51 @@ void CSpectatorMenu::OnTextChanged(KeyValues *data)
 	{
 		m_pConfigSettings->SetText("#Spec_Options");
 	}
-	else if ( box == m_pPlayerList )
+}
+
+void CSpectatorMenu::OnItemSelected(KeyValues *data)
+{
+	Panel *panel = reinterpret_cast<vgui::Panel *>( data->GetPtr("panel") );
+	vgui::ComboBox *box = dynamic_cast<vgui::ComboBox *>( panel );
+
+	if ( box == m_pPlayerList )
 	{
 		KeyValues *kv = box->GetActiveItemUserData();
-		if ( kv && GameResources() )
+		if ( kv )
 		{
-			const char *player = kv->GetString("player");
-
-			int currentPlayerNum = GetSpectatorTarget();
-			const char *currentPlayerName = GameResources()->GetPlayerName( currentPlayerNum );
-
-			if ( !FStrEq( currentPlayerName, player ) )
+			int iPlayerIndex = kv->GetInt( "index" );
+			if ( iPlayerIndex != GetSpectatorTarget() )
 			{
 				char command[128];
-				Q_snprintf( command, sizeof(command), "spec_player \"%s\"", player );
+#ifdef HL2MP
+				Q_snprintf( command, sizeof(command), "spec_player_index %d", iPlayerIndex );
+#else
+				player_info_t playerInfo;
+				if ( !engine->GetPlayerInfo( iPlayerIndex, &playerInfo ) )
+					return;
+				Q_snprintf( command, sizeof(command), "spec_player \"#%d\"", playerInfo.userID );
+#endif
 				engine->ClientCmd( command );
 			}
 		}
 	}
+#ifdef HL2MP
+	else if ( box == m_pViewOptions )
+	{
+		KeyValues *kv = box->GetActiveItemUserData();
+		if ( kv )
+		{
+			int iMode = kv->GetInt( "mode" );
+			int iCurrentMode = engine->IsHLTV() ? HLTVCamera()->GetMode() : GetSpectatorMode();
+			if ( iMode != iCurrentMode )
+			{
+				char command[32];
+				Q_snprintf( command, sizeof(command), "spec_mode %d", iMode );
+				engine->ClientCmd( command );
+			}
+		}
+	}
+#endif
 }
 
 void CSpectatorMenu::OnCommand( const char *command )
@@ -235,30 +292,24 @@ void CSpectatorMenu::FireGameEvent( IGameEvent * event )
 
  	if ( Q_strcmp( "spec_target_updated", pEventName ) == 0 )
 	{
-		IGameResources *gr = GameResources();
-		if ( !gr )
-			return;
-
 		// make sure the player combo box is up to date
 		int playernum = GetSpectatorTarget();
 		if ( playernum < 1 || playernum > MAX_PLAYERS )
 			return;
 
-		const char *selectedPlayerName = gr->GetPlayerName( playernum );
-		const char *currentPlayerName = "";
+		int currentPlayerNum = 0;
 		KeyValues *kv = m_pPlayerList->GetActiveItemUserData();
 		if ( kv )
-		{
-			currentPlayerName = kv->GetString( "player" );
-		}
-		if ( !FStrEq( currentPlayerName, selectedPlayerName ) )
+			currentPlayerNum = kv->GetInt( "index" );
+		if ( currentPlayerNum != playernum )
 		{
 			for ( int i=0; i<m_pPlayerList->GetItemCount(); ++i )
 			{
-				KeyValues *pKv = m_pPlayerList->GetItemUserData( i );
-				if ( pKv && FStrEq( pKv->GetString( "player" ), selectedPlayerName ) )
+				int iItemID = m_pPlayerList->GetItemIDFromRow( i );
+				KeyValues *pKv = m_pPlayerList->GetItemUserData( iItemID );
+				if ( pKv && pKv->GetInt( "index" ) == playernum )
 				{
-					m_pPlayerList->ActivateItemByRow( i );
+					m_pPlayerList->SilentActivateItemByRow( i );
 					break;
 				}
 			}
@@ -271,11 +322,31 @@ void CSpectatorMenu::FireGameEvent( IGameEvent * event )
 //-----------------------------------------------------------------------------
 void CSpectatorMenu::OnKeyCodePressed(KeyCode code)
 {
-	if ( code == m_iDuckKey )
+	if ( code == m_iDuckKey || code == KEY_ESCAPE )
 	{
 		// hide if DUCK is pressed again
 		m_pViewPort->ShowPanel( this, false );
+		return;
 	}
+
+	BaseClass::OnKeyCodePressed( code );
+}
+
+void CSpectatorMenu::OnThink()
+{
+	BaseClass::OnThink();
+
+	if ( !IsVisible() )
+		return;
+
+	bool bDuckKeyDown = m_iDuckKey != BUTTON_CODE_INVALID && g_pInputSystem->IsButtonDown( m_iDuckKey );
+	if ( ( bDuckKeyDown && m_bDuckKeyReleased ) || g_pInputSystem->IsButtonDown( KEY_ESCAPE ) )
+	{
+		m_pViewPort->ShowPanel( this, false );
+		return;
+	}
+
+	m_bDuckKeyReleased = !bDuckKeyDown;
 }
 
 void CSpectatorMenu::ShowPanel(bool bShow)
@@ -285,6 +356,9 @@ void CSpectatorMenu::ShowPanel(bool bShow)
 
 	if ( bShow )
 	{
+		m_iDuckKey = gameuifuncs->GetButtonCodeForBind( "duck" );
+		m_bDuckKeyReleased = m_iDuckKey == BUTTON_CODE_INVALID || !g_pInputSystem->IsButtonDown( m_iDuckKey );
+
 		// Force relayout in case Steam Controller stuff has changed.
 		InvalidateLayout( true, true );
 		Activate();
@@ -293,6 +367,12 @@ void CSpectatorMenu::ShowPanel(bool bShow)
 	}
 	else
 	{
+		m_pConfigSettings->HideMenu();
+		m_pViewOptions->HideMenu();
+		m_pPlayerList->HideMenu();
+		m_pConfigSettings->SelectNone();
+		m_pViewOptions->SelectNone();
+		m_pPlayerList->SelectNone();
 		SetVisible( false );
 		SetMouseInputEnabled( false );
 		SetKeyBoardInputEnabled( false );
@@ -342,7 +422,6 @@ void CSpectatorMenu::Update( void )
 
 		wchar_t playerText[ 80 ], playerName[ 64 ], *team, teamText[ 64 ];
 		char localizeTeamName[64];
-		char szPlayerIndex[16];
 		g_pVGuiLocalize->ConvertANSIToUnicode( UTIL_SafeName( gr->GetPlayerName(iPlayerIndex) ), playerName, sizeof( playerName ) );
 		const char * teamname = gr->GetTeamName( gr->GetTeam(iPlayerIndex) );
 		if ( teamname )
@@ -363,22 +442,21 @@ void CSpectatorMenu::Update( void )
 			g_pVGuiLocalize->ConstructString_safe( playerText, g_pVGuiLocalize->Find( "#Spec_PlayerItem" ), 1, playerName );
 		}
 
-		Q_snprintf( szPlayerIndex, sizeof( szPlayerIndex ), "%d", iPlayerIndex );
-
-		KeyValues *kv = new KeyValues( "UserData", "player", gr->GetPlayerName( iPlayerIndex ), "index", szPlayerIndex );
+		KeyValues *kv = new KeyValues( "UserData" );
+		kv->SetInt( "index", iPlayerIndex );
 		m_pPlayerList->AddItem( playerText, kv );
 		kv->deleteThis();
 	}
 
 	// make sure the player combo box is up to date
 	int playernum = GetSpectatorTarget();
-	const char *selectedPlayerName = gr->GetPlayerName( playernum );
 	for ( iPlayerIndex=0; iPlayerIndex<m_pPlayerList->GetItemCount(); ++iPlayerIndex )
 	{
-		KeyValues *kv = m_pPlayerList->GetItemUserData( iPlayerIndex );
-		if ( kv && FStrEq( kv->GetString( "player" ), selectedPlayerName ) )
+		int iItemID = m_pPlayerList->GetItemIDFromRow( iPlayerIndex );
+		KeyValues *kv = m_pPlayerList->GetItemUserData( iItemID );
+		if ( kv && kv->GetInt( "index" ) == playernum )
 		{
-			m_pPlayerList->ActivateItemByRow( iPlayerIndex );
+			m_pPlayerList->SilentActivateItemByRow( iPlayerIndex );
 			break;
 		}
 	}
@@ -389,9 +467,20 @@ void CSpectatorMenu::Update( void )
 	// mode can be changed multiple ways
 	//=============================================================================
 	
-	int specmode = GetSpectatorMode();
-	m_pViewOptions->SetText(s_SpectatorModes[specmode]);
-	
+	int specmode = engine->IsHLTV() ? HLTVCamera()->GetMode() : GetSpectatorMode();
+#ifdef HL2MP
+	if ( specmode == OBS_MODE_IN_EYE )
+		m_pViewOptions->SilentActivateItemByRow( 0 );
+	else if ( specmode == OBS_MODE_CHASE )
+		m_pViewOptions->SilentActivateItemByRow( 1 );
+	else if ( specmode == OBS_MODE_ROAMING )
+		m_pViewOptions->SilentActivateItemByRow( 2 );
+	else
+		m_pViewOptions->SetText( "#Spec_Modes" );
+#else
+	m_pViewOptions->SetText( specmode >= 0 && specmode < (int)ARRAYSIZE( s_SpectatorModes ) && s_SpectatorModes[specmode][0] ? s_SpectatorModes[specmode] : "#Spec_Modes" );
+#endif
+
 	//=============================================================================
 	// HPE_END
 	//=============================================================================
@@ -415,6 +504,7 @@ CSpectatorGUI::CSpectatorGUI(IViewPort *pViewPort) : EditablePanel( NULL, PANEL_
 
 	m_pViewPort = pViewPort;
 	g_pSpectatorGUI = this;
+	m_pBannerImage = NULL;
 
 	// initialize dialog
 	SetVisible(false);
@@ -426,10 +516,10 @@ CSpectatorGUI::CSpectatorGUI(IViewPort *pViewPort) : EditablePanel( NULL, PANEL_
 	SetKeyBoardInputEnabled( false );
 
 	m_pTopBar = new Panel( this, "topbar" );
- 	m_pBottomBarBlank = new Panel( this, "bottombarblank" );
+	m_pBottomBarBlank = new Panel( this, "bottombarblank" );
+	m_pPlayerLabel = new Label( this, "playerlabel", "" );
 
 	// m_pBannerImage = new ImagePanel( m_pTopBar, NULL );
-	m_pPlayerLabel = new Label( this, "playerlabel", "" );
 	m_pPlayerLabel->SetVisible( false );
 	TextImage *image = m_pPlayerLabel->GetTextImage();
 	if ( image )
@@ -478,13 +568,31 @@ void CSpectatorGUI::ApplySchemeSettings(IScheme *pScheme)
 		pConditions->deleteThis();
 	}
 
-	m_pBottomBarBlank->SetVisible( true );
-	m_pTopBar->SetVisible( true );
-
 	BaseClass::ApplySchemeSettings( pScheme );
 	SetBgColor(Color( 0,0,0,0 ) ); // make the background transparent
+
+#ifdef HL2MP
+	m_pTopBar->SetVisible( false );
+	m_pTopBar->SetPaintBackgroundEnabled( false );
+	m_pBottomBarBlank->SetVisible( false );
+	m_pBottomBarBlank->SetPaintBackgroundEnabled( false );
+
+	static const char * const classicControls[] =
+	{
+		"BlueScoreLabel", "BlueScoreValue", "RedScoreLabel", "RedScoreValue", "DividerBar", "timerclock", "timerlabel", "extrainfo", "titlelabel"
+	};
+	for ( int i = 0; i < (int)ARRAYSIZE( classicControls ); ++i )
+	{
+		Panel *pControl = FindChildByName( classicControls[i], true );
+		if ( pControl )
+			pControl->SetVisible( false );
+	}
+#else
+	m_pBottomBarBlank->SetVisible( true );
+	m_pTopBar->SetVisible( true );
 	m_pTopBar->SetBgColor(GetBlackBarColor());
 	m_pBottomBarBlank->SetBgColor(GetBlackBarColor());
+#endif
 	// m_pBottomBar->SetBgColor(Color( 0,0,0,0 ));
 	SetPaintBorderEnabled(false);
 
@@ -500,15 +608,25 @@ void CSpectatorGUI::ApplySchemeSettings(IScheme *pScheme)
 //-----------------------------------------------------------------------------
 void CSpectatorGUI::PerformLayout()
 {
-	int w,h,x,y;
+	BaseClass::PerformLayout();
+
+	int w,h;
 	GetHudSize(w, h);
 	
 	// fill the screen
 	SetBounds(0,0,w,h);
 
+#ifdef HL2MP
+	const int nNameWide = vgui::scheme()->GetProportionalScaledValueEx( GetScheme(), 350 );
+	const int nNameTall = vgui::scheme()->GetProportionalScaledValueEx( GetScheme(), 26 );
+	m_pPlayerLabel->SetBounds( ( w - nNameWide ) / 2, h - nNameTall - vgui::scheme()->GetProportionalScaledValueEx( GetScheme(), 13 ), nNameWide, nNameTall );
+	UpdatePlayerCard();
+#else
 	// stretch the bottom bar across the screen
+	int x,y;
 	m_pBottomBarBlank->GetPos(x,y);
 	m_pBottomBarBlank->SetSize( w, h - y );
+#endif
 }
 
 //-----------------------------------------------------------------------------
@@ -520,6 +638,10 @@ void CSpectatorGUI::OnThink()
 
 	if ( IsVisible() )
 	{
+#ifdef HL2MP
+		Update();
+#endif
+
 		if ( m_bSpecScoreboard != spec_scoreboard.GetBool() )
 		{
 			if ( !spec_scoreboard.GetBool() || !gViewPortInterface->GetActivePanel() )
@@ -626,11 +748,56 @@ bool CSpectatorGUI::ShouldShowPlayerLabel( int specmode )
 {
 	return ( (specmode == OBS_MODE_IN_EYE) ||	(specmode == OBS_MODE_CHASE) );
 }
+
+int CSpectatorGUI::GetBottomBarHeight()
+{
+#ifdef HL2MP
+	return 0;
+#else
+	return m_pBottomBarBlank->IsVisible() ? m_pBottomBarBlank->GetTall() : 0;
+#endif
+}
+
+#ifdef HL2MP
+void CSpectatorGUI::UpdatePlayerCard()
+{
+	int specmode = engine->IsHLTV() ? HLTVCamera()->GetMode() : GetSpectatorMode();
+	int playernum = GetSpectatorTarget();
+	if ( engine->IsHLTV() )
+	{
+		C_BaseEntity *pTarget = HLTVCamera()->GetPrimaryTarget();
+		playernum = pTarget ? pTarget->entindex() : 0;
+	}
+	C_BasePlayer *pPlayer = NULL;
+	if ( ShouldShowPlayerLabel( specmode ) && playernum > 0 && playernum <= gpGlobals->maxClients )
+		pPlayer = UTIL_PlayerByIndex( playernum );
+
+	IGameResources *gr = GameResources();
+	bool bShowPlayerCard = pPlayer && !pPlayer->IsObserver() && gr && gr->IsConnected( playernum );
+	m_pPlayerLabel->SetVisible( bShowPlayerCard );
+
+	if ( !bShowPlayerCard )
+	{
+		m_pPlayerLabel->SetText( "" );
+		return;
+	}
+
+	wchar_t wszPlayerName[128];
+	g_pVGuiLocalize->ConvertANSIToUnicode( UTIL_SafeName( gr->GetPlayerName( playernum ) ), wszPlayerName, sizeof( wszPlayerName ) );
+	m_pPlayerLabel->SetText( wszPlayerName );
+	m_pPlayerLabel->SetFgColor( gr->GetTeamColor( gr->GetTeam( playernum ) ) );
+}
+#endif
+
 //-----------------------------------------------------------------------------
 // Purpose: Updates the gui, rearranges elements
 //-----------------------------------------------------------------------------
 void CSpectatorGUI::Update()
 {
+#ifdef HL2MP
+	UpdatePlayerCard();
+	return;
+#endif
 	int wide, tall;
 	int bx, by, bwide, btall;
 
@@ -739,6 +906,9 @@ void CSpectatorGUI::Update()
 //-----------------------------------------------------------------------------
 const char * CSpectatorGUI::GetResFile( void )
 {
+#ifdef HL2MP
+	return "Resource/UI/Spectator.res";
+#else
 	if ( ::input->IsSteamControllerActive() )
 	{
 		return "Resource/UI/Spectator_SC.res";
@@ -747,6 +917,7 @@ const char * CSpectatorGUI::GetResFile( void )
 	{
 		return "Resource/UI/Spectator.res";
 	}
+#endif
 }
 
 //-----------------------------------------------------------------------------
@@ -874,6 +1045,37 @@ CON_COMMAND_F( spec_mode, "Set spectator mode", FCVAR_CLIENTCMD_CAN_EXECUTE )
 	}
 }
 
+#ifdef HL2MP
+CON_COMMAND_F( spec_player_index, "Spectate player by entity index", FCVAR_CLIENTCMD_CAN_EXECUTE )
+{
+	C_BasePlayer *pPlayer = C_BasePlayer::GetLocalPlayer();
+
+	if ( !pPlayer || !pPlayer->IsObserver() || args.ArgC() != 2 )
+		return;
+
+	int iPlayerIndex = Q_atoi( args[1] );
+	if ( iPlayerIndex < 1 || iPlayerIndex > gpGlobals->maxClients )
+		return;
+
+	if ( engine->IsHLTV() )
+	{
+		if ( HLTVCamera()->IsPVSLocked() )
+			return;
+
+		C_BasePlayer *pTarget = UTIL_PlayerByIndex( iPlayerIndex );
+		if ( !pTarget || ( pTarget->IsObserver() && pTarget->GetTeamNumber() != TEAM_SPECTATOR ) )
+			return;
+
+		HLTVCamera()->SetPrimaryTarget( iPlayerIndex );
+		HLTVCamera()->SetAutoDirector( false );
+	}
+	else
+	{
+		ForwardSpecCmdToServer( args );
+	}
+}
+#endif
+
 CON_COMMAND_F( spec_player, "Spectate player by partial name, steamid, or userid", FCVAR_CLIENTCMD_CAN_EXECUTE )
 {
 	C_BasePlayer *pPlayer = C_BasePlayer::GetLocalPlayer();
@@ -900,6 +1102,3 @@ CON_COMMAND_F( spec_player, "Spectate player by partial name, steamid, or userid
 		ForwardSpecCmdToServer( args );
 	}
 }
-
-
-

--- a/src/game/client/game_controls/spectatorgui.h
+++ b/src/game/client/game_controls/spectatorgui.h
@@ -62,8 +62,8 @@ public:
 	virtual void SetParent(vgui::VPANEL parent) { BaseClass::SetParent(parent); }
 	virtual void OnThink();
 
-	virtual int GetTopBarHeight() { return m_pTopBar->GetTall(); }
-	virtual int GetBottomBarHeight() { return m_pBottomBarBlank->GetTall(); }
+	virtual int GetTopBarHeight() { return m_pTopBar->IsVisible() ? m_pTopBar->GetTall() : 0; }
+	virtual int GetBottomBarHeight();
 	
 	virtual bool ShouldShowPlayerLabel( int specmode );
 
@@ -80,6 +80,9 @@ protected:
 	void MoveLabelToFront(const char *textEntryName);
 	void UpdateTimer();
 	void SetLogoImage(const char *image);
+#ifdef HL2MP
+	void UpdatePlayerCard();
+#endif
 
 protected:	
 	enum { INSET_OFFSET = 2 } ; 
@@ -125,6 +128,7 @@ public:
 	virtual bool HasInputElements( void ) { return true; }
 	virtual void ShowPanel( bool bShow );
 	virtual void FireGameEvent( IGameEvent *event );
+	virtual void OnThink();
 
 	// both vgui::Frame and IViewPortPanel define these, so explicitly define them here as passthroughs to vgui
 	virtual bool IsVisible() { return BaseClass::IsVisible(); }
@@ -136,6 +140,7 @@ public:
 private:
 	// VGUI2 overrides
 	MESSAGE_FUNC_PARAMS( OnTextChanged, "TextChanged", data );
+	MESSAGE_FUNC_PARAMS( OnItemSelected, "ItemSelected", data );
 	virtual void OnCommand( const char *command );
 	virtual void OnKeyCodePressed(vgui::KeyCode code);
 	virtual void ApplySchemeSettings(vgui::IScheme *pScheme);
@@ -153,6 +158,7 @@ private:
 
 	IViewPort *m_pViewPort;
 	ButtonCode_t m_iDuckKey;
+	bool m_bDuckKeyReleased;
 };
 
 extern CSpectatorGUI * g_pSpectatorGUI;

--- a/src/game/client/history_resource.cpp
+++ b/src/game/client/history_resource.cpp
@@ -23,6 +23,10 @@ extern ConVar hud_drawhistory_time;
 DECLARE_HUDELEMENT( CHudHistoryResource );
 DECLARE_HUD_MESSAGE( CHudHistoryResource, ItemPickup );
 DECLARE_HUD_MESSAGE( CHudHistoryResource, AmmoDenied );
+#ifdef HL2MP
+DECLARE_HUD_MESSAGE( CHudHistoryResource, SpecItemPickup );
+DECLARE_HUD_MESSAGE( CHudHistoryResource, SpecAmmoDenied );
+#endif
 
 //-----------------------------------------------------------------------------
 // Purpose: Constructor
@@ -32,6 +36,7 @@ CHudHistoryResource::CHudHistoryResource( const char *pElementName ) :
 {	
 	vgui::Panel *pParent = g_pClientMode->GetViewport();
 	SetParent( pParent );
+	m_hHistoryPlayer = NULL;
 	m_bDoNotDraw = true;
 	m_wcsAmmoFullMsg[0] = 0;
 	m_bNeedsDraw = false;
@@ -61,8 +66,26 @@ void CHudHistoryResource::Init( void )
 {
 	HOOK_HUD_MESSAGE( CHudHistoryResource, ItemPickup );
 	HOOK_HUD_MESSAGE( CHudHistoryResource, AmmoDenied );
+#ifdef HL2MP
+	HOOK_HUD_MESSAGE( CHudHistoryResource, SpecItemPickup );
+	HOOK_HUD_MESSAGE( CHudHistoryResource, SpecAmmoDenied );
+#endif
 
 	Reset();
+}
+
+void CHudHistoryResource::OnThink( void )
+{
+	BaseClass::OnThink();
+
+	C_BasePlayer *pHudPlayer = GetHudPlayer();
+	if ( m_hHistoryPlayer != pHudPlayer )
+	{
+		m_hHistoryPlayer = pHudPlayer;
+		Reset();
+		if ( pHudPlayer )
+			pHudPlayer->ResetHudAmmoHistory();
+	}
 }
 
 //-----------------------------------------------------------------------------
@@ -255,6 +278,24 @@ void CHudHistoryResource::MsgFunc_AmmoDenied( bf_read &msg )
 	// add into the list
 	AddToHistory( HISTSLOT_AMMODENIED, iAmmo, 0 );
 }
+
+#ifdef HL2MP
+void CHudHistoryResource::MsgFunc_SpecItemPickup( bf_read &msg )
+{
+	int iPlayer = msg.ReadByte();
+	C_BasePlayer *pHudPlayer = GetHudPlayer();
+	if ( pHudPlayer && pHudPlayer->entindex() == iPlayer )
+		MsgFunc_ItemPickup( msg );
+}
+
+void CHudHistoryResource::MsgFunc_SpecAmmoDenied( bf_read &msg )
+{
+	int iPlayer = msg.ReadByte();
+	C_BasePlayer *pHudPlayer = GetHudPlayer();
+	if ( pHudPlayer && pHudPlayer->entindex() == iPlayer )
+		MsgFunc_AmmoDenied( msg );
+}
+#endif
 
 //-----------------------------------------------------------------------------
 // Purpose: If there aren't any items in the history, clear it out.

--- a/src/game/client/history_resource.h
+++ b/src/game/client/history_resource.h
@@ -29,6 +29,7 @@ namespace vgui
 }
 
 class C_BaseCombatWeapon;
+class C_BasePlayer;
 
 //-----------------------------------------------------------------------------
 // Purpose: Used to draw the history of ammo / weapon / item pickups by the player
@@ -65,6 +66,7 @@ public:
 	virtual void Reset( void );
 	virtual bool ShouldDraw( void );
 	virtual void Paint( void );
+	virtual void OnThink( void );
 
 	virtual void ApplySchemeSettings( vgui::IScheme *pScheme );
 
@@ -73,6 +75,11 @@ public:
 	void	AddToHistory( C_BaseCombatWeapon *weapon );
 	void	MsgFunc_ItemPickup( bf_read &msg );
 	void	MsgFunc_AmmoDenied( bf_read &msg );
+#ifdef HL2MP
+	void	MsgFunc_SpecItemPickup( bf_read &msg );
+	void	MsgFunc_SpecAmmoDenied( bf_read &msg );
+#endif
+	bool	IsTrackingPlayer( C_BasePlayer *pPlayer ) const { return m_hHistoryPlayer == pPlayer; }
 	
 	void	CheckClearHistory( void );
 	void	SetHistoryGap( int iNewHistoryGap );
@@ -85,6 +92,7 @@ private:
 	bool	m_bDoNotDraw;
 	wchar_t m_wcsAmmoFullMsg[16];
 	bool	m_bNeedsDraw;
+	CHandle< C_BasePlayer > m_hHistoryPlayer;
 
 	CPanelAnimationVarAliasType( float, m_flHistoryGap, "history_gap", "42", "proportional_float" );
 	CPanelAnimationVarAliasType( float, m_flIconInset, "icon_inset", "28", "proportional_float" );

--- a/src/game/client/hl2/hud_ammo.cpp
+++ b/src/game/client/hl2/hud_ammo.cpp
@@ -36,6 +36,7 @@ public:
 
 	void SetAmmo(int ammo, bool playAnimation);
 	void SetAmmo2(int ammo2, bool playAnimation);
+	virtual bool ShouldDraw( void );
 	virtual void Paint( void );
 
 protected:
@@ -96,6 +97,11 @@ void CHudAmmo::VidInit( void )
 {
 }
 
+bool CHudAmmo::ShouldDraw( void )
+{
+	return CHudElement::ShouldDraw();
+}
+
 //-----------------------------------------------------------------------------
 // Purpose: Resets hud after save/restore
 //-----------------------------------------------------------------------------
@@ -119,7 +125,7 @@ void CHudAmmo::UpdatePlayerAmmo( C_BasePlayer *player )
 	// Clear out the vehicle entity
 	m_hCurrentVehicle = NULL;
 
-	C_BaseCombatWeapon *wpn = GetActiveWeapon();
+	C_BaseCombatWeapon *wpn = player ? player->GetActiveWeapon() : NULL;
 
 	hudlcd->SetGlobalStat( "(weapon_print_name)", wpn ? wpn->GetPrintName() : " " );
 	hudlcd->SetGlobalStat( "(weapon_name)", wpn ? wpn->GetName() : " " );
@@ -259,7 +265,7 @@ void CHudAmmo::OnThink()
 //-----------------------------------------------------------------------------
 void CHudAmmo::UpdateAmmoDisplays()
 {
-	C_BasePlayer *player = C_BasePlayer::GetLocalPlayer();
+	C_BasePlayer *player = GetHudPlayer();
 	IClientVehicle *pVehicle = player ? player->GetVehicle() : NULL;
 
 	if ( !pVehicle )
@@ -381,6 +387,11 @@ public:
 	{
 	}
 
+	bool ShouldDraw( void )
+	{
+		return CHudElement::ShouldDraw();
+	}
+
 	void SetAmmo( int ammo )
 	{
 		if (ammo != m_iAmmo)
@@ -438,8 +449,8 @@ protected:
 	virtual void OnThink()
 	{
 		// set whether or not the panel draws based on if we have a weapon that supports secondary ammo
-		C_BaseCombatWeapon *wpn = GetActiveWeapon();
-		C_BasePlayer *player = C_BasePlayer::GetLocalPlayer();
+		C_BasePlayer *player = GetHudPlayer();
+		C_BaseCombatWeapon *wpn = player ? player->GetActiveWeapon() : NULL;
 		IClientVehicle *pVehicle = player ? player->GetVehicle() : NULL;
 		if (!wpn || !player || pVehicle)
 		{
@@ -459,8 +470,8 @@ protected:
 
 	void UpdateAmmoState()
 	{
-		C_BaseCombatWeapon *wpn = GetActiveWeapon();
-		C_BasePlayer *player = C_BasePlayer::GetLocalPlayer();
+		C_BasePlayer *player = GetHudPlayer();
+		C_BaseCombatWeapon *wpn = player ? player->GetActiveWeapon() : NULL;
 
 		if (player && wpn && wpn->UsesSecondaryAmmo())
 		{
@@ -493,4 +504,3 @@ private:
 };
 
 DECLARE_HUDELEMENT( CHudSecondaryAmmo );
-

--- a/src/game/client/hl2/hud_autoaim.cpp
+++ b/src/game/client/hl2/hud_autoaim.cpp
@@ -147,7 +147,7 @@ void CHUDAutoAim::VidInit( void )
 bool CHUDAutoAim::ShouldDraw( void )
 {	
 #ifndef HL1_CLIENT_DLL
-	C_BaseHLPlayer *pLocalPlayer = (C_BaseHLPlayer *)C_BasePlayer::GetLocalPlayer();
+	C_BaseHLPlayer *pLocalPlayer = (C_BaseHLPlayer *)GetHudPlayer();
 	if ( pLocalPlayer )
 	{
 		if( !pLocalPlayer->m_HL2Local.m_bDisplayReticle )
@@ -155,6 +155,12 @@ bool CHUDAutoAim::ShouldDraw( void )
 			return false;
 		}
 	}
+
+#ifdef HL2MP
+	C_BasePlayer *pLocalObserver = C_BasePlayer::GetLocalPlayer();
+	if ( pLocalObserver && pLocalObserver->IsObserver() && pLocalObserver->GetObserverMode() != OBS_MODE_IN_EYE )
+		return false;
+#endif
 #endif
 
 	return ( (hud_draw_fixed_reticle.GetBool() || hud_draw_active_reticle.GetBool()) && CHudElement::ShouldDraw() && !engine->IsDrawingLoadingImage() );
@@ -177,7 +183,7 @@ void CHUDAutoAim::OnThink()
 	BaseClass::OnThink();
 
 	// Get the HL2 player
-	C_BaseHLPlayer *pLocalPlayer = (C_BaseHLPlayer *)C_BasePlayer::GetLocalPlayer();
+	C_BaseHLPlayer *pLocalPlayer = (C_BaseHLPlayer *)GetHudPlayer();
 	if ( pLocalPlayer == NULL )
 	{
 		// Just turn the autoaim crosshair off.
@@ -456,7 +462,7 @@ void CHUDAutoAim::Paint()
 		int r,g,b,a;
 		clr.GetColor( r,g,b,a );
 
-		C_BaseHLPlayer *pLocalPlayer = (C_BaseHLPlayer *)C_BasePlayer::GetLocalPlayer();
+		C_BaseHLPlayer *pLocalPlayer = (C_BaseHLPlayer *)GetHudPlayer();
 		if( pLocalPlayer && pLocalPlayer->m_HL2Local.m_hAutoAimTarget.Get() )
 		{
 			r = 250; 

--- a/src/game/client/hl2/hud_battery.cpp
+++ b/src/game/client/hl2/hud_battery.cpp
@@ -102,6 +102,15 @@ bool CHudBattery::ShouldDraw( void )
 //-----------------------------------------------------------------------------
 void CHudBattery::OnThink( void )
 {
+#ifdef HL2MP
+	if ( IsLocalPlayerSpectator() )
+	{
+		C_BasePlayer *pPlayer = GetHudPlayer();
+		if ( pPlayer )
+			m_iNewBat = pPlayer->ArmorValue();
+	}
+#endif
+
 	if ( m_iBat == m_iNewBat )
 		return;
 

--- a/src/game/client/hl2/hud_damageindicator.cpp
+++ b/src/game/client/hl2/hud_damageindicator.cpp
@@ -154,6 +154,15 @@ void CHudDamageIndicator::Init( void )
 //-----------------------------------------------------------------------------
 bool CHudDamageIndicator::ShouldDraw( void )
 {
+#ifdef HL2MP
+	if ( IsLocalPlayerSpectator() )
+	{
+		g_pClientMode->GetViewportAnimationController()->CancelAnimationsForPanel( this );
+		Reset();
+		return false;
+	}
+#endif
+
 	bool bNeedsDraw = m_DmgColorLeft[3] || 
 						m_DmgColorRight[3] || 
 						m_DmgHighColorLeft[3] || 

--- a/src/game/client/hl2/hud_flashlight.cpp
+++ b/src/game/client/hl2/hud_flashlight.cpp
@@ -105,7 +105,7 @@ void CHudFlashlight::SetFlashlightState( bool flashlightOn )
 void CHudFlashlight::Paint()
 {
 #ifdef HL2_EPISODIC
-	C_BaseHLPlayer *pPlayer = (C_BaseHLPlayer *)C_BasePlayer::GetLocalPlayer();
+	C_BaseHLPlayer *pPlayer = (C_BaseHLPlayer *)GetHudPlayer();
 	if ( !pPlayer )
 		return;
 

--- a/src/game/client/hl2/hud_health.cpp
+++ b/src/game/client/hl2/hud_health.cpp
@@ -48,6 +48,7 @@ public:
 	virtual void Init( void );
 	virtual void VidInit( void );
 	virtual void Reset( void );
+	virtual bool ShouldDraw( void );
 	virtual void OnThink();
 			void MsgFunc_Damage( bf_read &msg );
 
@@ -107,13 +108,18 @@ void CHudHealth::VidInit()
 	Reset();
 }
 
+bool CHudHealth::ShouldDraw( void )
+{
+	return CHudElement::ShouldDraw();
+}
+
 //-----------------------------------------------------------------------------
 // Purpose: 
 //-----------------------------------------------------------------------------
 void CHudHealth::OnThink()
 {
 	int newHealth = 0;
-	C_BasePlayer *local = C_BasePlayer::GetLocalPlayer();
+	C_BasePlayer *local = GetHudPlayer();
 	if ( local )
 	{
 		// Never below zero

--- a/src/game/client/hl2/hud_poisondamageindicator.cpp
+++ b/src/game/client/hl2/hud_poisondamageindicator.cpp
@@ -82,6 +82,14 @@ void CHudPoisonDamageIndicator::Reset( void )
 //-----------------------------------------------------------------------------
 bool CHudPoisonDamageIndicator::ShouldDraw( void )
 {
+#ifdef HL2MP
+	if ( IsLocalPlayerSpectator() )
+	{
+		Reset();
+		return false;
+	}
+#endif
+
 	C_BasePlayer *pPlayer = C_BasePlayer::GetLocalPlayer();
 	if ( !pPlayer )
 		return false;

--- a/src/game/client/hl2/hud_quickinfo.cpp
+++ b/src/game/client/hl2/hud_quickinfo.cpp
@@ -179,9 +179,15 @@ bool CHUDQuickInfo::ShouldDraw( void )
 	if ( !m_icon_c || !m_icon_rb || !m_icon_rbe || !m_icon_lb || !m_icon_lbe )
 		return false;
 
-	C_BasePlayer *player = C_BasePlayer::GetLocalPlayer();
+	C_BasePlayer *player = GetHudPlayer();
 	if ( player == NULL )
 		return false;
+
+#ifdef HL2MP
+	C_BasePlayer *pLocalPlayer = C_BasePlayer::GetLocalPlayer();
+	if ( pLocalPlayer && pLocalPlayer->IsObserver() && pLocalPlayer->GetObserverMode() != OBS_MODE_IN_EYE )
+		return false;
+#endif
 
 	if ( !crosshair.GetBool() && !IsX360() )
 		return false;
@@ -196,7 +202,7 @@ void CHUDQuickInfo::OnThink()
 {
 	BaseClass::OnThink();
 
-	C_BasePlayer *player = C_BasePlayer::GetLocalPlayer();
+	C_BasePlayer *player = GetHudPlayer();
 	if ( player == NULL )
 		return;
 
@@ -241,11 +247,11 @@ void CHUDQuickInfo::OnThink()
 
 void CHUDQuickInfo::Paint()
 {
-	C_BasePlayer *player = C_BasePlayer::GetLocalPlayer();
+	C_BasePlayer *player = GetHudPlayer();
 	if ( player == NULL )
 		return;
 
-	C_BaseCombatWeapon *pWeapon = GetActiveWeapon();
+	C_BaseCombatWeapon *pWeapon = player->GetActiveWeapon();
 	if ( pWeapon == NULL )
 		return;
 

--- a/src/game/client/hl2/hud_suitpower.cpp
+++ b/src/game/client/hl2/hud_suitpower.cpp
@@ -62,7 +62,7 @@ bool CHudSuitPower::ShouldDraw()
 {
 	bool bNeedsDraw = false;
 
-	C_BaseHLPlayer *pPlayer = (C_BaseHLPlayer *)C_BasePlayer::GetLocalPlayer();
+	C_BaseHLPlayer *pPlayer = (C_BaseHLPlayer *)GetHudPlayer();
 	if ( !pPlayer )
 		return false;
 
@@ -78,7 +78,7 @@ bool CHudSuitPower::ShouldDraw()
 void CHudSuitPower::OnThink( void )
 {
 	float flCurrentPower = 0;
-	C_BaseHLPlayer *pPlayer = (C_BaseHLPlayer *)C_BasePlayer::GetLocalPlayer();
+	C_BaseHLPlayer *pPlayer = (C_BaseHLPlayer *)GetHudPlayer();
 	if ( !pPlayer )
 		return;
 
@@ -134,7 +134,7 @@ void CHudSuitPower::OnThink( void )
 //-----------------------------------------------------------------------------
 void CHudSuitPower::Paint()
 {
-	C_BaseHLPlayer *pPlayer = (C_BaseHLPlayer *)C_BasePlayer::GetLocalPlayer();
+	C_BaseHLPlayer *pPlayer = (C_BaseHLPlayer *)GetHudPlayer();
 	if ( !pPlayer )
 		return;
 
@@ -253,5 +253,4 @@ void CHudSuitPower::Paint()
 		}
 	}
 }
-
 

--- a/src/game/client/hl2/hud_zoom.cpp
+++ b/src/game/client/hl2/hud_zoom.cpp
@@ -117,9 +117,15 @@ bool CHudZoom::ShouldDraw( void )
 {
 	bool bNeedsDraw = false;
 
-	C_BaseHLPlayer *pPlayer = dynamic_cast<C_BaseHLPlayer *>(C_BasePlayer::GetLocalPlayer());
+	C_BaseHLPlayer *pPlayer = dynamic_cast<C_BaseHLPlayer *>(GetHudPlayer());
 	if ( pPlayer == NULL )
 		return false;
+
+#ifdef HL2MP
+	C_BasePlayer *pLocalObserver = C_BasePlayer::GetLocalPlayer();
+	if ( pLocalObserver && pLocalObserver->IsObserver() && pLocalObserver->GetObserverMode() != OBS_MODE_IN_EYE )
+		return false;
+#endif
 
 	if ( pPlayer->m_HL2Local.m_bZooming )
 	{
@@ -144,7 +150,7 @@ void CHudZoom::Paint( void )
 	m_bPainted = false;
 
 	// see if we're zoomed any
-	C_BaseHLPlayer *pPlayer = dynamic_cast<C_BaseHLPlayer *>(C_BasePlayer::GetLocalPlayer());
+	C_BaseHLPlayer *pPlayer = dynamic_cast<C_BaseHLPlayer *>(GetHudPlayer());
 	if ( pPlayer == NULL )
 		return;
 

--- a/src/game/client/hl2mp/ui/hl2mptextwindow.cpp
+++ b/src/game/client/hl2mp/ui/hl2mptextwindow.cpp
@@ -140,6 +140,8 @@ void CHL2MPTextWindow::ApplySchemeSettings( vgui::IScheme *pScheme )
 
 CHL2MPSpectatorGUI::CHL2MPSpectatorGUI(IViewPort *pViewPort) : CSpectatorGUI(pViewPort)
 {
+	m_nLastSpecMode = -1;
+	m_nLastSpecTarget = NULL;
 }
 
 

--- a/src/game/client/hl2mp/ui/hl2mptextwindow.h
+++ b/src/game/client/hl2mp/ui/hl2mptextwindow.h
@@ -56,6 +56,9 @@ public:
 
 	virtual void Update( void );
 	virtual bool NeedsUpdate( void );
+	virtual Color GetBlackBarColor( void ) { return Color( 15, 18, 17, 224 ); }
+	virtual int GetTopBarHeight( void ) { return 0; }
+	virtual int GetBottomBarHeight( void ) { return 0; }
 
 protected:
 	int		m_nLastSpecMode;

--- a/src/game/client/hud.cpp
+++ b/src/game/client/hud.cpp
@@ -955,7 +955,7 @@ bool CHud::IsHidden( int iHudFlags )
 		return true;
 
 	// No local player yet?
-	C_BasePlayer *pPlayer = C_BasePlayer::GetLocalPlayer();
+	C_BasePlayer *pPlayer = GetHudPlayer();
 	if ( !pPlayer )
 		return true;
 

--- a/src/game/client/hud_vehicle.cpp
+++ b/src/game/client/hud_vehicle.cpp
@@ -45,7 +45,7 @@ void CHudVehicle::ApplySchemeSettings( IScheme *scheme )
 //-----------------------------------------------------------------------------
 IClientVehicle *CHudVehicle::GetLocalPlayerVehicle()
 {
-	C_BasePlayer *pPlayer = C_BasePlayer::GetLocalPlayer();
+	C_BasePlayer *pPlayer = GetHudPlayer();
 	if ( !pPlayer ||  !pPlayer->IsInAVehicle() )
 	{
 		return NULL;

--- a/src/game/client/weapon_selection.cpp
+++ b/src/game/client/weapon_selection.cpp
@@ -69,6 +69,16 @@ CBaseHudWeaponSelection *GetHudWeaponSelection()
 	return CBaseHudWeaponSelection::GetInstance();
 }
 
+static bool IsReadOnlySpectatorHud()
+{
+#ifdef HL2MP
+	C_BasePlayer *pPlayer = C_BasePlayer::GetLocalPlayer();
+	return pPlayer && pPlayer->IsObserver();
+#else
+	return false;
+#endif
+}
+
 //-----------------------------------------------------------------------------
 // Purpose: Constructor
 //-----------------------------------------------------------------------------
@@ -138,7 +148,14 @@ void CBaseHudWeaponSelection::OnThink( void )
 {
 	// Don't allow weapon selection if we're frozen in place
 	C_BasePlayer *pPlayer = C_BasePlayer::GetLocalPlayer();
-	if ( pPlayer->GetFlags() & FL_FROZEN || pPlayer->IsPlayerDead() )
+	if ( IsReadOnlySpectatorHud() )
+	{
+		if ( IsInSelectionMode() )
+			HideSelection();
+		return;
+	}
+
+	if ( pPlayer && ( pPlayer->GetFlags() & FL_FROZEN || pPlayer->IsPlayerDead() ) )
 	{
 		if ( IsInSelectionMode() )
 		{
@@ -153,7 +170,7 @@ void CBaseHudWeaponSelection::OnThink( void )
 void CBaseHudWeaponSelection::ProcessInput()
 {
 	C_BasePlayer *pPlayer = C_BasePlayer::GetLocalPlayer();
-	if ( !pPlayer )
+	if ( !pPlayer || IsReadOnlySpectatorHud() )
 		return;
 
 	int nFastswitchMode = hud_fastswitch.GetInt();
@@ -448,6 +465,9 @@ void CBaseHudWeaponSelection::SelectSlot( int iSlot )
 		return;
 	}
 
+	if ( IsReadOnlySpectatorHud() )
+		return;
+
 	// If we're not allowed to draw, ignore weapon selections
 	if ( !BaseClass::ShouldDraw() )
 	{
@@ -471,6 +491,9 @@ void CBaseHudWeaponSelection::UserCmd_Close(void)
 //-----------------------------------------------------------------------------
 void CBaseHudWeaponSelection::UserCmd_NextWeapon(void)
 {
+	if ( IsReadOnlySpectatorHud() )
+		return;
+
 	// If we're not allowed to draw, ignore weapon selections
 	if ( !BaseClass::ShouldDraw() )
 		return;
@@ -494,6 +517,9 @@ void CBaseHudWeaponSelection::UserCmd_NextWeapon(void)
 //-----------------------------------------------------------------------------
 void CBaseHudWeaponSelection::UserCmd_PrevWeapon(void)
 {
+	if ( IsReadOnlySpectatorHud() )
+		return;
+
 	// If we're not allowed to draw, ignore weapon selections
 	if ( !BaseClass::ShouldDraw() )
 		return;
@@ -518,6 +544,9 @@ void CBaseHudWeaponSelection::UserCmd_PrevWeapon(void)
 //-----------------------------------------------------------------------------
 void CBaseHudWeaponSelection::UserCmd_LastWeapon(void)
 {
+	if ( IsReadOnlySpectatorHud() )
+		return;
+
 	// If we're not allowed to draw, ignore weapon selections
 	if ( !BaseClass::ShouldDraw() )
 		return;

--- a/src/game/server/hl2/hl2_player.cpp
+++ b/src/game/server/hl2/hl2_player.cpp
@@ -411,7 +411,11 @@ CSuitPowerDevice SuitDeviceBreather( bits_SUIT_DEVICE_BREATHER, 6.7f );		// 100 
 
 
 IMPLEMENT_SERVERCLASS_ST(CHL2_Player, DT_HL2_Player)
+#ifdef HL2MP
+	SendPropDataTable(SENDINFO_DT(m_HL2Local), &REFERENCE_SEND_TABLE(DT_HL2Local), SendProxy_SendPlayerLocalDataTable),
+#else
 	SendPropDataTable(SENDINFO_DT(m_HL2Local), &REFERENCE_SEND_TABLE(DT_HL2Local), SendProxy_SendLocalDataTable),
+#endif
 	SendPropBool( SENDINFO(m_fIsSprinting) ),
 END_SEND_TABLE()
 
@@ -2005,12 +2009,7 @@ bool CHL2_Player::ApplyBattery( float powerMultiplier )
 		CPASAttenuationFilter filter( this, "ItemBattery.Touch" );
 		EmitSound( filter, entindex(), "ItemBattery.Touch" );
 
-		CSingleUserRecipientFilter user( this );
-		user.MakeReliable();
-
-		UserMessageBegin( user, "ItemPickup" );
-			WRITE_STRING( "item_battery" );
-		MessageEnd();
+		SendPlayerHudItemPickup( this, "item_battery" );
 
 		
 		// Suit reports new power level
@@ -2636,11 +2635,7 @@ int CHL2_Player::GiveAmmo( int nCount, int nAmmoIndex, bool bSuppressSound)
 	if ( nCount > 0 && nAdd == 0 )
 	{
 		// we've been denied the pickup, display a hud icon to show that
-		CSingleUserRecipientFilter user( this );
-		user.MakeReliable();
-		UserMessageBegin( user, "AmmoDenied" );
-			WRITE_SHORT( nAmmoIndex );
-		MessageEnd();
+		SendPlayerHudAmmoDenied( this, nAmmoIndex );
 	}
 
 	//

--- a/src/game/server/hl2/hl2_player.h
+++ b/src/game/server/hl2/hl2_player.h
@@ -92,6 +92,9 @@ public:
 	DECLARE_SERVERCLASS();
 	DECLARE_DATADESC();
 	DECLARE_ENT_SCRIPTDESC();
+#ifdef HL2MP
+	IMPLEMENT_NETWORK_VAR_FOR_DERIVED( m_ArmorValue );
+#endif
 
 	virtual void		CreateCorpse( void ) { CopyToBodyQue( this ); };
 

--- a/src/game/server/hl2/hl2_playerlocaldata.cpp
+++ b/src/game/server/hl2/hl2_playerlocaldata.cpp
@@ -38,7 +38,11 @@ BEGIN_SEND_TABLE_NOBASE( CHL2PlayerLocalData, DT_HL2Local )
 	SendPropFloat( SENDINFO(m_flFlashBattery) ),
 	SendPropVector( SENDINFO(m_vecLocatorOrigin) ),
 #endif
+#ifdef HL2MP
+	SendPropDataTable( SENDINFO_DT( m_LadderMove ), &REFERENCE_SEND_TABLE( DT_LadderMove ), SendProxy_SendPlayerLocalDataTable ),
+#else
 	SendPropDataTable( SENDINFO_DT( m_LadderMove ), &REFERENCE_SEND_TABLE( DT_LadderMove ), SendProxy_SendLocalDataTable ),
+#endif
 END_SEND_TABLE()
 
 BEGIN_SIMPLE_DATADESC( CHL2PlayerLocalData )

--- a/src/game/server/hl2/item_healthkit.cpp
+++ b/src/game/server/hl2/item_healthkit.cpp
@@ -69,12 +69,7 @@ bool CHealthKit::MyTouch( CBasePlayer *pPlayer )
 {
 	if ( pPlayer->TakeHealth( sk_healthkit.GetFloat(), DMG_GENERIC ) )
 	{
-		CSingleUserRecipientFilter user( pPlayer );
-		user.MakeReliable();
-
-		UserMessageBegin( user, "ItemPickup" );
-			WRITE_STRING( GetClassname() );
-		MessageEnd();
+		SendPlayerHudItemPickup( pPlayer, GetClassname() );
 
 		CPASAttenuationFilter filter( pPlayer, "HealthKit.Touch" );
 		EmitSound( filter, pPlayer->entindex(), "HealthKit.Touch" );
@@ -122,12 +117,7 @@ public:
 	{
 		if ( pPlayer->TakeHealth( sk_healthvial.GetFloat(), DMG_GENERIC ) )
 		{
-			CSingleUserRecipientFilter user( pPlayer );
-			user.MakeReliable();
-
-			UserMessageBegin( user, "ItemPickup" );
-				WRITE_STRING( GetClassname() );
-			MessageEnd();
+			SendPlayerHudItemPickup( pPlayer, GetClassname() );
 
 			CPASAttenuationFilter filter( pPlayer, "HealthVial.Touch" );
 			EmitSound( filter, pPlayer->entindex(), "HealthVial.Touch" );

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -95,6 +95,99 @@ ConVar	spec_freeze_traveltime( "spec_freeze_traveltime", "0.4", FCVAR_CHEAT | FC
 
 ConVar sv_bonus_challenge( "sv_bonus_challenge", "0", FCVAR_REPLICATED, "Set to values other than 0 to select a bonus map challenge type." );
 
+#ifdef HL2MP
+static bool ShouldReceivePlayerLocalData( CBasePlayer *pRecipient, CBasePlayer *pPlayer )
+{
+	if ( !pRecipient || !pPlayer || !pRecipient->IsConnected() )
+		return false;
+
+	if ( pRecipient == pPlayer || pRecipient->IsHLTV() || pRecipient->IsReplay() )
+		return true;
+
+	int iObserverMode = pRecipient->GetObserverMode();
+	return ( iObserverMode == OBS_MODE_IN_EYE || iObserverMode == OBS_MODE_CHASE ) &&
+		pRecipient->GetObserverTarget() == pPlayer;
+}
+
+static void AddPlayerHudSpectatorRecipients( CBasePlayer *pPlayer, CRecipientFilter &filter )
+{
+	for ( int i = 1; i <= gpGlobals->maxClients; ++i )
+	{
+		CBasePlayer *pRecipient = UTIL_PlayerByIndex( i );
+		if ( pRecipient != pPlayer && ShouldReceivePlayerLocalData( pRecipient, pPlayer ) )
+			filter.AddRecipient( pRecipient );
+	}
+}
+
+void SetPlayerLocalDataRecipients( CBasePlayer *pPlayer, CSendProxyRecipients *pRecipients )
+{
+	pRecipients->ClearAllRecipients();
+
+	for ( int i = 1; i <= gpGlobals->maxClients; ++i )
+	{
+		CBasePlayer *pRecipient = UTIL_PlayerByIndex( i );
+		if ( ShouldReceivePlayerLocalData( pRecipient, pPlayer ) )
+			pRecipients->SetRecipient( pRecipient->GetClientIndex() );
+	}
+}
+
+void* SendProxy_SendPlayerLocalDataTable( const SendProp *pProp, const void *pStruct, const void *pVarData, CSendProxyRecipients *pRecipients, int objectID )
+{
+	CBasePlayer *pPlayer = UTIL_PlayerByIndex( objectID );
+	if ( !pPlayer )
+		return NULL;
+
+	SetPlayerLocalDataRecipients( pPlayer, pRecipients );
+	return ( void * )pVarData;
+}
+
+REGISTER_SEND_PROXY_NON_MODIFIED_POINTER( SendProxy_SendPlayerLocalDataTable );
+#endif
+
+void SendPlayerHudItemPickup( CBasePlayer *pPlayer, const char *pszItemName )
+{
+	CSingleUserRecipientFilter owner( pPlayer );
+	owner.MakeReliable();
+	UserMessageBegin( owner, "ItemPickup" );
+		WRITE_STRING( pszItemName );
+	MessageEnd();
+
+#ifdef HL2MP
+	CRecipientFilter spectators;
+	AddPlayerHudSpectatorRecipients( pPlayer, spectators );
+	if ( spectators.GetRecipientCount() > 0 )
+	{
+		spectators.MakeReliable();
+		UserMessageBegin( spectators, "SpecItemPickup" );
+			WRITE_BYTE( pPlayer->entindex() );
+			WRITE_STRING( pszItemName );
+		MessageEnd();
+	}
+#endif
+}
+
+void SendPlayerHudAmmoDenied( CBasePlayer *pPlayer, int iAmmoType )
+{
+	CSingleUserRecipientFilter owner( pPlayer );
+	owner.MakeReliable();
+	UserMessageBegin( owner, "AmmoDenied" );
+		WRITE_SHORT( iAmmoType );
+	MessageEnd();
+
+#ifdef HL2MP
+	CRecipientFilter spectators;
+	AddPlayerHudSpectatorRecipients( pPlayer, spectators );
+	if ( spectators.GetRecipientCount() > 0 )
+	{
+		spectators.MakeReliable();
+		UserMessageBegin( spectators, "SpecAmmoDenied" );
+			WRITE_BYTE( pPlayer->entindex() );
+			WRITE_SHORT( iAmmoType );
+		MessageEnd();
+	}
+#endif
+}
+
 ConVar sv_chat_bucket_size_tier1( "sv_chat_bucket_size_tier1", "4", FCVAR_NONE, "The maximum size of the short term chat msg bucket." );
 ConVar sv_chat_seconds_per_msg_tier1( "sv_chat_seconds_per_msg_tier1", "3", FCVAR_NONE, "The number of seconds to accrue an additional short term chat msg." );
 ConVar sv_chat_bucket_size_tier2( "sv_chat_bucket_size_tier2", "30", FCVAR_NONE, "The maximum size of the long term chat msg bucket." );
@@ -6674,6 +6767,25 @@ bool CBasePlayer::ClientCommand( const CCommand &args )
 
 		return true;
 	}
+#ifdef HL2MP
+	else if ( stricmp( cmd, "spec_player_index" ) == 0 )
+	{
+		if ( GetObserverMode() > OBS_MODE_FIXED && args.ArgC() == 2 )
+		{
+			int iPlayerIndex = atoi( args[1] );
+			if ( iPlayerIndex >= 1 && iPlayerIndex <= gpGlobals->maxClients )
+			{
+				CBasePlayer *target = UTIL_PlayerByIndex( iPlayerIndex );
+				if ( IsValidObserverTarget( target ) )
+				{
+					SetObserverTarget( target );
+				}
+			}
+		}
+
+		return true;
+	}
+#endif
 	else if ( stricmp( cmd, "spec_player" ) == 0 ) // chase next player
 	{
 		if ( GetObserverMode() > OBS_MODE_FIXED && args.ArgC() == 2 )
@@ -8128,6 +8240,10 @@ void CMovementSpeedMod::InputSpeedMod(inputdata_t &data)
 		SendPropFloat		( SENDINFO(m_flFriction),		8,	SPROP_ROUNDDOWN,	0.0f,	4.0f),
 
 		SendPropArray3		( SENDINFO_ARRAY3(m_iAmmo), SendPropInt( SENDINFO_ARRAY(m_iAmmo), -1, SPROP_VARINT | SPROP_UNSIGNED ) ),
+
+#ifdef HL2MP
+		SendPropInt			( SENDINFO(m_ArmorValue), -1, SPROP_VARINT | SPROP_UNSIGNED ),
+#endif
 			
 		SendPropInt			( SENDINFO( m_fOnTarget ), 2, SPROP_UNSIGNED ),
 
@@ -8196,7 +8312,11 @@ void CMovementSpeedMod::InputSpeedMod(inputdata_t &data)
 #endif // USES_ECON_ITEMS
 
 		// Data that only gets sent to the local player.
+#ifdef HL2MP
+		SendPropDataTable( "localdata", 0, &REFERENCE_SEND_TABLE(DT_LocalPlayerExclusive), SendProxy_SendPlayerLocalDataTable ),
+#else
 		SendPropDataTable( "localdata", 0, &REFERENCE_SEND_TABLE(DT_LocalPlayerExclusive), SendProxy_SendLocalDataTable ),
+#endif
 
 	END_SEND_TABLE()
 

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -1608,5 +1608,11 @@ enum
 
 class CSendProxyRecipients;
 void* SendProxy_SendNonLocalDataTable( const SendProp *pProp, const void *pStruct, const void *pVarData, CSendProxyRecipients *pRecipients, int objectID );
+void SendPlayerHudItemPickup( CBasePlayer *pPlayer, const char *pszItemName );
+void SendPlayerHudAmmoDenied( CBasePlayer *pPlayer, int iAmmoType );
+#ifdef HL2MP
+void SetPlayerLocalDataRecipients( CBasePlayer *pPlayer, CSendProxyRecipients *pRecipients );
+void* SendProxy_SendPlayerLocalDataTable( const SendProp *pProp, const void *pStruct, const void *pVarData, CSendProxyRecipients *pRecipients, int objectID );
+#endif
 
 #endif // PLAYER_H

--- a/src/game/shared/basecombatweapon_shared.cpp
+++ b/src/game/shared/basecombatweapon_shared.cpp
@@ -2724,7 +2724,11 @@ void* SendProxy_SendActiveLocalWeaponDataTable( const SendProp *pProp, const voi
 		CBasePlayer *pPlayer = ToBasePlayer( pWeapon->GetOwner() );
 		if ( pPlayer /*&& pPlayer->GetActiveWeapon() == pWeapon*/ )
 		{
+#ifdef HL2MP
+			SetPlayerLocalDataRecipients( pPlayer, pRecipients );
+#else
 			pRecipients->SetOnly( pPlayer->GetClientIndex() );
+#endif
 			return (void*)pVarData;
 		}
 	}
@@ -2746,7 +2750,11 @@ void* SendProxy_SendLocalWeaponDataTable( const SendProp *pProp, const void *pSt
 		CBasePlayer *pPlayer = ToBasePlayer( pWeapon->GetOwner() );
 		if ( pPlayer )
 		{
+#ifdef HL2MP
+			SetPlayerLocalDataRecipients( pPlayer, pRecipients );
+#else
 			pRecipients->SetOnly( pPlayer->GetClientIndex() );
+#endif
 			return (void*)pVarData;
 		}
 	}

--- a/src/game/shared/hl2/hl2_usermessages.cpp
+++ b/src/game/shared/hl2/hl2_usermessages.cpp
@@ -41,6 +41,10 @@ void RegisterUserMessages( void )
 	usermessages->Register( "KeyHintText", -1 );	// Displays hint text display
 	usermessages->Register( "SquadMemberDied", 0 );
 	usermessages->Register( "AmmoDenied", 2 );
+#ifdef HL2MP
+	usermessages->Register( "SpecItemPickup", -1 );
+	usermessages->Register( "SpecAmmoDenied", 3 );
+#endif
 	usermessages->Register( "CreditsMsg", 1 );
 	usermessages->Register( "LogoTimeMsg", 4 );
 	usermessages->Register( "AchievementEvent", -1 );


### PR DESCRIPTION
The HL2MP spectator interface has a number of issues that needs addressing. First, if you hit the Ctrl key, you are stuck with the GUI controls until you use Ctrl + Tab a few times to remove the current GUI selection it is on. Observing a player shows the name and the health and that is about it.

I used CS2 as a point of reference for this. I added a compact bottom player card with adjacent, symmetrical spectator controls. Built camera selections from the actual observer enums, select targets by validated player index, show weapon names, and send over  health, armor, ammunition, suit power, and pickup history information for in-eye, chase, and SourceTV spectators. Fixed the controls so that players are no longer stuck in the spec GUI due to using Ctrl.

<img width="1948" height="1146" alt="image" src="https://github.com/user-attachments/assets/2bad7982-899a-4820-be23-15e96630a350" />

