### PR TITLE
[HL2MP] Enable radio style menus

### DIFF
--- a/game/mod_hl2mp/scripts/HudAnimations.txt
+++ b/game/mod_hl2mp/scripts/HudAnimations.txt
@@ -43,6 +43,26 @@ event LevelInit
 {
 }
 
+event MenuOpen
+{
+	StopEvent MenuClose 0.0
+	StopEvent MenuPulse 0.0
+	Animate HudMenu SelectionAlpha "255" Linear 0.0 0.0
+	Animate HudMenu Blur "0" Linear 0.0 0.0
+}
+
+event MenuClose
+{
+	StopEvent MenuOpen 0.0
+	Animate HudMenu SelectionAlpha "0" Linear 0.0 0.15
+}
+
+event MenuPulse
+{
+	Animate HudMenu Blur "2" Linear 0.0 0.0
+	Animate HudMenu Blur "0" Deaccel 0.01 0.14
+}
+
 event FadeOutTeamLine
 {
 	// make the display visible
@@ -859,4 +879,3 @@ event HideVoteBackgrounds
 	Animate		LabelOption4	Alpha	255 Linear	0.0 0.001
 	Animate		LabelOption5	Alpha	255 Linear	0.0 0.001
 }
-

--- a/game/mod_hl2mp/scripts/HudLayout.res
+++ b/game/mod_hl2mp/scripts/HudLayout.res
@@ -448,6 +448,10 @@
 		"enabled" "1"
 		"wide"	 "640"
 		"tall"	 "480"
+		"TextFont" "Default"
+		"ItemFont" "Default"
+		"ItemFontPulsing" "Default"
+		"OpenCloseTime" "0.15"
 	}
 
 	HudCloseCaption

--- a/src/game/client/menu.cpp
+++ b/src/game/client/menu.cpp
@@ -394,8 +394,10 @@ void CHudMenu::OnThink()
 //-----------------------------------------------------------------------------
 bool CHudMenu::ShouldDraw( void )
 {
+#if defined( HL2MP )
 	if ( !UseRadioMenus() )
-		return false;
+		return CHudElement::ShouldDraw() && IsMenuOpen() && engine->IsInGame() && !enginevgui->IsGameUIVisible();
+#endif
 
 	bool draw = CHudElement::ShouldDraw() && m_bMenuDisplayed;
 	if ( !draw )
@@ -438,6 +440,24 @@ void CHudMenu::PaintString( const wchar_t *text, int textlen, vgui::HFont& font,
 //-----------------------------------------------------------------------------
 void CHudMenu::Paint()
 {
+#if defined( HL2MP )
+	if ( !UseRadioMenus() )
+	{
+		if ( !ShouldDraw() )
+			return;
+
+		const wchar_t *text = L"Press ESC to open menu";
+		int wide, tall;
+		vgui::surface()->GetTextSize( m_hTextFont, text, wide, tall );
+		int inset = YRES( 8 );
+		int padding = YRES( 4 );
+		DrawBox( inset, inset, wide + 2 * padding, tall + 2 * padding, m_BoxColor, 1.0f );
+		vgui::surface()->DrawSetTextColor( m_MenuColor );
+		PaintString( text, V_wcslen( text ), m_hTextFont, inset + padding, inset + padding );
+		return;
+	}
+#endif
+
 	if ( !m_bMenuDisplayed )
 		return;
 

--- a/src/game/client/menu.cpp
+++ b/src/game/client/menu.cpp
@@ -29,7 +29,6 @@
 #include <vgui_controls/Frame.h>
 #include <vgui_controls/PanelListPanel.h>
 #include <vgui_controls/ScrollBar.h>
-#include <vgui_controls/ScrollBarSlider.h>
 #include <vgui_controls/TextImage.h>
 #endif
 
@@ -59,14 +58,13 @@ class CHudMenuDialog : public vgui::Frame
 	DECLARE_CLASS_SIMPLE( CHudMenuDialog, vgui::Frame );
 public:
 	CHudMenuDialog( CHudMenu *pMenu ) : BaseClass( NULL, "HudMenuDialog" ),
-		m_nMenuSerial( ~0u ), m_nHeaderTall( 0 ), m_nFooterTall( 0 ),
+		m_nMenuSerial( ~0u ),
 		m_nLastX( 0 ), m_nLastY( 0 ), m_bPositionInitialized( false )
 	{
 		m_hMenu = pMenu;
 		SetParent( enginevgui->GetPanel( PANEL_GAMEUIDLL ) );
 		SetAutoDelete( false );
-		SetScheme( pMenu->GetScheme() );
-		SetProportional( true );
+		SetProportional( false );
 		SetTitle( "Menu", true );
 		SetSizeable( false );
 		SetClipToParent( true );
@@ -75,12 +73,6 @@ public:
 		SetMaximizeButtonVisible( false );
 		SetMenuButtonVisible( false );
 		SetCloseButtonVisible( false );
-		m_pTitle = new vgui::Label( this, "MenuTitle", "Menu" );
-		m_pTitle->SetMouseInputEnabled( false );
-		m_pTitle->SetContentAlignment( vgui::Label::a_west );
-		m_pHint = new vgui::Label( this, "MenuHint", "ESC  Back to game" );
-		m_pHint->SetMouseInputEnabled( false );
-		m_pHint->SetContentAlignment( vgui::Label::a_west );
 		m_pItems = new vgui::PanelListPanel( this, "MenuItems" );
 		m_pItems->SetFirstColumnWidth( 0 );
 		KeyValues *pSettings = new KeyValues( "MenuItems" );
@@ -91,6 +83,11 @@ public:
 		SetVisible( false );
 	}
 
+	virtual ~CHudMenuDialog()
+	{
+		SavePosition();
+	}
+
 	void UpdateMenu()
 	{
 		CHudMenu *pMenu = m_hMenu.Get();
@@ -99,7 +96,6 @@ public:
 
 		m_nMenuSerial = pMenu->m_nMenuSerial;
 		m_pItems->DeleteAllItems();
-		m_pTitle->SetText( "Menu" );
 		SetTitle( "Menu", true );
 		for ( int i = 0; i < pMenu->m_Processed.Count(); ++i )
 		{
@@ -114,7 +110,6 @@ public:
 			{
 				if ( text[line.length - 1] == L':' )
 					text[line.length - 1] = 0;
-				m_pTitle->SetText( text );
 				SetTitle( text, true );
 				continue;
 			}
@@ -141,9 +136,24 @@ public:
 		InvalidateLayout( true );
 	}
 
-	virtual int GetCaptionHeight()
+	void SavePosition()
 	{
-		return vgui::scheme()->GetProportionalNormalizedValueEx( GetScheme(), m_nHeaderTall );
+		if ( !m_bPositionInitialized )
+			return;
+		int x, y;
+		GetPos( x, y );
+		if ( x == m_nLastX && y == m_nLastY )
+			return;
+
+		int screenWide, screenTall;
+		vgui::surface()->GetScreenSize( screenWide, screenTall );
+		if ( screenWide > 0 && screenTall > 0 )
+		{
+			m_nLastX = x;
+			m_nLastY = y;
+			cl_menu_dialog_x.SetValue( (float)x / screenWide );
+			cl_menu_dialog_y.SetValue( (float)y / screenTall );
+		}
 	}
 
 private:
@@ -161,28 +171,27 @@ private:
 
 	virtual void PerformLayout()
 	{
+		SavePosition();
 		int screenWide, screenTall;
 		vgui::surface()->GetScreenSize( screenWide, screenTall );
-		vgui::IScheme *pScheme = vgui::scheme()->GetIScheme( GetScheme() );
-		vgui::HFont font = pScheme->GetFont( "Default", true );
-		int fontTall = vgui::surface()->GetFontTall( font );
-		int padding = MAX( 1, vgui::scheme()->GetProportionalScaledValueEx( GetScheme(), 10 ) );
-		int gap = MAX( 1, vgui::scheme()->GetProportionalScaledValueEx( GetScheme(), 4 ) );
-		int wide = MIN( screenWide - 2 * padding, vgui::scheme()->GetProportionalScaledValueEx( GetScheme(), 280 ) );
-		int maxTall = MIN( screenTall - 2 * padding, vgui::scheme()->GetProportionalScaledValueEx( GetScheme(), 320 ) );
-		m_nHeaderTall = fontTall + 2 * padding;
-		m_nFooterTall = fontTall + 2 * gap;
+		if ( screenWide <= 0 || screenTall <= 0 )
+			return;
 
-		vgui::ScrollBar *pScrollBar = m_pItems->GetScrollbar();
-		pScrollBar->SetWide( padding );
-		pScrollBar->SetScrollbarButtonsVisible( false );
-		pScrollBar->GetSlider()->InvalidateLayout( true, true );
-		pScrollBar->GetSlider()->SetFgColor( Color( 126, 120, 101, 255 ) );
-		pScrollBar->GetSlider()->SetBgColor( Color( 26, 29, 32, 255 ) );
+		vgui::IScheme *pScheme = vgui::scheme()->GetIScheme( GetScheme() );
+		vgui::HFont font = pScheme->GetFont( "Default", IsProportional() );
+		int fontTall = vgui::surface()->GetFontTall( font );
+		int padding = 8;
+		int gap = 4;
+		SetSize( MIN( screenWide - 2 * padding, 360 ), MIN( screenTall - 2 * padding, 480 ) );
+		int x, y, wide, tall;
+		GetClientArea( x, y, wide, tall );
+		int frameTall = GetTall() - tall;
+
+		m_pItems->InvalidateLayout( true, true );
 		m_pItems->SetVerticalBufferPixels( gap );
 		m_pItems->SetPaintBackgroundEnabled( false );
 		m_pItems->SetPaintBorderEnabled( false );
-		int itemWide = MAX( 1, wide - 2 * padding - pScrollBar->GetWide() - gap - 12 );
+		int itemWide = MAX( 1, wide - m_pItems->GetScrollbar()->GetWide() - gap - 12 );
 		for ( int i = 0; i < m_pItems->GetItemCount(); ++i )
 		{
 			vgui::Label *pItem = static_cast<vgui::Label *>( m_pItems->GetItemPanel( m_pItems->GetItemIDFromRow( i ) ) );
@@ -194,47 +203,13 @@ private:
 			int textWide, textTall;
 			pItem->GetTextImage()->GetContentSize( textWide, textTall );
 			pItem->SetTall( MAX( textTall, fontTall ) + padding );
-			pItem->SetFgColor( Color( 171, 177, 182, 255 ) );
-			if ( vgui::Button *pButton = dynamic_cast<vgui::Button *>( pItem ) )
-			{
-				pButton->SetButtonBorderEnabled( false );
-				pButton->DrawFocusBox( true );
-				pButton->SetDefaultColor( Color( 229, 233, 235, 255 ), Color( 35, 39, 43, 255 ) );
-				pButton->SetArmedColor( Color( 255, 213, 133, 255 ), Color( 66, 56, 38, 255 ) );
-				pButton->SetSelectedColor( Color( 255, 213, 133, 255 ), Color( 66, 56, 38, 255 ) );
-				pButton->SetDepressedColor( Color( 255, 226, 169, 255 ), Color( 90, 69, 36, 255 ) );
-				pButton->SetDisabledFgColor1( Color( 102, 109, 115, 255 ) );
-				pButton->SetDisabledFgColor2( Color( 0, 0, 0, 0 ) );
-			}
 		}
-		int listTall = MIN( m_pItems->ComputeVPixelsNeeded(), MAX( 1, maxTall - m_nHeaderTall - m_nFooterTall ) );
-		SetSize( wide, m_nHeaderTall + listTall + m_nFooterTall );
+		int listTall = MIN( m_pItems->ComputeVPixelsNeeded(), MAX( 1, tall ) );
+		SetTall( frameTall + listTall );
 		BaseClass::PerformLayout();
-		SetPaintBorderEnabled( false );
-		m_pItems->SetBounds( padding, m_nHeaderTall, wide - 2 * padding, listTall );
+		m_pItems->SetBounds( x, y, wide, listTall );
 		m_pItems->InvalidateLayout( true );
-		m_pTitle->InvalidateLayout( true, true );
-		m_pTitle->SetFont( font );
-		m_pTitle->SetFgColor( Color( 255, 203, 109, 255 ) );
-		m_pTitle->SetBounds( padding + gap, padding, wide - 2 * ( padding + gap ), fontTall );
-		m_pHint->InvalidateLayout( true, true );
-		m_pHint->SetFont( font );
-		m_pHint->SetFgColor( Color( 141, 151, 158, 255 ) );
-		m_pHint->SetBounds( padding + gap, GetTall() - m_nFooterTall, wide - 2 * ( padding + gap ), m_nFooterTall );
 		RestorePosition();
-	}
-
-	virtual void PaintBackground()
-	{
-		vgui::surface()->DrawSetColor( Color( 20, 23, 26, 250 ) );
-		vgui::surface()->DrawFilledRect( 0, 0, GetWide(), GetTall() );
-		vgui::surface()->DrawSetColor( Color( 29, 33, 37, 255 ) );
-		vgui::surface()->DrawFilledRect( 0, 0, GetWide(), m_nHeaderTall );
-		vgui::surface()->DrawSetColor( Color( 65, 70, 74, 255 ) );
-		vgui::surface()->DrawOutlinedRect( 0, 0, GetWide(), GetTall() );
-		vgui::surface()->DrawLine( 1, GetTall() - m_nFooterTall, GetWide() - 1, GetTall() - m_nFooterTall );
-		vgui::surface()->DrawSetColor( Color( 220, 162, 65, 255 ) );
-		vgui::surface()->DrawFilledRect( 1, 1, GetWide() - 1, MAX( 2, vgui::scheme()->GetProportionalScaledValueEx( GetScheme(), 2 ) ) );
 	}
 
 	void RestorePosition()
@@ -256,40 +231,16 @@ private:
 			cl_menu_dialog_y.SetValue( (float)m_nLastY / screenTall );
 	}
 
-	virtual void OnMove()
-	{
-		BaseClass::OnMove();
-		if ( !m_bPositionInitialized || !IsVisible() )
-			return;
-		int x, y;
-		GetPos( x, y );
-		if ( x == m_nLastX && y == m_nLastY )
-			return;
-
-		int screenWide, screenTall;
-		vgui::surface()->GetScreenSize( screenWide, screenTall );
-		if ( screenWide > 0 && screenTall > 0 )
-		{
-			m_nLastX = x;
-			m_nLastY = y;
-			cl_menu_dialog_x.SetValue( (float)x / screenWide );
-			cl_menu_dialog_y.SetValue( (float)y / screenTall );
-		}
-	}
-
 	virtual void OnScreenSizeChanged( int oldwide, int oldtall )
 	{
+		m_bPositionInitialized = false;
 		BaseClass::OnScreenSizeChanged( oldwide, oldtall );
 		InvalidateLayout( true );
 	}
 
 	vgui::DHANDLE< CHudMenu > m_hMenu;
 	vgui::PanelListPanel *m_pItems;
-	vgui::Label *m_pTitle;
-	vgui::Label *m_pHint;
 	unsigned int m_nMenuSerial;
-	int m_nHeaderTall;
-	int m_nFooterTall;
 	int m_nLastX;
 	int m_nLastY;
 	bool m_bPositionInitialized;
@@ -399,6 +350,9 @@ bool CHudMenu::IsTakingInput( void )
 #if defined( HL2MP )
 void CHudMenu::OnTick()
 {
+	if ( m_hMenuDialog.Get() )
+		m_hMenuDialog->SavePosition();
+
 	bool visible = !UseRadioMenus() && IsMenuOpen() && engine->IsInGame() && enginevgui->IsGameUIVisible();
 	if ( !visible )
 	{

--- a/src/game/client/menu.cpp
+++ b/src/game/client/menu.cpp
@@ -29,6 +29,7 @@
 #include <vgui_controls/Frame.h>
 #include <vgui_controls/PanelListPanel.h>
 #include <vgui_controls/ScrollBar.h>
+#include <vgui_controls/ScrollBarSlider.h>
 #include <vgui_controls/TextImage.h>
 #endif
 
@@ -50,12 +51,16 @@ DECLARE_HUD_MESSAGE( CHudMenu, ShowMenu );
 
 #if defined( HL2MP )
 ConVar cl_radio_menus( "cl_radio_menus", "1", FCVAR_ARCHIVE, "Display server menus on the HUD (1) or in a dialog when ESC is pressed (0).", true, 0, true, 1 );
+ConVar cl_menu_dialog_x( "cl_menu_dialog_x", "-1", FCVAR_ARCHIVE, "Saved ESC menu horizontal position as a fraction of screen width (-1 centers it).", true, -1, true, 1 );
+ConVar cl_menu_dialog_y( "cl_menu_dialog_y", "-1", FCVAR_ARCHIVE, "Saved ESC menu vertical position as a fraction of screen height (-1 centers it).", true, -1, true, 1 );
 
 class CHudMenuDialog : public vgui::Frame
 {
 	DECLARE_CLASS_SIMPLE( CHudMenuDialog, vgui::Frame );
 public:
-	CHudMenuDialog( CHudMenu *pMenu ) : BaseClass( NULL, "HudMenuDialog" ), m_nMenuSerial( ~0u )
+	CHudMenuDialog( CHudMenu *pMenu ) : BaseClass( NULL, "HudMenuDialog" ),
+		m_nMenuSerial( ~0u ), m_nHeaderTall( 0 ), m_nFooterTall( 0 ),
+		m_nLastX( 0 ), m_nLastY( 0 ), m_bPositionInitialized( false )
 	{
 		m_hMenu = pMenu;
 		SetParent( enginevgui->GetPanel( PANEL_GAMEUIDLL ) );
@@ -64,12 +69,24 @@ public:
 		SetProportional( true );
 		SetTitle( "Menu", true );
 		SetSizeable( false );
+		SetClipToParent( true );
+		SetFadeEffectDisableOverride( true );
 		SetMinimizeButtonVisible( false );
 		SetMaximizeButtonVisible( false );
 		SetMenuButtonVisible( false );
 		SetCloseButtonVisible( false );
+		m_pTitle = new vgui::Label( this, "MenuTitle", "Menu" );
+		m_pTitle->SetMouseInputEnabled( false );
+		m_pTitle->SetContentAlignment( vgui::Label::a_west );
+		m_pHint = new vgui::Label( this, "MenuHint", "ESC  Back to game" );
+		m_pHint->SetMouseInputEnabled( false );
+		m_pHint->SetContentAlignment( vgui::Label::a_west );
 		m_pItems = new vgui::PanelListPanel( this, "MenuItems" );
 		m_pItems->SetFirstColumnWidth( 0 );
+		KeyValues *pSettings = new KeyValues( "MenuItems" );
+		pSettings->SetInt( "autohide_scrollbar", 1 );
+		m_pItems->ApplySettings( pSettings );
+		pSettings->deleteThis();
 		MakePopup();
 		SetVisible( false );
 	}
@@ -82,6 +99,8 @@ public:
 
 		m_nMenuSerial = pMenu->m_nMenuSerial;
 		m_pItems->DeleteAllItems();
+		m_pTitle->SetText( "Menu" );
+		SetTitle( "Menu", true );
 		for ( int i = 0; i < pMenu->m_Processed.Count(); ++i )
 		{
 			const CHudMenu::ProcessedLine &line = pMenu->m_Processed[i];
@@ -90,6 +109,15 @@ public:
 			int slot = line.menuitem;
 			if ( !slot && line.length >= 2 && text[0] >= L'0' && text[0] <= L'9' && text[1] == L'.' )
 				slot = text[0] == L'0' ? 10 : text[0] - L'0';
+
+			if ( i == 0 && !slot && line.length <= 64 )
+			{
+				if ( text[line.length - 1] == L':' )
+					text[line.length - 1] = 0;
+				m_pTitle->SetText( text );
+				SetTitle( text, true );
+				continue;
+			}
 
 			vgui::Label *pItem;
 			if ( slot >= 1 && slot <= 10 )
@@ -111,7 +139,11 @@ public:
 		}
 		m_pItems->MoveScrollBarToTop();
 		InvalidateLayout( true );
-		MoveToCenterOfScreen();
+	}
+
+	virtual int GetCaptionHeight()
+	{
+		return vgui::scheme()->GetProportionalNormalizedValueEx( GetScheme(), m_nHeaderTall );
 	}
 
 private:
@@ -131,40 +163,136 @@ private:
 	{
 		int screenWide, screenTall;
 		vgui::surface()->GetScreenSize( screenWide, screenTall );
-		int border = vgui::scheme()->GetProportionalScaledValueEx( GetScheme(), 8 );
-		SetSize( MIN( screenWide - 2 * border, vgui::scheme()->GetProportionalScaledValueEx( GetScheme(), 360 ) ),
-			MIN( screenTall - 2 * border, vgui::scheme()->GetProportionalScaledValueEx( GetScheme(), 400 ) ) );
-		BaseClass::PerformLayout();
+		vgui::IScheme *pScheme = vgui::scheme()->GetIScheme( GetScheme() );
+		vgui::HFont font = pScheme->GetFont( "Default", true );
+		int fontTall = vgui::surface()->GetFontTall( font );
+		int padding = MAX( 1, vgui::scheme()->GetProportionalScaledValueEx( GetScheme(), 10 ) );
+		int gap = MAX( 1, vgui::scheme()->GetProportionalScaledValueEx( GetScheme(), 4 ) );
+		int wide = MIN( screenWide - 2 * padding, vgui::scheme()->GetProportionalScaledValueEx( GetScheme(), 280 ) );
+		int maxTall = MIN( screenTall - 2 * padding, vgui::scheme()->GetProportionalScaledValueEx( GetScheme(), 320 ) );
+		m_nHeaderTall = fontTall + 2 * padding;
+		m_nFooterTall = fontTall + 2 * gap;
 
-		int x, y, wide, tall;
-		GetClientArea( x, y, wide, tall );
-		m_pItems->SetBounds( x + border, y + border, wide - 2 * border, tall - 2 * border );
-		m_pItems->SetVerticalBufferPixels( border / 2 );
-		int itemWide = MAX( 1, m_pItems->GetWide() - m_pItems->GetScrollbar()->GetWide() - border / 2 - 12 );
+		vgui::ScrollBar *pScrollBar = m_pItems->GetScrollbar();
+		pScrollBar->SetWide( padding );
+		pScrollBar->SetScrollbarButtonsVisible( false );
+		pScrollBar->GetSlider()->InvalidateLayout( true, true );
+		pScrollBar->GetSlider()->SetFgColor( Color( 126, 120, 101, 255 ) );
+		pScrollBar->GetSlider()->SetBgColor( Color( 26, 29, 32, 255 ) );
+		m_pItems->SetVerticalBufferPixels( gap );
+		m_pItems->SetPaintBackgroundEnabled( false );
+		m_pItems->SetPaintBorderEnabled( false );
+		int itemWide = MAX( 1, wide - 2 * padding - pScrollBar->GetWide() - gap - 12 );
 		for ( int i = 0; i < m_pItems->GetItemCount(); ++i )
 		{
 			vgui::Label *pItem = static_cast<vgui::Label *>( m_pItems->GetItemPanel( m_pItems->GetItemIDFromRow( i ) ) );
 			pItem->SetSize( itemWide, 1 );
-			pItem->SetTextInset( border / 2, 0 );
+			pItem->SetTextInset( padding, 0 );
 			pItem->InvalidateLayout( true, true );
-			pItem->GetTextImage()->SetDrawWidth( MAX( 1, itemWide - border ) );
+			pItem->SetFont( font );
+			pItem->GetTextImage()->SetDrawWidth( MAX( 1, itemWide - 2 * padding ) );
 			int textWide, textTall;
 			pItem->GetTextImage()->GetContentSize( textWide, textTall );
-			pItem->SetTall( MAX( textTall, vgui::surface()->GetFontTall( pItem->GetFont() ) ) + border );
+			pItem->SetTall( MAX( textTall, fontTall ) + padding );
+			pItem->SetFgColor( Color( 171, 177, 182, 255 ) );
+			if ( vgui::Button *pButton = dynamic_cast<vgui::Button *>( pItem ) )
+			{
+				pButton->SetButtonBorderEnabled( false );
+				pButton->DrawFocusBox( true );
+				pButton->SetDefaultColor( Color( 229, 233, 235, 255 ), Color( 35, 39, 43, 255 ) );
+				pButton->SetArmedColor( Color( 255, 213, 133, 255 ), Color( 66, 56, 38, 255 ) );
+				pButton->SetSelectedColor( Color( 255, 213, 133, 255 ), Color( 66, 56, 38, 255 ) );
+				pButton->SetDepressedColor( Color( 255, 226, 169, 255 ), Color( 90, 69, 36, 255 ) );
+				pButton->SetDisabledFgColor1( Color( 102, 109, 115, 255 ) );
+				pButton->SetDisabledFgColor2( Color( 0, 0, 0, 0 ) );
+			}
 		}
+		int listTall = MIN( m_pItems->ComputeVPixelsNeeded(), MAX( 1, maxTall - m_nHeaderTall - m_nFooterTall ) );
+		SetSize( wide, m_nHeaderTall + listTall + m_nFooterTall );
+		BaseClass::PerformLayout();
+		SetPaintBorderEnabled( false );
+		m_pItems->SetBounds( padding, m_nHeaderTall, wide - 2 * padding, listTall );
 		m_pItems->InvalidateLayout( true );
+		m_pTitle->InvalidateLayout( true, true );
+		m_pTitle->SetFont( font );
+		m_pTitle->SetFgColor( Color( 255, 203, 109, 255 ) );
+		m_pTitle->SetBounds( padding + gap, padding, wide - 2 * ( padding + gap ), fontTall );
+		m_pHint->InvalidateLayout( true, true );
+		m_pHint->SetFont( font );
+		m_pHint->SetFgColor( Color( 141, 151, 158, 255 ) );
+		m_pHint->SetBounds( padding + gap, GetTall() - m_nFooterTall, wide - 2 * ( padding + gap ), m_nFooterTall );
+		RestorePosition();
+	}
+
+	virtual void PaintBackground()
+	{
+		vgui::surface()->DrawSetColor( Color( 20, 23, 26, 250 ) );
+		vgui::surface()->DrawFilledRect( 0, 0, GetWide(), GetTall() );
+		vgui::surface()->DrawSetColor( Color( 29, 33, 37, 255 ) );
+		vgui::surface()->DrawFilledRect( 0, 0, GetWide(), m_nHeaderTall );
+		vgui::surface()->DrawSetColor( Color( 65, 70, 74, 255 ) );
+		vgui::surface()->DrawOutlinedRect( 0, 0, GetWide(), GetTall() );
+		vgui::surface()->DrawLine( 1, GetTall() - m_nFooterTall, GetWide() - 1, GetTall() - m_nFooterTall );
+		vgui::surface()->DrawSetColor( Color( 220, 162, 65, 255 ) );
+		vgui::surface()->DrawFilledRect( 1, 1, GetWide() - 1, MAX( 2, vgui::scheme()->GetProportionalScaledValueEx( GetScheme(), 2 ) ) );
+	}
+
+	void RestorePosition()
+	{
+		int screenWide, screenTall;
+		vgui::surface()->GetScreenSize( screenWide, screenTall );
+		if ( screenWide <= 0 || screenTall <= 0 )
+			return;
+
+		int x = cl_menu_dialog_x.GetFloat() < 0 ? ( screenWide - GetWide() ) / 2 : RoundFloatToInt( cl_menu_dialog_x.GetFloat() * screenWide );
+		int y = cl_menu_dialog_y.GetFloat() < 0 ? ( screenTall - GetTall() ) / 2 : RoundFloatToInt( cl_menu_dialog_y.GetFloat() * screenTall );
+		m_nLastX = clamp( x, 0, MAX( 0, screenWide - GetWide() ) );
+		m_nLastY = clamp( y, 0, MAX( 0, screenTall - GetTall() ) );
+		m_bPositionInitialized = true;
+		SetPos( m_nLastX, m_nLastY );
+		if ( cl_menu_dialog_x.GetFloat() < 0 )
+			cl_menu_dialog_x.SetValue( (float)m_nLastX / screenWide );
+		if ( cl_menu_dialog_y.GetFloat() < 0 )
+			cl_menu_dialog_y.SetValue( (float)m_nLastY / screenTall );
+	}
+
+	virtual void OnMove()
+	{
+		BaseClass::OnMove();
+		if ( !m_bPositionInitialized || !IsVisible() )
+			return;
+		int x, y;
+		GetPos( x, y );
+		if ( x == m_nLastX && y == m_nLastY )
+			return;
+
+		int screenWide, screenTall;
+		vgui::surface()->GetScreenSize( screenWide, screenTall );
+		if ( screenWide > 0 && screenTall > 0 )
+		{
+			m_nLastX = x;
+			m_nLastY = y;
+			cl_menu_dialog_x.SetValue( (float)x / screenWide );
+			cl_menu_dialog_y.SetValue( (float)y / screenTall );
+		}
 	}
 
 	virtual void OnScreenSizeChanged( int oldwide, int oldtall )
 	{
 		BaseClass::OnScreenSizeChanged( oldwide, oldtall );
 		InvalidateLayout( true );
-		MoveToCenterOfScreen();
 	}
 
 	vgui::DHANDLE< CHudMenu > m_hMenu;
 	vgui::PanelListPanel *m_pItems;
+	vgui::Label *m_pTitle;
+	vgui::Label *m_pHint;
 	unsigned int m_nMenuSerial;
+	int m_nHeaderTall;
+	int m_nFooterTall;
+	int m_nLastX;
+	int m_nLastY;
+	bool m_bPositionInitialized;
 };
 #endif
 

--- a/src/game/client/menu.cpp
+++ b/src/game/client/menu.cpp
@@ -22,6 +22,16 @@
 #include <KeyValues.h>
 #include <vgui_controls/AnimationController.h>
 
+#if defined( HL2MP )
+#include "ienginevgui.h"
+#include <vgui/IVGui.h>
+#include <vgui_controls/Button.h>
+#include <vgui_controls/Frame.h>
+#include <vgui_controls/PanelListPanel.h>
+#include <vgui_controls/ScrollBar.h>
+#include <vgui_controls/TextImage.h>
+#endif
+
 #define MAX_MENU_STRING	512
 wchar_t g_szMenuString[MAX_MENU_STRING];
 char g_szPrelocalisedMenuString[MAX_MENU_STRING];
@@ -37,6 +47,126 @@ char g_szPrelocalisedMenuString[MAX_MENU_STRING];
 
 DECLARE_HUDELEMENT( CHudMenu );
 DECLARE_HUD_MESSAGE( CHudMenu, ShowMenu );
+
+#if defined( HL2MP )
+ConVar cl_radio_menus( "cl_radio_menus", "1", FCVAR_ARCHIVE, "Display server menus on the HUD (1) or in a dialog when ESC is pressed (0).", true, 0, true, 1 );
+
+class CHudMenuDialog : public vgui::Frame
+{
+	DECLARE_CLASS_SIMPLE( CHudMenuDialog, vgui::Frame );
+public:
+	CHudMenuDialog( CHudMenu *pMenu ) : BaseClass( NULL, "HudMenuDialog" ), m_nMenuSerial( ~0u )
+	{
+		m_hMenu = pMenu;
+		SetParent( enginevgui->GetPanel( PANEL_GAMEUIDLL ) );
+		SetAutoDelete( false );
+		SetScheme( pMenu->GetScheme() );
+		SetProportional( true );
+		SetTitle( "Menu", true );
+		SetSizeable( false );
+		SetMinimizeButtonVisible( false );
+		SetMaximizeButtonVisible( false );
+		SetMenuButtonVisible( false );
+		SetCloseButtonVisible( false );
+		m_pItems = new vgui::PanelListPanel( this, "MenuItems" );
+		m_pItems->SetFirstColumnWidth( 0 );
+		MakePopup();
+		SetVisible( false );
+	}
+
+	void UpdateMenu()
+	{
+		CHudMenu *pMenu = m_hMenu.Get();
+		if ( !pMenu || m_nMenuSerial == pMenu->m_nMenuSerial )
+			return;
+
+		m_nMenuSerial = pMenu->m_nMenuSerial;
+		m_pItems->DeleteAllItems();
+		for ( int i = 0; i < pMenu->m_Processed.Count(); ++i )
+		{
+			const CHudMenu::ProcessedLine &line = pMenu->m_Processed[i];
+			wchar_t text[MAX_MENU_STRING];
+			V_wcsncpy( text, &g_szMenuString[line.startchar], ( line.length + 1 ) * sizeof( wchar_t ) );
+			int slot = line.menuitem;
+			if ( !slot && line.length >= 2 && text[0] >= L'0' && text[0] <= L'9' && text[1] == L'.' )
+				slot = text[0] == L'0' ? 10 : text[0] - L'0';
+
+			vgui::Label *pItem;
+			if ( slot >= 1 && slot <= 10 )
+			{
+				vgui::Button *pButton = new vgui::Button( m_pItems, "MenuItem", text );
+				pButton->SetCommand( new KeyValues( "MenuItemSelected", "slot", slot, "serial", (int)m_nMenuSerial ) );
+				pButton->AddActionSignalTarget( this );
+				pButton->SetEnabled( ( pMenu->m_bitsValidSlots & ( 1 << ( slot - 1 ) ) ) != 0 );
+				pButton->SetTabPosition( i + 1 );
+				pItem = pButton;
+			}
+			else
+			{
+				pItem = new vgui::Label( m_pItems, "MenuText", text );
+			}
+			pItem->SetContentAlignment( vgui::Label::a_west );
+			pItem->SetWrap( true );
+			m_pItems->AddItem( NULL, pItem );
+		}
+		m_pItems->MoveScrollBarToTop();
+		InvalidateLayout( true );
+		MoveToCenterOfScreen();
+	}
+
+private:
+	MESSAGE_FUNC_INT_INT( OnMenuItemSelected, "MenuItemSelected", slot, serial )
+	{
+		CHudMenu *pMenu = m_hMenu.Get();
+		if ( pMenu && IsVisible() && (unsigned int)serial == pMenu->m_nMenuSerial &&
+			!pMenu->UseRadioMenus() && engine->IsInGame() && enginevgui->IsGameUIVisible() )
+		{
+			pMenu->SelectMenuItem( slot );
+			if ( !pMenu->IsMenuOpen() )
+				SetVisible( false );
+		}
+	}
+
+	virtual void PerformLayout()
+	{
+		int screenWide, screenTall;
+		vgui::surface()->GetScreenSize( screenWide, screenTall );
+		int border = vgui::scheme()->GetProportionalScaledValueEx( GetScheme(), 8 );
+		SetSize( MIN( screenWide - 2 * border, vgui::scheme()->GetProportionalScaledValueEx( GetScheme(), 360 ) ),
+			MIN( screenTall - 2 * border, vgui::scheme()->GetProportionalScaledValueEx( GetScheme(), 400 ) ) );
+		BaseClass::PerformLayout();
+
+		int x, y, wide, tall;
+		GetClientArea( x, y, wide, tall );
+		m_pItems->SetBounds( x + border, y + border, wide - 2 * border, tall - 2 * border );
+		m_pItems->SetVerticalBufferPixels( border / 2 );
+		int itemWide = MAX( 1, m_pItems->GetWide() - m_pItems->GetScrollbar()->GetWide() - border / 2 - 12 );
+		for ( int i = 0; i < m_pItems->GetItemCount(); ++i )
+		{
+			vgui::Label *pItem = static_cast<vgui::Label *>( m_pItems->GetItemPanel( m_pItems->GetItemIDFromRow( i ) ) );
+			pItem->SetSize( itemWide, 1 );
+			pItem->SetTextInset( border / 2, 0 );
+			pItem->InvalidateLayout( true, true );
+			pItem->GetTextImage()->SetDrawWidth( MAX( 1, itemWide - border ) );
+			int textWide, textTall;
+			pItem->GetTextImage()->GetContentSize( textWide, textTall );
+			pItem->SetTall( MAX( textTall, vgui::surface()->GetFontTall( pItem->GetFont() ) ) + border );
+		}
+		m_pItems->InvalidateLayout( true );
+	}
+
+	virtual void OnScreenSizeChanged( int oldwide, int oldtall )
+	{
+		BaseClass::OnScreenSizeChanged( oldwide, oldtall );
+		InvalidateLayout( true );
+		MoveToCenterOfScreen();
+	}
+
+	vgui::DHANDLE< CHudMenu > m_hMenu;
+	vgui::PanelListPanel *m_pItems;
+	unsigned int m_nMenuSerial;
+};
+#endif
 
 //
 //-----------------------------------------------------
@@ -56,13 +186,25 @@ static char* ConvertCRtoNL( char *str )
 //-----------------------------------------------------------------------------
 CHudMenu::CHudMenu( const char *pElementName ) :
 	CHudElement( pElementName ), BaseClass(NULL, "HudMenu")
+#if defined( HL2MP )
+	, m_nMenuSerial( 0 )
+#endif
 {
-	m_nSelectedItem = -1;
+	Reset();
 
 	vgui::Panel *pParent = g_pClientMode->GetViewport();
 	SetParent( pParent );
 	
 	SetHiddenBits( HIDEHUD_MISCSTATUS );
+}
+
+CHudMenu::~CHudMenu()
+{
+#if defined( HL2MP )
+	vgui::ivgui()->RemoveTickSignal( GetVPanel() );
+	if ( m_hMenuDialog.Get() )
+		m_hMenuDialog->MarkForDeletion();
+#endif
 }
 
 //-----------------------------------------------------------------------------
@@ -72,12 +214,9 @@ void CHudMenu::Init( void )
 {
 	HOOK_HUD_MESSAGE( CHudMenu, ShowMenu );
 
-	m_bMenuTakesInput = false;
-	m_bMenuDisplayed = false;
-	m_bitsValidSlots = 0;
-	m_Processed.RemoveAll();
-	m_nMaxPixels = 0;
-	m_nHeight = 0;
+#if defined( HL2MP )
+	vgui::ivgui()->AddTickSignal( GetVPanel(), 50 );
+#endif
 	Reset();
 }
 
@@ -86,6 +225,21 @@ void CHudMenu::Init( void )
 //-----------------------------------------------------------------------------
 void CHudMenu::Reset( void )
 {
+#if defined( HL2MP )
+	++m_nMenuSerial;
+	m_bNetworkMenu = false;
+	if ( m_hMenuDialog.Get() )
+		m_hMenuDialog->SetVisible( false );
+#endif
+	m_bMenuTakesInput = false;
+	m_bMenuDisplayed = false;
+	m_bitsValidSlots = 0;
+	m_flShutoffTime = -1;
+	m_nSelectedItem = -1;
+	m_Processed.RemoveAll();
+	m_nMaxPixels = 0;
+	m_nHeight = 0;
+	g_szMenuString[0] = 0;
 	g_szPrelocalisedMenuString[0] = 0;
 	m_fWaitingForMore = false;
 }
@@ -96,14 +250,49 @@ void CHudMenu::Reset( void )
 //-----------------------------------------------------------------------------
 bool CHudMenu::IsMenuOpen( void )
 {
-	return m_bMenuDisplayed && m_bMenuTakesInput;
+	return m_bMenuDisplayed && m_bMenuTakesInput &&
+		( m_flShutoffTime < 0 || m_flShutoffTime > gpGlobals->realtime );
 }
+
+bool CHudMenu::UseRadioMenus( void )
+{
+#if defined( HL2MP )
+	return !m_bNetworkMenu || cl_radio_menus.GetBool();
+#else
+	return true;
+#endif
+}
+
+bool CHudMenu::IsTakingInput( void )
+{
+	return UseRadioMenus() && IsMenuOpen();
+}
+
+#if defined( HL2MP )
+void CHudMenu::OnTick()
+{
+	bool visible = !UseRadioMenus() && IsMenuOpen() && engine->IsInGame() && enginevgui->IsGameUIVisible();
+	if ( !visible )
+	{
+		if ( m_hMenuDialog.Get() )
+			m_hMenuDialog->SetVisible( false );
+		return;
+	}
+
+	if ( !m_hMenuDialog.Get() )
+		m_hMenuDialog = new CHudMenuDialog( this );
+	m_hMenuDialog->UpdateMenu();
+	if ( !m_hMenuDialog->IsVisible() )
+		m_hMenuDialog->Activate();
+}
+#endif
 
 //-----------------------------------------------------------------------------
 // Purpose: 
 //-----------------------------------------------------------------------------
 void CHudMenu::VidInit( void )
 {
+	Reset();
 }
 
 //-----------------------------------------------------------------------------
@@ -111,12 +300,10 @@ void CHudMenu::VidInit( void )
 //-----------------------------------------------------------------------------
 void CHudMenu::OnThink()
 {
-	float flSelectionTimeout = MENU_SELECTION_TIMEOUT;
-
-	// If we've been open for a while without input, hide
-	if ( m_bMenuDisplayed && ( gpGlobals->curtime - m_flSelectionTime > flSelectionTimeout ) )
+	if ( m_bMenuDisplayed && m_flShutoffTime >= 0 && m_flShutoffTime <= gpGlobals->realtime )
 	{
 		m_bMenuDisplayed = false;
+		m_bMenuTakesInput = false;
 	}
 }
 
@@ -125,15 +312,19 @@ void CHudMenu::OnThink()
 //-----------------------------------------------------------------------------
 bool CHudMenu::ShouldDraw( void )
 {
+	if ( !UseRadioMenus() )
+		return false;
+
 	bool draw = CHudElement::ShouldDraw() && m_bMenuDisplayed;
 	if ( !draw )
 		return false;
 
 	// check for if menu is set to disappear
-	if ( m_flShutoffTime > 0 && m_flShutoffTime <= gpGlobals->realtime )
+	if ( m_flShutoffTime >= 0 && m_flShutoffTime <= gpGlobals->realtime )
 	{  
 		// times up, shutoff
 		m_bMenuDisplayed = false;
+		m_bMenuTakesInput = false;
 		return false;
 	}
 
@@ -247,8 +438,11 @@ void CHudMenu::Paint()
 //-----------------------------------------------------------------------------
 void CHudMenu::SelectMenuItem( int menu_item )
 {
+	if ( menu_item == 0 )
+		menu_item = 10;
+
 	// if menu_item is in a valid slot,  send a menuselect command to the server
-	if ( (menu_item > 0) && (m_bitsValidSlots & (1 << (menu_item-1))) )
+	if ( IsMenuOpen() && menu_item > 0 && menu_item <= 10 && ( m_bitsValidSlots & ( 1 << ( menu_item - 1 ) ) ) )
 	{
 		char szbuf[32];
 		Q_snprintf( szbuf, sizeof( szbuf ), "menuselect %d\n", menu_item );
@@ -267,6 +461,9 @@ void CHudMenu::SelectMenuItem( int menu_item )
 
 void CHudMenu::ProcessText( void )
 {
+#if defined( HL2MP )
+	++m_nMenuSerial;
+#endif
 	m_Processed.RemoveAll();
 	m_nMaxPixels = 0;
 	m_nHeight = 0;
@@ -285,6 +482,8 @@ void CHudMenu::ProcessText( void )
 		{
 			// Special handling for menu item specifiers
 			swscanf( &g_szMenuString[ i + 2 ], L"%d", &menuitem );
+			if ( menuitem == 0 )
+				menuitem = 10;
 			i += 2;
 			startpos += 2;
 
@@ -363,6 +562,7 @@ void CHudMenu::ProcessText( void )
 //-----------------------------------------------------------------------------
 void CHudMenu::HideMenu( void )
 {
+	m_fWaitingForMore = false;
 	m_bMenuTakesInput = false;
 	m_flShutoffTime = gpGlobals->realtime + m_flOpenCloseTime;
 	g_pClientMode->GetViewportAnimationController()->StartAnimationSequence("MenuClose");
@@ -378,7 +578,10 @@ void CHudMenu::HideMenu( void )
 //-----------------------------------------------------------------------------
 void CHudMenu::ShowMenu( const char * menuName, int validSlots )
 {
-	m_flShutoffTime = -1;
+#if defined( HL2MP )
+	m_bNetworkMenu = false;
+#endif
+	m_flShutoffTime = gpGlobals->realtime + MENU_SELECTION_TIMEOUT;
 	m_bitsValidSlots = validSlots;
 	m_fWaitingForMore = 0;
 
@@ -396,8 +599,6 @@ void CHudMenu::ShowMenu( const char * menuName, int validSlots )
 
 	m_bMenuDisplayed = true;
 	m_bMenuTakesInput = true;
-
-	m_flSelectionTime = gpGlobals->curtime;
 }
 
 //-----------------------------------------------------------------------------
@@ -405,7 +606,10 @@ void CHudMenu::ShowMenu( const char * menuName, int validSlots )
 //-----------------------------------------------------------------------------
 void CHudMenu::ShowMenu_KeyValueItems( KeyValues *pKV )
 {
-	m_flShutoffTime = -1;
+#if defined( HL2MP )
+	m_bNetworkMenu = false;
+#endif
+	m_flShutoffTime = gpGlobals->realtime + MENU_SELECTION_TIMEOUT;
 	m_fWaitingForMore = 0;
 	m_bitsValidSlots = 0;
 
@@ -444,8 +648,6 @@ void CHudMenu::ShowMenu_KeyValueItems( KeyValues *pKV )
 
 	m_bMenuDisplayed = true;
 	m_bMenuTakesInput = true;
-
-	m_flSelectionTime = gpGlobals->curtime;
 }
 
 //-----------------------------------------------------------------------------
@@ -459,13 +661,16 @@ void CHudMenu::ShowMenu_KeyValueItems( KeyValues *pKV )
 //-----------------------------------------------------------------------------
 void CHudMenu::MsgFunc_ShowMenu( bf_read &msg)
 {
+#if defined( HL2MP )
+	m_bNetworkMenu = true;
+#endif
 	m_bitsValidSlots = (short)msg.ReadWord();
 	int DisplayTime = msg.ReadChar();
 	int NeedMore = msg.ReadByte();
 
 	if ( DisplayTime > 0 )
 	{
-		m_flShutoffTime = m_flOpenCloseTime + DisplayTime + gpGlobals->realtime;
+		m_flShutoffTime = DisplayTime + gpGlobals->realtime;
 
 	}
 	else
@@ -480,6 +685,8 @@ void CHudMenu::MsgFunc_ShowMenu( bf_read &msg)
 
 		if ( !m_fWaitingForMore ) // this is the start of a new menu
 		{
+			m_bMenuDisplayed = false;
+			m_bMenuTakesInput = false;
 			Q_strncpy( g_szPrelocalisedMenuString, szString, sizeof( g_szPrelocalisedMenuString ) );
 		}
 		else
@@ -498,16 +705,15 @@ void CHudMenu::MsgFunc_ShowMenu( bf_read &msg)
 			g_pVGuiLocalize->ConvertANSIToUnicode( szMenuString, g_szMenuString, sizeof( g_szMenuString ) );
 			
 			ProcessText();
+
+			m_bMenuDisplayed = true;
+			m_bMenuTakesInput = true;
 		}
-
-		m_bMenuDisplayed = true;
-		m_bMenuTakesInput = true;
-
-		m_flSelectionTime = gpGlobals->curtime;
 	}
 	else
 	{
 		HideMenu();
+		return;
 	}
 
 	m_fWaitingForMore = NeedMore;

--- a/src/game/client/menu.h
+++ b/src/game/client/menu.h
@@ -17,6 +17,10 @@
 
 #define MENU_SELECTION_TIMEOUT	5.0f
 
+#if defined( HL2MP )
+class CHudMenuDialog;
+#endif
+
 //-----------------------------------------------------------------------------
 // Purpose: 
 //-----------------------------------------------------------------------------
@@ -25,6 +29,7 @@ class CHudMenu : public CHudElement, public vgui::Panel
 	DECLARE_CLASS_SIMPLE( CHudMenu, vgui::Panel );
 public:
 	CHudMenu( const char *pElementName );
+	virtual ~CHudMenu();
 	void Init( void );
 	void VidInit( void );
 	void Reset( void );
@@ -35,6 +40,7 @@ public:
 	void ShowMenu_KeyValueItems( KeyValues *pKV );
 
 	bool IsMenuOpen( void );
+	bool IsTakingInput( void );
 	void SelectMenuItem( int menu_item );
 
 private:
@@ -43,6 +49,15 @@ private:
 	virtual void ApplySchemeSettings(vgui::IScheme *pScheme);
 private:
 	void		ProcessText( void );
+	bool UseRadioMenus( void );
+
+#if defined( HL2MP )
+	friend class CHudMenuDialog;
+	virtual void OnTick();
+	vgui::DHANDLE< CHudMenuDialog > m_hMenuDialog;
+	unsigned int m_nMenuSerial;
+	bool m_bNetworkMenu;
+#endif
 
 	void PaintString( const wchar_t *text, int textlen, vgui::HFont& font, int x, int y );
 
@@ -66,8 +81,6 @@ private:
 	int				m_fWaitingForMore;
 	int				m_nSelectedItem;
 	bool			m_bMenuTakesInput;
-
-	float			m_flSelectionTime;
 
 	CPanelAnimationVar( float, m_flOpenCloseTime, "OpenCloseTime", "1" );
 

--- a/src/game/client/weapon_selection.cpp
+++ b/src/game/client/weapon_selection.cpp
@@ -265,7 +265,7 @@ int	CBaseHudWeaponSelection::KeyInput( int down, ButtonCode_t keynum, const char
 		return 0;
 	}
 
-	if ( down >= 1 && keynum >= KEY_1 && keynum <= KEY_9 )
+	if ( down >= 1 && keynum >= KEY_0 && keynum <= KEY_9 )
 	{
 		if ( HandleHudMenuInput( keynum - KEY_0 ) )
 			return 0;
@@ -301,7 +301,7 @@ void CBaseHudWeaponSelection::UserCmd_Slot1(void)
 		nFastswitchMode = HUDTYPE_FASTSWITCH;
 	}
 
-	if( HUDTYPE_CAROUSEL == nFastswitchMode )
+	if( HUDTYPE_CAROUSEL == nFastswitchMode && !IsHudMenuTakingInput() )
 	{
 		UserCmd_LastWeapon();
 	}
@@ -319,7 +319,7 @@ void CBaseHudWeaponSelection::UserCmd_Slot2(void)
 		nFastswitchMode = HUDTYPE_FASTSWITCH;
 	}
 
-	if( HUDTYPE_CAROUSEL == nFastswitchMode )
+	if( HUDTYPE_CAROUSEL == nFastswitchMode && !IsHudMenuTakingInput() )
 	{
 		UserCmd_NextWeapon();
 	}
@@ -337,7 +337,7 @@ void CBaseHudWeaponSelection::UserCmd_Slot3(void)
 		nFastswitchMode = HUDTYPE_FASTSWITCH;
 	}
 
-	if( HUDTYPE_CAROUSEL == nFastswitchMode )
+	if( HUDTYPE_CAROUSEL == nFastswitchMode && !IsHudMenuTakingInput() )
 	{
 		engine->ClientCmd( "phys_swap" );
 	}
@@ -355,7 +355,7 @@ void CBaseHudWeaponSelection::UserCmd_Slot4(void)
 		nFastswitchMode = HUDTYPE_FASTSWITCH;
 	}
 
-	if( HUDTYPE_CAROUSEL == nFastswitchMode )
+	if( HUDTYPE_CAROUSEL == nFastswitchMode && !IsHudMenuTakingInput() )
 	{
 		UserCmd_PrevWeapon();
 	}
@@ -406,7 +406,7 @@ void CBaseHudWeaponSelection::UserCmd_Slot10(void)
 bool CBaseHudWeaponSelection::IsHudMenuTakingInput()
 {
 	CHudMenu *pHudMenu = GET_HUDELEMENT( CHudMenu );
-	return ( pHudMenu && pHudMenu->IsMenuOpen() );
+	return ( pHudMenu && pHudMenu->IsTakingInput() );
 }
 
 //-----------------------------------------------------------------------------
@@ -415,7 +415,7 @@ bool CBaseHudWeaponSelection::IsHudMenuTakingInput()
 bool CBaseHudWeaponSelection::HandleHudMenuInput( int iSlot )
 {
 	CHudMenu *pHudMenu = GET_HUDELEMENT( CHudMenu );
-	if ( !pHudMenu || !pHudMenu->IsMenuOpen() )
+	if ( !pHudMenu || !pHudMenu->IsTakingInput() )
 		return false;
 
 	pHudMenu->SelectMenuItem( iSlot );


### PR DESCRIPTION
This has been a long standing issue. Radio menus have never been enabled in HL2DM and menus as a whole rely on an outdated design, and even got broken in the anniversary update without a client-side fix. Besides, `cl_showpluginmessages` defaults to 0, which does not help as well.

This PR is therefore simple. Enable those radio menus for better and quicker admin access.
<img width="1920" height="1080" alt="20260909115907_1" src="https://github.com/user-attachments/assets/16f0b779-554f-4c10-8e34-fdaa81a69f7b" />
<img width="1920" height="1080" alt="20260909115912_1" src="https://github.com/user-attachments/assets/50a92674-2bde-43be-82c5-a92ea26aaa7c" />

<img width="1920" height="1080" alt="20260909115904_1" src="https://github.com/user-attachments/assets/b922a0ba-353b-4977-b43d-b2e1978a4288" />

The advantage here is that this does not need to rely on `cl_showpluginmessages`. Those menus will show regardless of the value of this cvar.

Bonus: I might be in the minority here, but I hate the radio menus, just because it interfered in gameplay way back in the CSS days when RTV menus opened during a firefight or when an admin decided to initiate a vote and you wanted to hit 1, 2 or 3 to switch weapons but instead interacted with the menu. So I added `cl_radio_menus` so that when disabled, it goes back to using the menu panels. However, I also redesigned those panels to also not have to deal with `cl_showpluginmessages`.
<img width="1922" height="1079" alt="image" src="https://github.com/user-attachments/assets/19176676-bfd1-4f83-982a-ca7e2beb501e" />
