### PR TITLE
[HL2MP] Fix & predict missing grenade roll sound

### DIFF
--- a/src/game/shared/hl2mp/weapon_frag.cpp
+++ b/src/game/shared/hl2mp/weapon_frag.cpp
@@ -546,6 +546,9 @@ void CWeaponFrag::RollGrenade( CBasePlayer *pPlayer )
 
 #endif
 
+#ifndef CLIENT_DLL
+	CDisablePredictionFiltering disablePred;
+#endif
 	WeaponSound( SPECIAL1 );
 
 	// player "shoot" animation
@@ -553,4 +556,3 @@ void CWeaponFrag::RollGrenade( CBasePlayer *pPlayer )
 
 	m_bRedraw = true;
 }
-

--- a/src/game/shared/hl2mp/weapon_frag.cpp
+++ b/src/game/shared/hl2mp/weapon_frag.cpp
@@ -9,6 +9,8 @@
 #include "in_buttons.h"
 
 #ifdef CLIENT_DLL
+	#include "animation.h"
+	#include "baseviewmodel_shared.h"
 	#include "c_hl2mp_player.h"
 	#include "c_te_effect_dispatch.h"
 #else
@@ -339,6 +341,39 @@ void CWeaponFrag::DecrementAmmo( CBaseCombatCharacter *pOwner )
 //-----------------------------------------------------------------------------
 void CWeaponFrag::ItemPostFrame( void )
 {
+#ifdef CLIENT_DLL
+	CBasePlayer *pPlayer = ToBasePlayer( GetOwner() );
+	CBaseViewModel *pViewModel = pPlayer ? pPlayer->GetViewModel( m_nViewModelIndex ) : NULL;
+	if ( pViewModel && pPlayer == CBasePlayer::GetLocalPlayer() && pViewModel->GetOwningWeapon() == this && gpGlobals->frametime > 0.0f )
+	{
+		MDLCACHE_CRITICAL_SECTION();
+		CStudioHdr *pStudioHdr = pViewModel->GetModelPtr();
+		int nSequence = pViewModel->GetSequence();
+		if ( pStudioHdr && nSequence >= 0 && nSequence < pStudioHdr->GetNumSeq() )
+		{
+			float flCycleRate = pViewModel->GetSequenceCycleRate( pStudioHdr, nSequence ) * pViewModel->GetPlaybackRate();
+			int nTick = TIME_TO_TICKS( gpGlobals->curtime );
+			float flStartCycle = ( TICKS_TO_TIME( nTick - 1 ) - pViewModel->GetAnimTime() ) * flCycleRate;
+			float flEndCycle = ( TICKS_TO_TIME( nTick ) - pViewModel->GetAnimTime() ) * flCycleRate;
+			animevent_t event;
+			int nEvent = 0;
+			while ( ( nEvent = GetAnimationEvent( pStudioHdr, nSequence, &event, flStartCycle, flEndCycle, nEvent ) ) != 0 )
+			{
+				switch ( event.event )
+				{
+				case EVENT_WEAPON_SEQUENCE_FINISHED:
+					m_fDrawbackFinished = true;
+					break;
+
+				case EVENT_WEAPON_THROW2:
+					WeaponSound( SPECIAL1 );
+					break;
+				}
+			}
+		}
+	}
+#endif
+
 	if( m_fDrawbackFinished )
 	{
 		CBasePlayer *pOwner = ToBasePlayer( GetOwner() );
@@ -546,9 +581,6 @@ void CWeaponFrag::RollGrenade( CBasePlayer *pPlayer )
 
 #endif
 
-#ifndef CLIENT_DLL
-	CDisablePredictionFiltering disablePred;
-#endif
 	WeaponSound( SPECIAL1 );
 
 	// player "shoot" animation


### PR DESCRIPTION
Issue:

Over a year ago, I opened a PR that aimed at fixing the missing roll sound for the frag grenade (see https://github.com/ValveSoftware/source-sdk-2013/pull/1101). The original fix was to use `CDisablePredictionFiltering disablePred;` so that the server played the sound for the client. This is still a valid fix for dedicated servers looking at fixing this with only server-side changes or plugins. The problem is that the client never hears that sound because the roll sound is triggered only by a server animation event, but prediction filtering excludes the owning player. Since the client never handles that event, the owner hears nothing.

Fix:

The fix here is to handle pullback completion and the roll-release event during client prediction, using the model’s existing animation timing. The local client hears the sound locally, while the server plays it for nearby players without duplicating it for the owner.