### PR TITLE
[ALL] Fix player spawn angles and initial command timing

### DIFF
--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -3190,7 +3190,10 @@ void CBasePlayer::RunNullCommand( void )
 	float flOldFrametime = gpGlobals->frametime;
 	float flOldCurtime = gpGlobals->curtime;
 
-	pl.fixangle = FIXANGLE_NONE;
+	if ( pl.fixangle != FIXANGLE_ABSOLUTE || IsReplay() )
+	{
+		pl.fixangle = FIXANGLE_NONE;
+	}
 
 	if ( IsReplay() )
 	{
@@ -3401,7 +3404,10 @@ void CBasePlayer::PhysicsSimulate( void )
 			CUserCmd cmd = m_LastCmd;
 			cmd.tick_count = gpGlobals->tickcount;
 			cmd.viewangles = EyeAngles();
-			pl.fixangle = FIXANGLE_NONE; // this forces use of cmd.viewangles directly, not as a relative value
+			if ( pl.fixangle != FIXANGLE_ABSOLUTE )
+			{
+				pl.fixangle = FIXANGLE_NONE;
+			}
 			PlayerRunCommand( &cmd, MoveHelperServer() );
 
 			if ( m_nMovementTicksForUserCmdProcessingRemaining > nMaxTicks )
@@ -5019,6 +5025,8 @@ ReturnSpot:
 void CBasePlayer::InitialSpawn( void )
 {
 	m_iConnected = PlayerConnected;
+	m_flLastUserCommandTime = gpGlobals->curtime;
+	SetTimeBase( gpGlobals->curtime );
 	gamestats->Event_PlayerConnected( this );
 }
 


### PR DESCRIPTION
**Issue:**
This was mainly in HL2DM, but I am going to consider all games here since the changes below are for both. Connecting or reconnecting to a dedicated server can leave the player's view at `0 0 0` instead of the spawn angles. `RunNullCommand()` and the command-budget fallback clear `FIXANGLE_ABSOLUTE` before the engine sends the correction.

New players also start with a zero command timestamp and tick base. This can trigger an immediate timeout or a false drowning sound when the first real command corrects the player's clock.

**Fix:**
Preserve pending absolute angle corrections in both fallback paths and initialize the command timestamp and player clock in `InitialSpawn()`. Retain the existing replay and relative-angle behavior.