### PR TITLE
[TF2] Remove stun noise if TF_STUN_NO_EFFECTS flag is used.

### DIFF
--- a/src/game/shared/tf/tf_player_shared.cpp
+++ b/src/game/shared/tf/tf_player_shared.cpp
@@ -9900,10 +9900,11 @@ void CTFPlayerShared::StunPlayer( float flTime, float flReductionAmount, int iSt
 		}
 	}
 
-	if ( ( GetActiveStunInfo()->iStunFlags & TF_STUN_SOUND ) ||
-		 ( GetActiveStunInfo()->iStunFlags & TF_STUN_SPECIAL_SOUND ) ||
-		 ( GetActiveStunInfo()->iStunFlags & TF_STUN_CONTROLS ) ||
-		 ( GetActiveStunInfo()->iStunFlags & TF_STUN_LOSER_STATE ) )
+	if ( ( ( GetActiveStunInfo()->iStunFlags & TF_STUN_SOUND ) ||
+		( GetActiveStunInfo()->iStunFlags & TF_STUN_SPECIAL_SOUND ) ||
+		( GetActiveStunInfo()->iStunFlags & TF_STUN_CONTROLS ) ||
+		( GetActiveStunInfo()->iStunFlags & TF_STUN_LOSER_STATE ) ) &&
+		!( GetActiveStunInfo()->iStunFlags & TF_STUN_NO_EFFECTS ) )
 	{
 		m_pOuter->StunSound( pAttacker, GetActiveStunInfo()->iStunFlags, iOldStunFlags );
 	}


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description
Before the Jungle Inferno update, the stun noise used to be hardcoded to only be played if the stun type is either TF_STUN_LOSER_STATE (scared by a ghost) or TF_STUN_CONTROLS (Übersaw taunt stun). After the Jungle Inferno update, to force Sandman and Bonk to play stun sound without being the aforementioned stun types, Valve added a new TF_STUN_SOUND flag that forces the stun sound to be played.
However, due to an oversight, the TF_STUN_NO_EFFECTS flag that is meant to prevent stun noise from being played now does nothing. I restore its intended functionality.