### PR TITLE
[TF2] Improve awkward Force-a-Nature pre-round handling

### DIFF
--- a/src/game/shared/tf/tf_weapon_shotgun.cpp
+++ b/src/game/shared/tf/tf_weapon_shotgun.cpp
@@ -320,15 +320,12 @@ void CTFScatterGun::FireBullet( CTFPlayer *pPlayer )
 	{
 		// Perform some knock back.
 		CTFPlayer *pOwner = ToTFPlayer( GetPlayerOwner() );
-		if ( !pOwner )
-			return;
 
 		// No knockback during pre-round freeze.
-		if ( TFGameRules() && (TFGameRules()->State_Get() == GR_STATE_PREROUND) )
-			return;
+		bool bPreRound = TFGameRules() && (TFGameRules()->State_Get() == GR_STATE_PREROUND);
 
 		// Knock the firer back!
-		if ( !(pOwner->GetFlags() & FL_ONGROUND) && !pPlayer->m_Shared.m_bScattergunJump )
+		if ( pOwner && !bPreRound && !(pOwner->GetFlags() & FL_ONGROUND) && !pPlayer->m_Shared.m_bScattergunJump )
 		{
 			pPlayer->m_Shared.m_bScattergunJump = true;
 
@@ -370,6 +367,10 @@ void CTFScatterGun::ApplyPostHitEffects( const CTakeDamageInfo &inputInfo, CTFPl
 {
 #ifndef CLIENT_DLL
 	if ( !HasKnockback() )
+		return;
+
+	// No knockback during pre-round freeze.
+	if ( TFGameRules() && (TFGameRules()->State_Get() == GR_STATE_PREROUND) )
 		return;
 
 	CTFPlayer *pAttacker = ToTFPlayer( inputInfo.GetAttacker() );


### PR DESCRIPTION
<!--
Thanks for your interest in Source SDK 2013!  When you make a contribution to the Source SDK 2013, either by creating an Issue or submitting a Pull Request (a "Contribution"), Valve wants to be able to use your Contribution to improve the Source 2013 SDK and other Valve products. 
1.	Contributions: When you provide a Contribution, please ensure it is your original creation. You agree to the following license and warranty for any Contributions you provide: 
1.1	 You grant Valve a non-exclusive, perpetual, irrevocable, royalty-free, sublicensable, and worldwide license to make, use, sell, reproduce, modify, create derivate works, directly and indirectly distribute, publicly display, publish, transmit and perform the Contribution, and any derivative works thereof. . 
1.2	 You represent and warrant that you are either the owner or authorized licensee of the Contribution, that you have all necessary consents to grant this license to the Contribution to Valve, and that the Contribution does not violate any third-party intellectual property rights. 
1.3	Except as set forth in (2) above, you provide your Contribution "as is" without warranties of any kind.  
2.	Other Materials or Suggestions: If you want to submit any materials or suggestions that are not your original work, you agree to do the following: 
2.1	You may submit other materials or suggestions to Valve separate from any Contributions; 
2.2	You will explicitly identify them as sourced from a third party and state the details of its origin;  and 
2.3	You will include Valve with any third party licenses, terms, or other restrictions that apply, if you are aware of any. 
-->

# Description

To prevent players from being able to use the Force-a-Nature's knockback to move during the pre-round freeze, TF2 stops the Force-a-Nature from firing any bullets that would otherwise deal knockback. Although this works, it looks awkward in-game; when a player fires the Force-a-Nature during the pre-round freeze, the weapon will consume ammo and play its firing animation (including its muzzleflash) but won't fire any bullets or play any sound.

This PR resolves these visual discrepancies by changing TF2's pre-round FaN handling; instead of not allowing the FaN to fire bullets altogether, we allow it to fire bullets but stop its knockback from taking effect.