### PR TITLE
[TF2] Fix Missing Righteous Bison and Pomson 6000 Critical Hit Projectile Particle Effects

### DIFF
--- a/src/game/shared/tf/tf_projectile_energy_ring.cpp
+++ b/src/game/shared/tf/tf_projectile_energy_ring.cpp
@@ -50,6 +50,11 @@ const char* g_pszEnergyProjectileImpactParticle	( "drg_pomson_impact" );
 IMPLEMENT_NETWORKCLASS_ALIASED( TFProjectile_EnergyRing, DT_TFProjectile_EnergyRing )
 
 BEGIN_NETWORK_TABLE( CTFProjectile_EnergyRing, DT_TFProjectile_EnergyRing )
+#ifdef GAME_DLL
+	SendPropBool( SENDINFO( m_bCritical ) ),
+#else
+	RecvPropBool( RECVINFO( m_bCritical ) ),
+#endif
 END_NETWORK_TABLE()
 
 //-----------------------------------------------------------------------------
@@ -122,6 +127,8 @@ CTFProjectile_EnergyRing *CTFProjectile_EnergyRing::Create( CTFWeaponBaseGun *pL
 	pRing->SetLauncher( pLauncher );
 
 	pRing->SetScorer( pScorer );
+
+	pRing->m_bCritical = bCritical;
 
 	// Spawn.
 	pRing->Spawn();
@@ -373,11 +380,11 @@ const char*	CTFProjectile_EnergyRing::GetTrailParticleName() const
 {
 	if ( ShouldPenetrate() )	// Righteous Bison
 	{
-		return IsCritical() ? g_pszBisonTrailParticleCrit : g_pszBisonTrailParticle;
+		return m_bCritical ? g_pszBisonTrailParticleCrit : g_pszBisonTrailParticle;
 	}
 	else // Pomson
 	{
-		return IsCritical() ? g_pszPomsonTrailParticleCrit : g_pszPomsonTrailParticle;
+		return m_bCritical ? g_pszPomsonTrailParticleCrit : g_pszPomsonTrailParticle;
 	}
 }
 

--- a/src/game/shared/tf/tf_projectile_energy_ring.h
+++ b/src/game/shared/tf/tf_projectile_energy_ring.h
@@ -65,6 +65,8 @@ private:
 	bool			ShouldPenetrate() const;
 	const char*		GetTrailParticleName() const;
 
+	CNetworkVar( bool, m_bCritical );
+
 	Vector			m_vColor1;
 	Vector			m_vColor2;
 


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
Fixes the missing critical hit particle effects for the Righteous Bison and the Pomson 6000. This is done by networking m_bCritical.

Fixes https://github.com/ValveSoftware/Source-1-Games/issues/4960

**_Better critical hit particle effects that is more visually recognizable is recommended after this fix._** 
See https://github.com/ValveSoftware/Source-1-Games/issues/7704 for better critical hit particle effects.

# Video Demonstration
## Righteous Bison

https://github.com/user-attachments/assets/d4d0ac12-6dab-4f12-ab17-539dd004f1eb


https://github.com/user-attachments/assets/af525678-9360-4817-8036-187d0d9b2eec


## Pomson 6000

https://github.com/user-attachments/assets/0e5744ed-4013-401d-abd6-94484ee11564


https://github.com/user-attachments/assets/352580b5-6d74-446e-bb1d-7f6e020da2aa

