### PR TITLE
[HL2MP] Use all spawn points for the initial spawn

### DIFF
--- a/src/game/server/hl2mp/hl2mp_player.cpp
+++ b/src/game/server/hl2mp/hl2mp_player.cpp
@@ -1414,9 +1414,19 @@ CBaseEntity* CHL2MP_Player::EntSelectSpawnPoint( void )
 		}
 	}
 
+	int nSpawnPointRange = 5;
+	if ( !pLastSpawnPoint )
+	{
+		nSpawnPointRange = 0;
+		while ( ( pSpot = gEntList.FindEntityByClassname( pSpot, pSpawnpointName ) ) != NULL )
+		{
+			++nSpawnPointRange;
+		}
+	}
+
 	pSpot = pLastSpawnPoint;
 	// Randomize the start spot
-	for ( int i = random->RandomInt(1,5); i > 0; i-- )
+	for ( int i = random->RandomInt( 1, MAX( nSpawnPointRange, 1 ) ); i > 0; i-- )
 		pSpot = gEntList.FindEntityByClassname( pSpot, pSpawnpointName );
 	if ( !pSpot )  // skip over the null point
 		pSpot = gEntList.FindEntityByClassname( pSpot, pSpawnpointName );


### PR DESCRIPTION
**Issue:**
With no previous spawn point, selection advances only 1–5 entries through the spawn entities. On maps with more than five valid points, such as `dm_lockdown` with nine (or more on the newer updated version of the game), the remaining points cannot be selected for the initial spawn when the first five are valid. This issue was documented here https://github.com/ValveSoftware/Source-1-Games/issues/6760

**Fix:**
In the past, I delayed the initial spawn as documented on #1037 and this also fixed the 0,0,0 angle issue on #2065. This, however, was not ideal. Therefore, the new fix is to use the full count of the selected spawn class for the initial random selection, including team spawn classes. Preserve the existing selection range for subsequent spawns and the validity and fallback checks.